### PR TITLE
[GH-277] Hide drag grip on content blocks in read-only mode

### DIFF
--- a/webapp/src/components/contentBlock.tsx
+++ b/webapp/src/components/contentBlock.tsx
@@ -106,12 +106,14 @@ const ContentBlock = React.memo((props: Props): JSX.Element => {
                         </Menu>
                     </MenuWrapper>
                 }
-                <div
-                    ref={gripRef}
-                    className='dnd-handle'
-                >
-                    <GripIcon/>
-                </div>
+                {!props.readonly &&
+                    <div
+                        ref={gripRef}
+                        className='dnd-handle'
+                    >
+                        <GripIcon/>
+                    </div>
+                }
             </div>
             <ContentElement
                 block={block}


### PR DESCRIPTION
#### Summary

This wraps the `.dnd-handle` drag grip with `!props.readonly &&` so that it doesn't show when viewing card details in read-only mode.

Since all children of the parent `.octo-block-margin` div are excluded in read-only mode now, we could also move the read-only check here. Other than preventing the empty div, that didn't seem to provide any significant advantage though so I left it like this. Happy to change this if you disagree though. 🙂

#### Ticket Link

Fixes #277