### PR TITLE
Add basic setup for unit testing components with sass files import

### DIFF
--- a/webapp/__mocks__/styleMock.js
+++ b/webapp/__mocks__/styleMock.js
@@ -1,0 +1,3 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+module.exports = {};

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -32,6 +32,9 @@
 		"react-simplemde-editor": "^4.1.3"
 	},
 	"jest": {
+    "moduleNameMapper": {
+      "\\.(scss)$": "<rootDir>/__mocks__/styleMock.js"
+    },
 		"globals": {
 			"ts-jest": {
 				"tsConfig": "./src/tsconfig.json"

--- a/webapp/src/widgets/propertyMenu.test.tsx
+++ b/webapp/src/widgets/propertyMenu.test.tsx
@@ -1,0 +1,39 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react'
+import {render} from '@testing-library/react'
+import '@testing-library/jest-dom'
+import {IntlProvider} from 'react-intl'
+
+import PropertyMenu from './propertyMenu'
+
+describe('widgets/PropertyMenu', () => {
+    beforeEach(() => {
+        // Quick fix to disregard console error when unmounting a component
+        console.error = jest.fn()
+        document.execCommand = jest.fn()
+    })
+
+    test('should trigger callback when type change', () => {
+        const rootPortalDiv = document.createElement('div')
+        rootPortalDiv.id = 'root-portal'
+        const callback = jest.fn()
+
+        const {getByText} = render(
+            <IntlProvider locale='en'>
+                <PropertyMenu
+                    propertyId={'id'}
+                    propertyName={'email of a person'}
+                    propertyType={'email'}
+                    onTypeChanged={callback}
+                    onNameChanged={callback}
+                    onDelete={callback}
+                />
+            </IntlProvider>,
+            {container: document.body.appendChild(rootPortalDiv)},
+        )
+
+        expect(getByText('Type: Email')).toBeVisible()
+    })
+})

--- a/webapp/src/widgets/propertyMenu.test.tsx
+++ b/webapp/src/widgets/propertyMenu.test.tsx
@@ -15,7 +15,7 @@ describe('widgets/PropertyMenu', () => {
         document.execCommand = jest.fn()
     })
 
-    test('should trigger callback when type change', () => {
+    test('should display the type of property', () => {
         const rootPortalDiv = document.createElement('div')
         rootPortalDiv.id = 'root-portal'
         const callback = jest.fn()


### PR DESCRIPTION
#### Summary
Yesterday, I submitted a PR (https://github.com/mattermost/focalboard/pull/84) for adding email as an option for the property type. But I didn't write any unit tests as part of it, and @jespino agreed it is okay to submit the unit tests as a separate PR. This PR contains a basic unit test for the `propertyMenu.tsx`  file I changed as part of yesterday's PR.

I had to change the Jest config to provide a mock in place of `sass` files imported by components.

Once this PR is in, I would be happy to add more unit tests.



