### PR TITLE
[GH-443] Create new window when reopening without existing windows

### DIFF
--- a/mac/Focalboard/AppDelegate.swift
+++ b/mac/Focalboard/AppDelegate.swift
@@ -26,6 +26,13 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 		NotificationCenter.default.post(name: AppDelegate.serverStartedNotification, object: nil)
 	}
 
+	func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
+		if !flag {
+			openNewWindow(nil)
+		}
+		return true
+	}
+
 	func applicationWillTerminate(_ aNotification: Notification) {
 		stopServer()
 	}

--- a/mac/Focalboard/AppDelegate.swift
+++ b/mac/Focalboard/AppDelegate.swift
@@ -27,8 +27,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 	}
 
 	func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
-		if !flag {
+		guard flag else {
 			openNewWindow(nil)
+			return false
 		}
 		return true
 	}


### PR DESCRIPTION
#### Summary

This change intercepts reopen events and creates a new window in case no windows exist.

#### Ticket Link

Fixes https://github.com/mattermost/focalboard/issues/443