### PR TITLE
Add Dockerfile to run service in a container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM ubuntu:latest
+
+RUN apt update 
+RUN apt upgrade -y
+RUN apt install -y wget tar gzip unzip file
+RUN wget https://releases.mattermost.com/focalboard/0.5.0/focalboard-server-linux-amd64.tar.gz
+RUn unzip -o focalboard-server-linux-amd64.tar.gz
+RUN tar -xvzf focalboard-server-linux-amd64.tar.gz
+RUN mv focalboard /opt
+
+EXPOSE 8000
+
+WORKDIR /opt/focalboard
+
+CMD /opt/focalboard/bin/focalboard-server

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,15 @@
 FROM ubuntu:latest
 
-RUN apt update 
-RUN apt upgrade -y
-RUN apt install -y wget tar gzip unzip file
-RUN wget https://releases.mattermost.com/focalboard/0.5.0/focalboard-server-linux-amd64.tar.gz
-RUn unzip -o focalboard-server-linux-amd64.tar.gz
-RUN tar -xvzf focalboard-server-linux-amd64.tar.gz
-RUN mv focalboard /opt
+# Make sure that the underlying container is patched to the latest versions
+RUN apt update && \
+    apt upgrade -y && \
+    apt install -y wget tar gzip unzip file
+
+# Now install Focalboard as a seperate layer
+RUN wget https://releases.mattermost.com/focalboard/0.5.0/focalboard-server-linux-amd64.tar.gz && \
+    unzip -o focalboard-server-linux-amd64.tar.gz && \
+    tar -xvzf focalboard-server-linux-amd64.tar.gz && \
+    mv focalboard /opt
 
 EXPOSE 8000
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,6 @@ FROM ubuntu:latest
 
 # Make sure that the underlying container is patched to the latest versions
 RUN apt update && \
-    apt upgrade -y && \
     apt install -y wget tar gzip unzip file
 
 # Now install Focalboard as a seperate layer


### PR DESCRIPTION
#### Summary

Add a Dockerfile to launch the application within a container.

*NOTE:* At the moment, the focalboard version is hard-coded and there is
a bug that means the download is not actually a .tar.gz file, but a
.tgz.gz file inside a .zip file.

This also assumes the use of SQLite as the database rather than PgSQL.


#### Ticket Link
Fixes https://github.com/mattermost/mattermost-server/issues/75

