### PR TITLE
316 - Updating editable default height

### DIFF
--- a/webapp/src/widgets/editable.scss
+++ b/webapp/src/widgets/editable.scss
@@ -4,6 +4,8 @@
     overflow: hidden;
     text-overflow: ellipsis;
     border: 1px solid transparent;
+    min-height: 24px;
+
     &.active {
 	    min-width: 100px;
     }


### PR DESCRIPTION
#### Summary
316 - Updating editable default height

#### Ticket Link
https://github.com/mattermost/focalboard/issues/316

#### Screenshot
<img width="704" alt="Screenshot 2021-04-26 at 5 18 40 PM" src="https://user-images.githubusercontent.com/11034289/116081346-97bc7800-a6b3-11eb-8977-f7372bac426c.png">
