### PR TITLE
Adding Changelog update instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,10 @@ Thank you for your interest in contributing! Please see the [Focalboard Contribu
 
 When you submit a pull request, it goes through a [code review process outlined here](https://www.focalboard.com/contribute/getting-started/code-review/).
 
+# Updating Changelog
+
+After you've merged a bug fix or an improvement, please make a pull request to the [CHANGELOG.MD](https://github.com/mattermost/focalboard/blob/main/CHANGELOG.md) under the next release section. 
+
 # Bug reports
 
 Please file a [GitHub issue](https://github.com/mattermost/focalboard/issues) if anything isn't working the way you expect.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ When you submit a pull request, it goes through a [code review process outlined 
 
 # Updating Changelog
 
-After you've merged a bug fix or an improvement, please make a pull request to the [CHANGELOG.MD](https://github.com/mattermost/focalboard/blob/main/CHANGELOG.md) under the next release section. 
+After you've merged a bug fix or an improvement, please make a pull request to the [CHANGELOG.md](https://github.com/mattermost/focalboard/blob/main/CHANGELOG.md) under the next release section. 
 
 # Bug reports
 


### PR DESCRIPTION
Have contributors update changelog, e.g. https://github.com/mattermost/focalboard/pull/138
