### PR TITLE
[GH-278] Prevent dragging of gallery cards in read-only mode

### DIFF
--- a/webapp/src/components/gallery/galleryCard.tsx
+++ b/webapp/src/components/gallery/galleryCard.tsx
@@ -37,7 +37,7 @@ type Props = {
 
 const GalleryCard = React.memo((props: Props) => {
     const {cardTree} = props
-    const [isDragging, isOver, cardRef] = useSortable('card', cardTree.card, props.isManualSort, props.onDrop)
+    const [isDragging, isOver, cardRef] = useSortable('card', cardTree.card, props.isManualSort && !props.readonly, props.onDrop)
 
     const visiblePropertyTemplates = props.visiblePropertyTemplates || []
 


### PR DESCRIPTION
#### Summary

This prevents cards on gallery boards from being draggable when the board is read-only.

Comparing with [KanbanCard](https://github.com/mattermost/focalboard/blob/main/webapp/src/components/kanban/kanbanCard.tsx#L44), I noticed that the `draggable` property is also set explicitly there. In my testing for gallery cards this did not seem necessary though.

#### Ticket Link

Fixes #278

PS: When signing the CLA, the form said you'll send me something as a thank you if my contribution is accepted. Please don't mail me anything to Germany for a one-line fix. I would feel embarrassed. 😅