### PR TITLE
[GH-375] Persist `randomIcons` setting in native mac app

### DIFF
--- a/webapp/src/userSettings.ts
+++ b/webapp/src/userSettings.ts
@@ -11,7 +11,7 @@ export class UserSettings {
     }
 }
 
-const keys = ['language', 'theme', 'lastBoardId', 'lastViewId', 'emoji-mart.last', 'emoji-mart.frequently']
+const keys = ['language', 'theme', 'lastBoardId', 'lastViewId', 'emoji-mart.last', 'emoji-mart.frequently', 'randomIcons']
 
 export function exportUserSettingsBlob(): string {
     return window.btoa(exportUserSettings())


### PR DESCRIPTION
#### Summary

This adds `randomIcons` to the exported user settings. Apologies for missing this earlier. 🤦 

#### Ticket Link

Fixes #375