### PR TITLE
Clean up temp files in Dockerfile to save image size

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,11 +2,13 @@ FROM ubuntu:20.04
 
 # Make sure that the underlying container is patched to the latest versions
 RUN apt-get update && \
-    apt-get install -y gzip tar wget
+    apt-get install -y gzip tar wget && \
+    rm -rf /var/lib/apt/lists/*
 
 # Now install Focalboard as a seperate layer
 RUN wget https://github.com/mattermost/focalboard/releases/download/v0.6.1/focalboard-server-linux-amd64.tar.gz && \
     tar -xvzf focalboard-server-linux-amd64.tar.gz && \
+    rm focalboard-server-linux-amd64.tar.gz && \
     mv focalboard /opt
 
 EXPOSE 8000


### PR DESCRIPTION
#### Summary

Clean up temporary/cache files in Dockerfile to save image size

Result:

```text
REPOSITORY            TAG             IMAGE ID            CREATED              SIZE
after                 latest          521681716ad5        About a minute ago   107MB
before                latest          c192efaae426        3 minutes ago        147MB
```
