### PR TITLE
linux: find server executable relative to app

### DIFF
--- a/linux/main.go
+++ b/linux/main.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 
 	"github.com/google/uuid"
@@ -13,9 +14,10 @@ import (
 )
 
 var sessionToken string = "su-" + uuid.New().String()
+var serverExecutable string = filepath.Join(filepath.Dir(os.Executable()), "focalboard-server")
 
 func runServer(ctx context.Context) {
-	cmd := exec.CommandContext(ctx, "./focalboard-server", "--monitorpid", strconv.FormatInt(int64(os.Getpid()), 10), "-single-user")
+	cmd := exec.CommandContext(ctx, serverExecutable, "--monitorpid", strconv.FormatInt(int64(os.Getpid()), 10), "-single-user")
 	cmd.Env = []string{fmt.Sprintf("FOCALBOARD_SINGLE_USER_TOKEN=%s", sessionToken)}
 	cmd.Stdout = os.Stdout
 	err := cmd.Run()


### PR DESCRIPTION

This PR changes the search path of the server binary in the linux app  to be not `./` (the working directory) but the same path as the apps executable. 

This is part of an effort to better separate program and configuration. 
