### PR TITLE
chore(Docker) Install last release while building image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,11 @@ FROM ubuntu:latest
 
 # Make sure that the underlying container is patched to the latest versions
 RUN apt update && \
-    apt install -y wget tar gzip
+    apt install -y wget tar gzip unzip file curl
 
 # Now install Focalboard as a seperate layer
-RUN wget https://github.com/mattermost/focalboard/releases/download/v0.6.1/focalboard-server-linux-amd64.tar.gz && \
+RUN	RELEASE=$(curl --silent "https://api.github.com/repos/mattermost/focalboard/releases/latest" | grep -Po '"tag_name": "\K.*?(?=")') && \
+	wget https://github.com/mattermost/focalboard/releases/download/$RELEASE/focalboard-server-linux-amd64.tar.gz && \
     tar -xvzf focalboard-server-linux-amd64.tar.gz && \
     mv focalboard /opt
 


### PR DESCRIPTION
#### Summary
Pull last Github release of Focal Board instead of fixed version while building docker image.

#### Ticket Link
Minor improvement without a corresponding Help Wanted ticket.

