### PR TITLE
[GH-309] Prevent description duplication on Safari / macOS app

### DIFF
--- a/webapp/src/components/markdownEditor.tsx
+++ b/webapp/src/components/markdownEditor.tsx
@@ -128,7 +128,6 @@ const MarkdownEditor = (props: Props): JSX. Element => {
                             stateAndPropsRef.current.onBlur(newText)
                         }
 
-                        instance.getInputField()?.blur()
                         stateAndPropsRef.current.setIsEditing(false)
                     },
                     focus: () => {


### PR DESCRIPTION
#### Summary

This removes a redundant manual blur of the input field. In the macOS app this caused the blur handler to be retriggered which resulted in the description being duplicated.

#### Ticket Link

Fixes #309