### PR TITLE
Switch from "Feature Request" to "Feature Idea"

### DIFF
--- a/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/.github/ISSUE_TEMPLATE/enhancement.md
@@ -1,7 +1,7 @@
 ---
-name: Enhancement / Feature Request
+name: Enhancement / Feature Idea
 about: Suggest a new capability
-title: 'Feature Request: '
+title: 'Feature Idea: '
 labels: enhancement
 assignees: ''
 


### PR DESCRIPTION
We had this problem in Mattermost where when we used the term "Feature Requests" it sounded a bit like "Pull Requests" and there was an expectation sometimes, in our own team and in the community, that it was some sort of formal ticket that had to be addressed. 

We later changed to "Feature Idea" and then the expectations changed, where the maintainers didn't necessarily need to address every new ticket, since it was more sharing an idea, versus putting in a request. 

Right now the volume of feature ideas is a little overwhelming and my sense is we should make this change to lower the perceived pressure a bit. 

If we make this change, we can go update the previous tickets to match, and link to this ticket to explain why.
