### PR TITLE
GH-358 - Make it possible to use sources when building docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,16 +1,26 @@
 FROM golang:alpine as gobuild
 
+ARG USE_LOCAL_SOURCES=false
+
+COPY . ./focalboard
+COPY ./docker/get_sources.sh .
+
 RUN apk update && \
     apk add ca-certificates gcc git make musl-dev && \
-    git clone https://github.com/mattermost/focalboard && \
+ 		./get_sources.sh && \
     cd focalboard && \
     make server-linux
 
 FROM node:alpine as nodebuild
 
+ARG USE_LOCAL_SOURCES=false
+
+COPY . ./focalboard
+COPY ./docker/get_sources.sh .
+
 RUN apk update && \
     apk add ca-certificates git && \
-    git clone https://github.com/mattermost/focalboard && \
+ 		./get_sources.sh && \
     cd focalboard/webapp && \
     npm install && npm run pack
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,7 +7,7 @@ COPY ./docker/get_sources.sh .
 
 RUN apk update && \
     apk add ca-certificates gcc git make musl-dev && \
- 		./get_sources.sh && \
+    ./get_sources.sh && \
     cd focalboard && \
     make server-linux
 
@@ -20,7 +20,7 @@ COPY ./docker/get_sources.sh .
 
 RUN apk update && \
     apk add ca-certificates git && \
- 		./get_sources.sh && \
+    ./get_sources.sh && \
     cd focalboard/webapp && \
     npm install && npm run pack
 

--- a/docker/docker-compose-db-nginx.yml
+++ b/docker/docker-compose-db-nginx.yml
@@ -2,18 +2,19 @@ version: "3"
 services:
   app:
     build:
-      context: ./
+      context: ./..
+      dockerfile: ./docker/Dockerfile
     container_name: focalboard
     depends_on:
       - focalboard-db
-    expose: 
+    expose:
       - 8000
     environment:
       - VIRTUAL_HOST=focalboard.local
       - VIRTUAL_PORT=8000
     volumes:
       - "./config.json:/opt/focalboard/config.json"
-  
+
   proxy:
     image: jwilder/nginx-proxy:latest
     container_name: focalboard-proxy

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -2,9 +2,10 @@ version: "3"
 services:
   app:
     build:
-      context: ./
+      context: ./..
+      dockerfile: ./docker/Dockerfile
     container_name: focalboard
-    ports: 
+    ports:
       - 80:8000
     environment:
       - VIRTUAL_HOST=focalboard.local

--- a/docker/get_sources.sh
+++ b/docker/get_sources.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+# Used as part of docker build.
+# If not specified to use local sources, the repository will be cloned.
+
+if [ "$USE_LOCAL_SOURCES" = "true" ]; then
+    echo "Using local sources"
+else
+    echo "Cloning sources"
+    rm -rf ./focalboard
+    git clone https://github.com/mattermost/focalboard
+fi


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
This PR makes it possible to build docker image from sources.
To build from sources, run from project root:
```
docker build . -f ./docker/Dockerfile --build-arg USE_LOCAL_SOURCES=true
```

#### Ticket Link
#358

