### PR TITLE
Remove unnecessary binaries, update to use github releases

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,10 @@ FROM ubuntu:latest
 
 # Make sure that the underlying container is patched to the latest versions
 RUN apt update && \
-    apt install -y wget tar gzip unzip file
+    apt install -y wget tar gzip
 
 # Now install Focalboard as a seperate layer
-RUN wget https://releases.mattermost.com/focalboard/0.5.0/focalboard-server-linux-amd64.tar.gz && \
-    unzip -o focalboard-server-linux-amd64.tar.gz && \
+RUN wget https://github.com/mattermost/focalboard/releases/download/v0.6.1/focalboard-server-linux-amd64.tar.gz && \
     tar -xvzf focalboard-server-linux-amd64.tar.gz && \
     mv focalboard /opt
 


### PR DESCRIPTION
#### Summary
Remove the need for `unzip` and switch to using the Github Releases file as per #77 

#### Ticket Link

#77 

