### PR TITLE
[GH-315] Enable spell checking in inputs and markdown editor

### DIFF
--- a/webapp/src/components/cardDetail/cardDetail.tsx
+++ b/webapp/src/components/cardDetail/cardDetail.tsx
@@ -94,6 +94,7 @@ const CardDetail = (props: Props): JSX.Element|null => {
                     }}
                     onCancel={() => setTitle(props.cardTree.card.title)}
                     readonly={props.readonly}
+                    spellCheck={true}
                 />
 
                 {/* Property list */}

--- a/webapp/src/components/content/__snapshots__/checkboxElement.test.tsx.snap
+++ b/webapp/src/components/content/__snapshots__/checkboxElement.test.tsx.snap
@@ -13,6 +13,7 @@ exports[`components/content/CheckboxElement should match snapshot 1`] = `
     <input
       class="Editable undefined"
       placeholder="Edit text..."
+      spellcheck="true"
       title="test-title"
       value="test-title"
     />
@@ -33,6 +34,7 @@ exports[`components/content/CheckboxElement should match snapshot on change titl
     <input
       class="Editable undefined"
       placeholder="Edit text..."
+      spellcheck="true"
       title="test-title"
       value="test-title"
     >
@@ -57,6 +59,7 @@ exports[`components/content/CheckboxElement should match snapshot on read only 1
       class="Editable undefined"
       placeholder="Edit text..."
       readonly=""
+      spellcheck="true"
       title="test-title"
       value="test-title"
     />
@@ -77,6 +80,7 @@ exports[`components/content/CheckboxElement should match snapshot on toggle 1`] 
     <input
       class="Editable undefined"
       placeholder="Edit text..."
+      spellcheck="true"
       title="test-title"
       value="test-title"
     />

--- a/webapp/src/components/content/checkboxElement.tsx
+++ b/webapp/src/components/content/checkboxElement.tsx
@@ -52,6 +52,7 @@ const CheckboxElement = React.memo((props: Props) => {
                     mutator.updateBlock(newBlock, block, intl.formatMessage({id: 'ContentBlock.editCardCheckboxText', defaultMessage: 'edit card text'}))
                 }}
                 readonly={readonly}
+                spellCheck={true}
             />
         </div>
     )

--- a/webapp/src/components/kanban/kanbanColumnHeader.tsx
+++ b/webapp/src/components/kanban/kanbanColumnHeader.tsx
@@ -104,6 +104,7 @@ export default function KanbanColumnHeader(props: Props): JSX.Element {
                             setGroupTitle(group.option.value)
                         }}
                         readonly={props.readonly}
+                        spellCheck={true}
                     />
                 </Label>}
             <Button>{`${group.cards.length}`}</Button>

--- a/webapp/src/components/markdownEditor.tsx
+++ b/webapp/src/components/markdownEditor.tsx
@@ -145,6 +145,8 @@ const MarkdownEditor = (props: Props): JSX. Element => {
                     toolbar: false,
                     status: false,
                     spellChecker: false,
+                    inputStyle: 'contenteditable',
+                    nativeSpellcheck: true,
                     minHeight: '10px',
                     shortcuts: {
                         toggleStrikethrough: 'Cmd-.',

--- a/webapp/src/components/propertyValueElement.tsx
+++ b/webapp/src/components/propertyValueElement.tsx
@@ -116,6 +116,7 @@ const PropertyValueElement = (props:Props): JSX.Element => {
                     onSave={() => mutator.changePropertyValue(card, propertyTemplate.id, value)}
                     onCancel={() => setValue(propertyValue)}
                     validator={(newValue) => validateProp(propertyTemplate.type, newValue)}
+                    spellCheck={propertyTemplate.type === 'text'}
                 />
             )
         }

--- a/webapp/src/components/table/tableRow.tsx
+++ b/webapp/src/components/table/tableRow.tsx
@@ -86,6 +86,7 @@ const TableRow = React.memo((props: Props) => {
                         }}
                         onCancel={() => setTitle(card.title)}
                         readonly={props.readonly}
+                        spellCheck={true}
                     />
                 </div>
 

--- a/webapp/src/components/viewHeader/viewHeader.tsx
+++ b/webapp/src/components/viewHeader/viewHeader.tsx
@@ -65,6 +65,7 @@ const ViewHeader = React.memo((props: Props) => {
                 onChange={setViewTitle}
                 saveOnEsc={true}
                 readonly={props.readonly}
+                spellCheck={true}
             />
             <MenuWrapper>
                 <IconButton icon={<DropdownIcon/>}/>

--- a/webapp/src/components/viewTitle.tsx
+++ b/webapp/src/components/viewTitle.tsx
@@ -83,6 +83,7 @@ const ViewTitle = React.memo((props: Props) => {
                     onSave={() => mutator.changeTitle(board, title)}
                     onCancel={() => setTitle(props.board.title)}
                     readonly={props.readonly}
+                    spellCheck={true}
                 />
             </div>
 

--- a/webapp/src/widgets/__snapshots__/propertyMenu.test.tsx.snap
+++ b/webapp/src/widgets/__snapshots__/propertyMenu.test.tsx.snap
@@ -13,6 +13,7 @@ exports[`widgets/PropertyMenu should match snapshot 1`] = `
       >
         <input
           class="PropertyMenu menu-textbox"
+          spellcheck="true"
           type="text"
           value="test-property"
         />

--- a/webapp/src/widgets/editable.tsx
+++ b/webapp/src/widgets/editable.tsx
@@ -11,6 +11,7 @@ type Props = {
     className?: string
     saveOnEsc?: boolean
     readonly?: boolean
+    spellCheck?: boolean
 
     validator?: (value: string) => boolean
     onCancel?: () => void
@@ -90,6 +91,7 @@ const Editable = (props: Props, ref: React.Ref<{focus: (selectAll?: boolean) => 
                 }
             }}
             readOnly={props.readonly}
+            spellCheck={props.spellCheck}
         />
     )
 }

--- a/webapp/src/widgets/propertyMenu.tsx
+++ b/webapp/src/widgets/propertyMenu.tsx
@@ -75,6 +75,7 @@ const PropertyMenu = React.memo((props: Props) => {
                         e.stopPropagation()
                     }
                 }}
+                spellCheck={true}
             />
             <Menu.SubMenu
                 id='type'


### PR DESCRIPTION
#### Summary

This PR enables built-in browser spell checking by:

- Adding `spellcheck="true"` to all relevant `<input>` elements
- Enabling the native spell checking mode in easy-markdown-editor

Tested on macOS with German set as the primary and US English as the secondary language. Safari and Chrome correctly spell check both languages:

![Bildschirmfoto 2021-05-01 um 21 08 11](https://user-images.githubusercontent.com/1137962/116792771-0be78900-aac3-11eb-8c5b-f6adf105d345.png)

Firefox, unfortunately, continued using English only for spell checking even after changing the language in the browser settings. 😞 

![Bildschirmfoto 2021-05-01 um 21 11 44](https://user-images.githubusercontent.com/1137962/116792789-2f123880-aac3-11eb-8e29-2c1fc088c970.png)

Safari, sadly, refuses to do spell checking in the markdown editor:

![Bildschirmfoto 2021-05-01 um 21 24 50](https://user-images.githubusercontent.com/1137962/116792889-c24b6e00-aac3-11eb-9df8-981c857f2aed.png)

Chrome and Firefox do though:

![Bildschirmfoto 2021-05-01 um 21 25 12](https://user-images.githubusercontent.com/1137962/116792914-e14a0000-aac3-11eb-90c9-d3748948c2a1.png) ![Bildschirmfoto 2021-05-01 um 21 26 35](https://user-images.githubusercontent.com/1137962/116792921-ec9d2b80-aac3-11eb-83bf-a25db8e1c4a5.png)

#### Ticket Link

Relates to #315