### PR TITLE
updated the document to include `dbtype` in dbconfig

### DIFF
--- a/website/site/content/download/personal-edition/ubuntu.md
+++ b/website/site/content/download/personal-edition/ubuntu.md
@@ -143,6 +143,7 @@ nano /opt/focalboard/config.json
 
 Change the dbconfig setting to use the postgres database you created:
 ```
+"dbtype": "postgres",
 "dbconfig": "postgres://boardsuser:boardsuser-password@localhost/boards?sslmode=disable&connect_timeout=10",
 ```
 


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
The documentation doesn't show to change the dbtype to postgres, which when is kept as sqlite will result in failure. This fixes that.


