### PR TITLE
Adding DockerHub, PR#s, release date to changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,15 @@ This changelog summarizes updates to our open source project. You can also find 
 ## [Work In Progress] - v0.7 Release - [Date TBD]
 
 * Key Updates:
+  * Focalboard now available on DockerHub at https://hub.docker.com/r/mattermost/focalboard. [#91](https://github.com/mattermost/focalboard/issues/91) Thanks @jwilander @obbardc!
   * You can now contribute translations to Focalboard on https://translate.mattermost.com/. Thanks @jespino!
   * Added German language translation. Thanks @svelle!
   * Added Japanese language translation. Thanks @kaakaa!
   * Added French language translation. Thanks @CyrilLD!
-  * Add Dockerfile to run service in a container. Thanks @proffalken!
-  * Add docker-compose to run the whole service in containers. Thanks @jbutler992!
+  * Add Dockerfile to run service in a container. [#76](https://github.com/mattermost/focalboard/pull/76) Thanks @proffalken!
+  * Add docker-compose to run the whole service in containers. [#105](https://github.com/mattermost/focalboard/pull/105) Thanks @jbutler992!
 * Requested Contributions
-  * Add more frontend unit test coverage. Thanks @renjithgr!
+  * Add more frontend unit test coverage. [#126](https://github.com/mattermost/focalboard/pull/126) Thanks @renjithgr!
   * [GH-40](https://github.com/mattermost/focalboard/issues/40) - Add property type email [#84](https://github.com/mattermost/focalboard/pull/84). Thanks @renjithgr!
 
 ## v0.6 Release - March 2021

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ This changelog summarizes updates to our open source project. You can also find 
   * Add more frontend unit test coverage. [#126](https://github.com/mattermost/focalboard/pull/126) Thanks @renjithgr!
   * [GH-40](https://github.com/mattermost/focalboard/issues/40) - Add property type email [#84](https://github.com/mattermost/focalboard/pull/84). Thanks @renjithgr!
 
-## v0.6 Release - March 2021
+## v0.6 Release - March 15, 2021
 
 * Focalboard Personal Desktop is now live in the App Stores:
     * [Mac App Store](https://apps.apple.com/app/apple-store/id1556908618?pt=2114704&ct=changelog&mt=8)


### PR DESCRIPTION
Also linking to contributor PRs. Also adding release dates, rather than release months. We might release more than once a month given our velocity right now. 
