### PR TITLE
Add Docker volume persistence

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,6 +9,12 @@ RUN wget https://github.com/mattermost/focalboard/releases/download/v0.6.1/focal
     tar -xvzf focalboard-server-linux-amd64.tar.gz && \
     mv focalboard /opt
 
+# Copy config.json to point data to /data directory
+COPY server_config.json /opt/focalboard/config.json
+
+# Add volume if volume map not specified
+VOLUME /data
+
 EXPOSE 8000
 
 WORKDIR /opt/focalboard

--- a/docker/README.md
+++ b/docker/README.md
@@ -6,7 +6,7 @@ The Dockerfile gives a quick and easy way to pull the latest Focalboard server a
 
 ```
 docker build -t focalboard .
-docker run -it -p 80:8000 focalboard
+docker run -it -v "/home/user/focalboard-data:/data" -p 80:8000 focalboard
 ```
 
 Open a browser to http://localhost to start

--- a/docker/README.md
+++ b/docker/README.md
@@ -9,6 +9,8 @@ docker build -t focalboard .
 docker run -it -v "/home/user/focalboard-data:/data" -p 80:8000 focalboard
 ```
 
+> The `-v` flag can be used to store Focalboard's database and uploaded files in a directory on the Docker host
+
 Open a browser to http://localhost to start
 
 ## Docker-Compose
@@ -19,7 +21,7 @@ To start the server run
 
 ```
 docker-compose up
-``` 
+```
 
 This will automatically build the focalboard image and start it with the http port mapping.
 
@@ -27,4 +29,4 @@ To run focalboard with a nginx proxy and a postgres backend run
 
 ```
 docker-compose -f docker-compose-db-nginx.yml up
-``` 
+```

--- a/docker/server_config.json
+++ b/docker/server_config.json
@@ -1,0 +1,16 @@
+{
+  "serverRoot": "http://localhost:8000",
+  "port": 8000,
+  "dbtype": "sqlite3",
+  "dbconfig": "/data/focalboard.db",
+  "postgres_dbconfig": "dbname=focalboard sslmode=disable",
+  "useSSL": false,
+  "webpath": "./pack",
+  "filespath": "/data/files",
+  "telemetry": true,
+  "session_expire_time": 2592000,
+  "session_refresh_time": 18000,
+  "localOnly": false,
+  "enableLocalMode": true,
+  "localModeSocketLocation": "/var/tmp/focalboard_local.socket"
+}


### PR DESCRIPTION

#### Summary
This sets a default volume of `/data` for the Docker container.

This allows for persistence when using the default SQLite database and uploaded files, plus the option of mounting the volume to the host for backing up.
