### PR TITLE
server: additionally read config settings from env

### DIFF
--- a/server/services/config/config.go
+++ b/server/services/config/config.go
@@ -41,6 +41,8 @@ func ReadConfigFile() (*Configuration, error) {
 	viper.SetConfigName("config") // name of config file (without extension)
 	viper.SetConfigType("json")   // REQUIRED if the config file does not have the extension in the name
 	viper.AddConfigPath(".")      // optionally look for config in the working directory
+	viper.SetEnvPrefix("focalboard")
+	viper.AutomaticEnv() // read config values from env like FOCALBOARD_SERVERROOT=...
 	viper.SetDefault("ServerRoot", DefaultServerRoot)
 	viper.SetDefault("Port", DefaultPort)
 	viper.SetDefault("DBType", "sqlite3")


### PR DESCRIPTION
The current setup expects `focalboard-app`, `focalboard-server`, `config.json` and the `pack` directory to reside in the same location. 

This PR allows for at least the configuration to be overridden via the execution environment which makes it easier to use the app in a environment where the programs assets and executables reside in a global, not user writeable location as is the case with nix(os) and many other scenarios. 

ideally the app would take a `--config-file` parameter but this is not straight forward with the viper framework and therefore I present this as the smallest and least invasive change to solve the problem. 
