### PR TITLE
Fix setup command

### DIFF
--- a/website/site/content/download/personal-edition/ubuntu.md
+++ b/website/site/content/download/personal-edition/ubuntu.md
@@ -100,7 +100,7 @@ server {
 
 Enable the site, test the config, and reload NGINX:
 ```
-sudo ln -s /etc/nginx/sites-enabled/focalboard /etc/nginx/sites-available/focalboard
+sudo ln -s /etc/nginx/sites-available/focalboard /etc/nginx/sites-enabled/focalboard
 sudo nginx -t
 sudo /etc/init.d/nginx reload
 ```


### PR DESCRIPTION

#### Summary

`ln` command in server setup was failed. It should be `ln -s ${source_file} ${target_file}`.

```bash
$ sudo ln -s /etc/nginx/sites-enabled/focalboard /etc/nginx/sites-available/focalboard
ln: failed to create symbolic link '/etc/nginx/sites-available/focalboard': File exists
```

#### Ticket Link
N/A
