### PR TITLE
Store files per workspace and root block

### DIFF
--- a/server/app/files.go
+++ b/server/app/files.go
@@ -18,7 +18,7 @@ func (a *App) SaveFile(reader io.Reader, workspaceID, rootID, filename string) (
 	}
 
 	createdFilename := fmt.Sprintf(`%s%s`, utils.CreateGUID(), fileExtension)
-	filePath := fmt.Sprintf(`%s/%s/%s`, workspaceID, rootID, createdFilename)
+	filePath := filepath.Join(workspaceID, rootID, createdFilename)
 
 	_, appErr := a.filesBackend.WriteFile(reader, filePath)
 	if appErr != nil {

--- a/server/app/files.go
+++ b/server/app/files.go
@@ -10,7 +10,7 @@ import (
 	"github.com/mattermost/focalboard/server/utils"
 )
 
-func (a *App) SaveFile(reader io.Reader, filename string) (string, error) {
+func (a *App) SaveFile(reader io.Reader, workspaceID, rootID, filename string) (string, error) {
 	// NOTE: File extension includes the dot
 	fileExtension := strings.ToLower(filepath.Ext(filename))
 	if fileExtension == ".jpeg" {
@@ -18,8 +18,9 @@ func (a *App) SaveFile(reader io.Reader, filename string) (string, error) {
 	}
 
 	createdFilename := fmt.Sprintf(`%s%s`, utils.CreateGUID(), fileExtension)
+	filePath := fmt.Sprintf(`%s/%s/%s`, workspaceID, rootID, createdFilename)
 
-	_, appErr := a.filesBackend.WriteFile(reader, createdFilename)
+	_, appErr := a.filesBackend.WriteFile(reader, filePath)
 	if appErr != nil {
 		return "", errors.New("unable to store the file in the files storage")
 	}
@@ -27,8 +28,9 @@ func (a *App) SaveFile(reader io.Reader, filename string) (string, error) {
 	return createdFilename, nil
 }
 
-func (a *App) GetFilePath(filename string) string {
+func (a *App) GetFilePath(workspaceID, rootID, filename string) string {
 	folderPath := a.config.FilesPath
+	rootPath := filepath.Join(folderPath, workspaceID, rootID)
 
-	return filepath.Join(folderPath, filename)
+	return filepath.Join(rootPath, filename)
 }

--- a/server/swagger/docs/html/index.html
+++ b/server/swagger/docs/html/index.html
@@ -3160,7 +3160,7 @@ Type of blocks to return, omit to specify all types
                         <p class="marked">Returns the contents of an uploaded file</p>
                         <p></p>
                         <br />
-                        <pre class="prettyprint language-html prettyprinted" data-type="get"><code><span class="pln">/files/{fileID}</span></code></pre>
+                        <pre class="prettyprint language-html prettyprinted" data-type="get"><code><span class="pln">/workspaces/{workspaceID}/{rootID}/{fileID}</span></code></pre>
                         <p>
                           <h3>Usage and SDK Samples</h3>
                         </p>
@@ -3184,7 +3184,7 @@ Type of blocks to return, omit to specify all types
                             <pre class="prettyprint"><code class="language-bsh">curl -X GET\
 -H "Authorization: [[apiKey]]"\
  -H "Accept: application/json,image/jpg,image/png"\
- "http://localhost/api/v1/files/{fileID}"</code></pre>
+ "http://localhost/api/v1/workspaces/{workspaceID}/{rootID}/{fileID}"</code></pre>
                           </div>
                           <div class="tab-pane" id="examples-Default-getFile-0-java">
                             <pre class="prettyprint"><code class="language-java">import org.openapitools.client.*;
@@ -3207,10 +3207,12 @@ public class DefaultApiExample {
         
         // Create an instance of the API class
         DefaultApi apiInstance = new DefaultApi();
+        String workspaceID = workspaceID_example; // String | Workspace ID
+        String rootID = rootID_example; // String | ID of the root block
         String fileID = fileID_example; // String | ID of the file
         
         try {
-            apiInstance.getFile(fileID);
+            apiInstance.getFile(workspaceID, rootID, fileID);
         } catch (ApiException e) {
             System.err.println("Exception when calling DefaultApi#getFile");
             e.printStackTrace();
@@ -3226,10 +3228,12 @@ public class DefaultApiExample {
 public class DefaultApiExample {
     public static void main(String[] args) {
         DefaultApi apiInstance = new DefaultApi();
+        String workspaceID = workspaceID_example; // String | Workspace ID
+        String rootID = rootID_example; // String | ID of the root block
         String fileID = fileID_example; // String | ID of the file
         
         try {
-            apiInstance.getFile(fileID);
+            apiInstance.getFile(workspaceID, rootID, fileID);
         } catch (ApiException e) {
             System.err.println("Exception when calling DefaultApi#getFile");
             e.printStackTrace();
@@ -3252,9 +3256,13 @@ public class DefaultApiExample {
 
 // Create an instance of the API class
 DefaultApi *apiInstance = [[DefaultApi alloc] init];
+String *workspaceID = workspaceID_example; // Workspace ID (default to null)
+String *rootID = rootID_example; // ID of the root block (default to null)
 String *fileID = fileID_example; // ID of the file (default to null)
 
-[apiInstance getFileWith:fileID
+[apiInstance getFileWith:workspaceID
+    rootID:rootID
+    fileID:fileID
               completionHandler: ^(NSError* error) {
     if (error) {
         NSLog(@"Error: %@", error);
@@ -3275,6 +3283,8 @@ BearerAuth.apiKey = "YOUR API KEY";
 
 // Create an instance of the API class
 var api = new FocalboardServer.DefaultApi()
+var workspaceID = workspaceID_example; // {String} Workspace ID
+var rootID = rootID_example; // {String} ID of the root block
 var fileID = fileID_example; // {String} ID of the file
 
 var callback = function(error, data, response) {
@@ -3284,7 +3294,7 @@ var callback = function(error, data, response) {
     console.log('API called successfully.');
   }
 };
-api.getFile(fileID, callback);
+api.getFile(workspaceID, rootID, fileID, callback);
 </code></pre>
                             </div>
 
@@ -3311,10 +3321,12 @@ namespace Example
             
             // Create an instance of the API class
             var apiInstance = new DefaultApi();
+            var workspaceID = workspaceID_example;  // String | Workspace ID (default to null)
+            var rootID = rootID_example;  // String | ID of the root block (default to null)
             var fileID = fileID_example;  // String | ID of the file (default to null)
 
             try {
-                apiInstance.getFile(fileID);
+                apiInstance.getFile(workspaceID, rootID, fileID);
             } catch (Exception e) {
                 Debug.Print("Exception when calling DefaultApi.getFile: " + e.Message );
             }
@@ -3335,10 +3347,12 @@ OpenAPITools\Client\Configuration::getDefaultConfiguration()->setApiKey('Authori
 
 // Create an instance of the API class
 $api_instance = new OpenAPITools\Client\Api\DefaultApi();
+$workspaceID = workspaceID_example; // String | Workspace ID
+$rootID = rootID_example; // String | ID of the root block
 $fileID = fileID_example; // String | ID of the file
 
 try {
-    $api_instance->getFile($fileID);
+    $api_instance->getFile($workspaceID, $rootID, $fileID);
 } catch (Exception $e) {
     echo 'Exception when calling DefaultApi->getFile: ', $e->getMessage(), PHP_EOL;
 }
@@ -3357,10 +3371,12 @@ $WWW::OPenAPIClient::Configuration::api_key->{'Authorization'} = 'YOUR_API_KEY';
 
 # Create an instance of the API class
 my $api_instance = WWW::OPenAPIClient::DefaultApi->new();
+my $workspaceID = workspaceID_example; # String | Workspace ID
+my $rootID = rootID_example; # String | ID of the root block
 my $fileID = fileID_example; # String | ID of the file
 
 eval { 
-    $api_instance->getFile(fileID => $fileID);
+    $api_instance->getFile(workspaceID => $workspaceID, rootID => $rootID, fileID => $fileID);
 };
 if ($@) {
     warn "Exception when calling DefaultApi->getFile: $@\n";
@@ -3381,10 +3397,12 @@ openapi_client.configuration.api_key['Authorization'] = 'YOUR_API_KEY'
 
 # Create an instance of the API class
 api_instance = openapi_client.DefaultApi()
+workspaceID = workspaceID_example # String | Workspace ID (default to null)
+rootID = rootID_example # String | ID of the root block (default to null)
 fileID = fileID_example # String | ID of the file (default to null)
 
 try: 
-    api_instance.get_file(fileID)
+    api_instance.get_file(workspaceID, rootID, fileID)
 except ApiException as e:
     print("Exception when calling DefaultApi->getFile: %s\n" % e)</code></pre>
                             </div>
@@ -3393,10 +3411,12 @@ except ApiException as e:
                               <pre class="prettyprint"><code class="language-rust">extern crate DefaultApi;
 
 pub fn main() {
+    let workspaceID = workspaceID_example; // String
+    let rootID = rootID_example; // String
     let fileID = fileID_example; // String
 
     let mut context = DefaultApi::Context::default();
-    let result = client.getFile(fileID, &context).wait();
+    let result = client.getFile(workspaceID, rootID, fileID, &context).wait();
 
     println!("{:?}", result);
 }
@@ -3417,6 +3437,52 @@ pub fn main() {
                                   <th width="150px">Name</th>
                                   <th>Description</th>
                                 </tr>
+                                  <tr><td style="width:150px;">workspaceID*</td>
+<td>
+
+
+    <div id="d2e199_getFile_workspaceID">
+        <div class="json-schema-view">
+            <div class="primitive">
+                <span class="type">
+                    String
+                </span>
+
+                    <div class="inner description marked">
+Workspace ID
+                    </div>
+            </div>
+                <div class="inner required">
+                    Required
+                </div>
+        </div>
+    </div>
+</td>
+</tr>
+
+                                  <tr><td style="width:150px;">rootID*</td>
+<td>
+
+
+    <div id="d2e199_getFile_rootID">
+        <div class="json-schema-view">
+            <div class="primitive">
+                <span class="type">
+                    String
+                </span>
+
+                    <div class="inner description marked">
+ID of the root block
+                    </div>
+            </div>
+                <div class="inner required">
+                    Required
+                </div>
+        </div>
+    </div>
+</td>
+</tr>
+
                                   <tr><td style="width:150px;">fileID*</td>
 <td>
 
@@ -8490,10 +8556,10 @@ $(document).ready(function() {
                         <div class="pull-right"></div>
                         <div class="clearfix"></div>
                         <p></p>
-                        <p class="marked">Upload a binary file</p>
+                        <p class="marked">Upload a binary file, attached to a root block</p>
                         <p></p>
                         <br />
-                        <pre class="prettyprint language-html prettyprinted" data-type="post"><code><span class="pln">/api/v1/files</span></code></pre>
+                        <pre class="prettyprint language-html prettyprinted" data-type="post"><code><span class="pln">/api/v1/workspaces/{workspaceID}/{rootID}/files</span></code></pre>
                         <p>
                           <h3>Usage and SDK Samples</h3>
                         </p>
@@ -8518,7 +8584,7 @@ $(document).ready(function() {
 -H "Authorization: [[apiKey]]"\
  -H "Accept: application/json"\
  -H "Content-Type: multipart/form-data"\
- "http://localhost/api/v1/api/v1/files"</code></pre>
+ "http://localhost/api/v1/api/v1/workspaces/{workspaceID}/{rootID}/files"</code></pre>
                           </div>
                           <div class="tab-pane" id="examples-Default-uploadFile-0-java">
                             <pre class="prettyprint"><code class="language-java">import org.openapitools.client.*;
@@ -8541,10 +8607,12 @@ public class DefaultApiExample {
         
         // Create an instance of the API class
         DefaultApi apiInstance = new DefaultApi();
+        String workspaceID = workspaceID_example; // String | Workspace ID
+        String rootID = rootID_example; // String | ID of the root block
         File uploaded file = BINARY_DATA_HERE; // File | The file to upload
         
         try {
-            FileUploadResponse result = apiInstance.uploadFile(uploaded file);
+            FileUploadResponse result = apiInstance.uploadFile(workspaceID, rootID, uploaded file);
             System.out.println(result);
         } catch (ApiException e) {
             System.err.println("Exception when calling DefaultApi#uploadFile");
@@ -8561,10 +8629,12 @@ public class DefaultApiExample {
 public class DefaultApiExample {
     public static void main(String[] args) {
         DefaultApi apiInstance = new DefaultApi();
+        String workspaceID = workspaceID_example; // String | Workspace ID
+        String rootID = rootID_example; // String | ID of the root block
         File uploaded file = BINARY_DATA_HERE; // File | The file to upload
         
         try {
-            FileUploadResponse result = apiInstance.uploadFile(uploaded file);
+            FileUploadResponse result = apiInstance.uploadFile(workspaceID, rootID, uploaded file);
             System.out.println(result);
         } catch (ApiException e) {
             System.err.println("Exception when calling DefaultApi#uploadFile");
@@ -8588,9 +8658,13 @@ public class DefaultApiExample {
 
 // Create an instance of the API class
 DefaultApi *apiInstance = [[DefaultApi alloc] init];
+String *workspaceID = workspaceID_example; // Workspace ID (default to null)
+String *rootID = rootID_example; // ID of the root block (default to null)
 File *uploaded file = BINARY_DATA_HERE; // The file to upload (optional) (default to null)
 
-[apiInstance uploadFileWith:uploaded file
+[apiInstance uploadFileWith:workspaceID
+    rootID:rootID
+    uploaded file:uploaded file
               completionHandler: ^(FileUploadResponse output, NSError* error) {
     if (output) {
         NSLog(@"%@", output);
@@ -8614,6 +8688,8 @@ BearerAuth.apiKey = "YOUR API KEY";
 
 // Create an instance of the API class
 var api = new FocalboardServer.DefaultApi()
+var workspaceID = workspaceID_example; // {String} Workspace ID
+var rootID = rootID_example; // {String} ID of the root block
 var opts = {
   'uploaded file': BINARY_DATA_HERE // {File} The file to upload
 };
@@ -8625,7 +8701,7 @@ var callback = function(error, data, response) {
     console.log('API called successfully. Returned data: ' + data);
   }
 };
-api.uploadFile(opts, callback);
+api.uploadFile(workspaceID, rootID, opts, callback);
 </code></pre>
                             </div>
 
@@ -8652,10 +8728,12 @@ namespace Example
             
             // Create an instance of the API class
             var apiInstance = new DefaultApi();
+            var workspaceID = workspaceID_example;  // String | Workspace ID (default to null)
+            var rootID = rootID_example;  // String | ID of the root block (default to null)
             var uploaded file = BINARY_DATA_HERE;  // File | The file to upload (optional)  (default to null)
 
             try {
-                FileUploadResponse result = apiInstance.uploadFile(uploaded file);
+                FileUploadResponse result = apiInstance.uploadFile(workspaceID, rootID, uploaded file);
                 Debug.WriteLine(result);
             } catch (Exception e) {
                 Debug.Print("Exception when calling DefaultApi.uploadFile: " + e.Message );
@@ -8677,10 +8755,12 @@ OpenAPITools\Client\Configuration::getDefaultConfiguration()->setApiKey('Authori
 
 // Create an instance of the API class
 $api_instance = new OpenAPITools\Client\Api\DefaultApi();
+$workspaceID = workspaceID_example; // String | Workspace ID
+$rootID = rootID_example; // String | ID of the root block
 $uploaded file = BINARY_DATA_HERE; // File | The file to upload
 
 try {
-    $result = $api_instance->uploadFile($uploaded file);
+    $result = $api_instance->uploadFile($workspaceID, $rootID, $uploaded file);
     print_r($result);
 } catch (Exception $e) {
     echo 'Exception when calling DefaultApi->uploadFile: ', $e->getMessage(), PHP_EOL;
@@ -8700,10 +8780,12 @@ $WWW::OPenAPIClient::Configuration::api_key->{'Authorization'} = 'YOUR_API_KEY';
 
 # Create an instance of the API class
 my $api_instance = WWW::OPenAPIClient::DefaultApi->new();
+my $workspaceID = workspaceID_example; # String | Workspace ID
+my $rootID = rootID_example; # String | ID of the root block
 my $uploaded file = BINARY_DATA_HERE; # File | The file to upload
 
 eval { 
-    my $result = $api_instance->uploadFile(uploaded file => $uploaded file);
+    my $result = $api_instance->uploadFile(workspaceID => $workspaceID, rootID => $rootID, uploaded file => $uploaded file);
     print Dumper($result);
 };
 if ($@) {
@@ -8725,10 +8807,12 @@ openapi_client.configuration.api_key['Authorization'] = 'YOUR_API_KEY'
 
 # Create an instance of the API class
 api_instance = openapi_client.DefaultApi()
+workspaceID = workspaceID_example # String | Workspace ID (default to null)
+rootID = rootID_example # String | ID of the root block (default to null)
 uploaded file = BINARY_DATA_HERE # File | The file to upload (optional) (default to null)
 
 try: 
-    api_response = api_instance.upload_file(uploaded file=uploaded file)
+    api_response = api_instance.upload_file(workspaceID, rootID, uploaded file=uploaded file)
     pprint(api_response)
 except ApiException as e:
     print("Exception when calling DefaultApi->uploadFile: %s\n" % e)</code></pre>
@@ -8738,10 +8822,12 @@ except ApiException as e:
                               <pre class="prettyprint"><code class="language-rust">extern crate DefaultApi;
 
 pub fn main() {
+    let workspaceID = workspaceID_example; // String
+    let rootID = rootID_example; // String
     let uploaded file = BINARY_DATA_HERE; // File
 
     let mut context = DefaultApi::Context::default();
-    let result = client.uploadFile(uploaded file, &context).wait();
+    let result = client.uploadFile(workspaceID, rootID, uploaded file, &context).wait();
 
     println!("{:?}", result);
 }
@@ -8756,6 +8842,59 @@ pub fn main() {
 
                           <h2>Parameters</h2>
 
+                            <div class="methodsubtabletitle">Path parameters</div>
+                            <table id="methodsubtable">
+                                <tr>
+                                  <th width="150px">Name</th>
+                                  <th>Description</th>
+                                </tr>
+                                  <tr><td style="width:150px;">workspaceID*</td>
+<td>
+
+
+    <div id="d2e199_uploadFile_workspaceID">
+        <div class="json-schema-view">
+            <div class="primitive">
+                <span class="type">
+                    String
+                </span>
+
+                    <div class="inner description marked">
+Workspace ID
+                    </div>
+            </div>
+                <div class="inner required">
+                    Required
+                </div>
+        </div>
+    </div>
+</td>
+</tr>
+
+                                  <tr><td style="width:150px;">rootID*</td>
+<td>
+
+
+    <div id="d2e199_uploadFile_rootID">
+        <div class="json-schema-view">
+            <div class="primitive">
+                <span class="type">
+                    String
+                </span>
+
+                    <div class="inner description marked">
+ID of the root block
+                    </div>
+            </div>
+                <div class="inner required">
+                    Required
+                </div>
+        </div>
+    </div>
+</td>
+</tr>
+
+                            </table>
 
 
 

--- a/server/swagger/swagger.yml
+++ b/server/swagger/swagger.yml
@@ -291,30 +291,6 @@ info:
   title: Focalboard Server
   version: 1.0.0
 paths:
-  /api/v1/files:
-    post:
-      consumes:
-      - multipart/form-data
-      description: Upload a binary file
-      operationId: uploadFile
-      parameters:
-      - description: The file to upload
-        in: formData
-        name: uploaded file
-        type: file
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: success
-          schema:
-            $ref: '#/definitions/FileUploadResponse'
-        default:
-          description: internal error
-          schema:
-            $ref: '#/definitions/ErrorResponse'
-      security:
-      - BearerAuth: []
   /api/v1/login:
     post:
       description: Login user
@@ -451,6 +427,40 @@ paths:
           description: success
           schema:
             $ref: '#/definitions/Workspace'
+        default:
+          description: internal error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+      security:
+      - BearerAuth: []
+  /api/v1/workspaces/{workspaceID}/{rootID}/files:
+    post:
+      consumes:
+      - multipart/form-data
+      description: Upload a binary file, attached to a root block
+      operationId: uploadFile
+      parameters:
+      - description: Workspace ID
+        in: path
+        name: workspaceID
+        required: true
+        type: string
+      - description: ID of the root block
+        in: path
+        name: rootID
+        required: true
+        type: string
+      - description: The file to upload
+        in: formData
+        name: uploaded file
+        type: file
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: success
+          schema:
+            $ref: '#/definitions/FileUploadResponse'
         default:
           description: internal error
           schema:
@@ -714,11 +724,21 @@ paths:
             $ref: '#/definitions/ErrorResponse'
       security:
       - BearerAuth: []
-  /files/{fileID}:
+  /workspaces/{workspaceID}/{rootID}/{fileID}:
     get:
       description: Returns the contents of an uploaded file
       operationId: getFile
       parameters:
+      - description: Workspace ID
+        in: path
+        name: workspaceID
+        required: true
+        type: string
+      - description: ID of the root block
+        in: path
+        name: rootID
+        required: true
+        type: string
       - description: ID of the file
         in: path
         name: fileID

--- a/webapp/src/components/addContentMenuItem.tsx
+++ b/webapp/src/components/addContentMenuItem.tsx
@@ -38,7 +38,7 @@ const AddContentMenuItem = React.memo((props:Props): JSX.Element => {
             name={handler.getDisplayText(intl)}
             icon={handler.getIcon()}
             onClick={async () => {
-                const newBlock = await handler.createBlock()
+                const newBlock = await handler.createBlock(card.rootId)
                 newBlock.parentId = card.id
                 newBlock.rootId = card.rootId
 

--- a/webapp/src/components/cardDetail/cardDetailContentsMenu.tsx
+++ b/webapp/src/components/cardDetail/cardDetailContentsMenu.tsx
@@ -34,7 +34,7 @@ function addContentMenu(card: Card, intl: IntlShape, type: BlockTypes): JSX.Elem
 }
 
 async function addBlock(card: Card, intl: IntlShape, handler: ContentHandler) {
-    const newBlock = await handler.createBlock()
+    const newBlock = await handler.createBlock(card.rootId)
     newBlock.parentId = card.id
     newBlock.rootId = card.rootId
 

--- a/webapp/src/components/content/contentRegistry.tsx
+++ b/webapp/src/components/content/contentRegistry.tsx
@@ -11,7 +11,7 @@ type ContentHandler = {
     type: BlockTypes,
     getDisplayText: (intl: IntlShape) => string,
     getIcon: () => JSX.Element,
-    createBlock: () => Promise<MutableContentBlock>,
+    createBlock: (rootId: string) => Promise<MutableContentBlock>,
     createComponent: (block: IContentBlock, intl: IntlShape, readonly: boolean) => JSX.Element,
 }
 

--- a/webapp/src/components/content/imageElement.tsx
+++ b/webapp/src/components/content/imageElement.tsx
@@ -17,17 +17,17 @@ type Props = {
 const ImageElement = React.memo((props: Props): JSX.Element|null => {
     const [imageDataUrl, setImageDataUrl] = useState<string|null>(null)
 
+    const {block} = props
+
     useEffect(() => {
         if (!imageDataUrl) {
             const loadImage = async () => {
-                const url = await octoClient.getFileAsDataUrl(props.block.fields.fileId)
+                const url = await octoClient.getFileAsDataUrl(block.rootId, props.block.fields.fileId)
                 setImageDataUrl(url)
             }
             loadImage()
         }
     })
-
-    const {block} = props
 
     if (!imageDataUrl) {
         return null
@@ -45,11 +45,11 @@ contentRegistry.registerContentType({
     type: 'image',
     getDisplayText: (intl) => intl.formatMessage({id: 'ContentBlock.image', defaultMessage: 'image'}),
     getIcon: () => <ImageIcon/>,
-    createBlock: async () => {
+    createBlock: async (rootId: string) => {
         return new Promise<MutableImageBlock>(
             (resolve) => {
                 Utils.selectLocalFile(async (file) => {
-                    const fileId = await octoClient.uploadFile(file)
+                    const fileId = await octoClient.uploadFile(rootId, file)
 
                     const block = new MutableImageBlock()
                     block.fileId = fileId || ''

--- a/webapp/src/mutator.ts
+++ b/webapp/src/mutator.ts
@@ -592,31 +592,6 @@ class Mutator {
         return octoClient.importFullArchive(blocks)
     }
 
-    async createImageBlock(parent: IBlock, file: File, description = 'add image'): Promise<IBlock | undefined> {
-        const fileId = await octoClient.uploadFile(file)
-        if (!fileId) {
-            return undefined
-        }
-
-        const block = new MutableImageBlock()
-        block.parentId = parent.id
-        block.rootId = parent.rootId
-        block.fileId = fileId
-
-        await undoManager.perform(
-            async () => {
-                await octoClient.insertBlock(block)
-            },
-            async () => {
-                await octoClient.deleteBlock(block.id)
-            },
-            description,
-            this.undoGroupId,
-        )
-
-        return block
-    }
-
     get canUndo(): boolean {
         return undoManager.canUndo
     }

--- a/webapp/src/mutator.ts
+++ b/webapp/src/mutator.ts
@@ -6,7 +6,6 @@ import {Board, IPropertyOption, IPropertyTemplate, MutableBoard, PropertyType} f
 import {BoardView, ISortOption, MutableBoardView} from './blocks/boardView'
 import {Card, MutableCard} from './blocks/card'
 import {FilterGroup} from './blocks/filterGroup'
-import {MutableImageBlock} from './blocks/imageBlock'
 import octoClient from './octoClient'
 import {OctoUtils} from './octoUtils'
 import undoManager from './undomanager'

--- a/webapp/src/octoClient.ts
+++ b/webapp/src/octoClient.ts
@@ -17,7 +17,8 @@ class OctoClient {
     set token(value: string) {
         localStorage.setItem('sessionId', value)
     }
-    get readToken(): string {
+
+    private readToken(): string {
         const queryString = new URLSearchParams(window.location.search)
         const readToken = queryString.get('r') || ''
         return readToken
@@ -123,8 +124,9 @@ class OctoClient {
 
     async getSubtree(rootId?: string, levels = 2): Promise<IBlock[]> {
         let path = this.workspacePath() + `/blocks/${encodeURIComponent(rootId || '')}/subtree?l=${levels}`
-        if (this.readToken) {
-            path += `&read_token=${this.readToken}`
+        const readToken = this.readToken()
+        if (readToken) {
+            path += `&read_token=${readToken}`
         }
         const response = await fetch(this.serverUrl + path, {headers: this.headers()})
         if (response.status !== 200) {
@@ -308,7 +310,7 @@ class OctoClient {
     // Files
 
     // Returns fileId of uploaded file, or undefined on failure
-    async uploadFile(file: File): Promise<string | undefined> {
+    async uploadFile(rootID: string, file: File): Promise<string | undefined> {
         // IMPORTANT: We need to post the image as a form. The browser will convert this to a application/x-www-form-urlencoded POST
         const formData = new FormData()
         formData.append('file', file)
@@ -319,7 +321,7 @@ class OctoClient {
             // TIPTIP: Leave out Content-Type here, it will be automatically set by the browser
             delete headers['Content-Type']
 
-            const response = await fetch(this.serverUrl + '/api/v1/files', {
+            const response = await fetch(this.serverUrl + this.workspacePath() + '/' + rootID + '/files', {
                 method: 'POST',
                 headers,
                 body: formData,
@@ -345,8 +347,12 @@ class OctoClient {
         return undefined
     }
 
-    async getFileAsDataUrl(fileId: string): Promise<string> {
-        const path = '/files/' + fileId
+    async getFileAsDataUrl(rootId: string, fileId: string): Promise<string> {
+        let path = '/files/workspaces/' + this.workspaceId + '/' + rootId + '/' + fileId
+        const readToken = this.readToken()
+        if (readToken) {
+            path += `?read_token=${readToken}`
+        }
         const response = await fetch(this.serverUrl + path, {headers: this.headers()})
         if (response.status !== 200) {
             return ''


### PR DESCRIPTION
#### Summary
Changed files API to store and retrieve files per workspace and rootID. This is to allow permissions later. A user has access to a file if and only if one of the following is true:
1. Logged in with a valid session (and has access to the workspace, if workspaces are enabled)
2. Pass a valid read_token in the querystring, that is valid for the specified root block (sharing read-only)

This is a breaking change on the previous file storage location.