### PR TITLE
Use AddIcon instead of "+" in text in sidebarAddBoardMenu.tsx 

### DIFF
--- a/webapp/src/components/sidebar/sidebarAddBoardMenu.tsx
+++ b/webapp/src/components/sidebar/sidebarAddBoardMenu.tsx
@@ -9,6 +9,7 @@ import mutator from '../../mutator'
 import octoClient from '../../octoClient'
 import {GlobalTemplateTree, MutableGlobalTemplateTree} from '../../viewModel/globalTemplateTree'
 import {WorkspaceTree} from '../../viewModel/workspaceTree'
+import AddIcon from '../../widgets/icons/add'
 import BoardIcon from '../../widgets/icons/board'
 import Menu from '../../widgets/menu'
 import MenuWrapper from '../../widgets/menuWrapper'
@@ -136,8 +137,9 @@ const SidebarAddBoardMenu = (props: Props): JSX.Element => {
                     />
 
                     <Menu.Text
+                        icon={<AddIcon/>}
                         id='add-template'
-                        name={intl.formatMessage({id: 'Sidebar.add-template', defaultMessage: '+ New template'})}
+                        name={intl.formatMessage({id: 'Sidebar.add-template', defaultMessage: 'New template'})}
                         onClick={() => addBoardTemplateClicked(props.showBoard, props.activeBoardId)}
                     />
                 </Menu>


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

Use AddIcon instead of "+" in text

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

Similar change to https://github.com/mattermost/focalboard/pull/400, replaces a "+" with the icon
