### PR TITLE
[GH-351] Truncate Column Headers in Table View if necessary

### DIFF
--- a/webapp/src/components/table/table.scss
+++ b/webapp/src/components/table/table.scss
@@ -69,6 +69,7 @@
         .octo-propertyvalue {
             text-align: left;
             white-space: nowrap;
+            width: inherit;
         }
     }
 
@@ -108,6 +109,18 @@
             &:hover {
                 background-color: rgba(var(--body-color), 0.08);
             }
+        }
+    }
+
+    .MenuWrapper {  
+        width: 100%;
+        max-width: calc(100% - 5px);
+
+        .Label {
+            width: 100%;
+            display: inline-block;
+            text-overflow: ellipsis;
+            overflow: hidden;
         }
     }
 }


### PR DESCRIPTION
#### Summary
Updates css, to prevent column headers from overflowing into the next cell.

Also fixes sizing in text properties where they didn't take up entire cell.

#### Ticket Link
Fixes https://github.com/mattermost/focalboard/issues/351
![Screen Shot 2021-04-27 at 12 46 58 PM](https://user-images.githubusercontent.com/12704875/116317357-7a011880-a770-11eb-8449-2a6bee723890.png)
Fixes https://github.com/mattermost/focalboard/issues/352
![Screen Shot 2021-04-27 at 12 46 35 PM](https://user-images.githubusercontent.com/12704875/116317361-7a011880-a770-11eb-98e4-ce9837d03831.png)
