### PR TITLE
Update "Open" button size

### DIFF
--- a/webapp/src/components/table/tableRow.scss
+++ b/webapp/src/components/table/tableRow.scss
@@ -11,6 +11,8 @@
             background-color: rgba(var(--body-color), 0.1);
             box-shadow: rgba(var(--body-color), 0.1) 0px 0px 0px 1px,
                 rgba(var(--body-color), 0.1) 0px 2px 4px;
+            height: 90%;
+            width: 100%;
         }
     }
 


### PR DESCRIPTION
Updated the "Open" button size to better fill the row

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
The open button currently does not fill the row completely and makes it a bit odd when trying to click on it

![Focalboard_2021-05-05_21-01-47](https://user-images.githubusercontent.com/363587/117167895-4d3ea800-ade5-11eb-941e-b5fd0230700d.png)

Which has been updated to,

![Focalboard_2021-05-05_21-00-24](https://user-images.githubusercontent.com/363587/117167945-5b8cc400-ade5-11eb-9581-15b1d1832d87.png)



#### Ticket Link
 
None I think
