### PR TITLE
Add macOS quarantine

### DIFF
--- a/mac/Focalboard/Info.plist
+++ b/mac/Focalboard/Info.plist
@@ -24,18 +24,20 @@
 	<string>public.app-category.productivity</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
-    <key>ITSAppUsesNonExemptEncryption</key>
+	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>
 		<true/>
 	</dict>
-    <key>NSHumanReadableCopyright</key>
+	<key>NSHumanReadableCopyright</key>
 	<string>Copyright © 2021 Mattermost, Inc. All rights reserved.</string>
 	<key>NSMainStoryboardFile</key>
 	<string>Main</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
+	<key>LSFileQuarantineEnabled</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
#### Summary

Let macOS handle quarantine on downloaded files.

I know focalboard still doesn't have files other than images (although non images can be uploaded and they wont display properly). but at some point it will and having the OS handle quarantine files will probably ease security.

#### Ticket Link

No ticket per se, but I recently [did that on the desktop app](https://mattermost.atlassian.net/browse/MM-20677) and thought it would be nice to have it here as well. 

#### Testing

I don't think it can be tested right now, but once you can download a file from Focalboard you can create a sample file out of the terminal app by going to the menu->shell->export settings (export as a `.terminal` file)