### PR TITLE
[GH-255] Add crucial step to Trello import readme

### DIFF
--- a/import/trello/README.md
+++ b/import/trello/README.md
@@ -3,9 +3,10 @@
 This node app converts a Trello json archive into a Focalboard archive. To use:
 1. From the Trello Board Menu, select `More`, then `Print and Export`, and `Export to JSON`
 2. Save it locally, e.g. to `trello.json`
-3. Run `npm install`
-4. Run `npx ts-node importTrello.ts -i <trello.json> -o archive.focalboard`
-5. In Focalboard, click `Settings`, then `Import archive` and select `archive.focalboard`
+3. Run `npm install` from within `focalboard/webapp`
+4. Run `npm install` from within `focalboard/import/trello`
+5. Run `npx ts-node importTrello.ts -i <path-to-trello.json> -o archive.focalboard` (also from within `focalboard/import/trello`)
+6. In Focalboard, click `Settings`, then `Import archive` and select `archive.focalboard`
 
 ## Import scope
 


### PR DESCRIPTION
#### Summary

This is a documentation-only change.

Without this, the steps indicated in the Trello import readme currently result in errors, as described on the ticket below.

#### Ticket Link

Fixes #255 .