### PR TITLE
[GH-410] Remove background from read-only input fields

### DIFF
--- a/webapp/src/components/content/__snapshots__/checkboxElement.test.tsx.snap
+++ b/webapp/src/components/content/__snapshots__/checkboxElement.test.tsx.snap
@@ -56,7 +56,7 @@ exports[`components/content/CheckboxElement should match snapshot on read only 1
       value="off"
     />
     <input
-      class="Editable undefined"
+      class="Editable readonly undefined"
       placeholder="Edit text..."
       readonly=""
       spellcheck="true"

--- a/webapp/src/widgets/editable.scss
+++ b/webapp/src/widgets/editable.scss
@@ -17,4 +17,7 @@
         border: 1px solid var(--error-color);
         border-radius: var(--default-rad);
     }
+    &.readonly {
+        background-color: transparent;
+    }
 }

--- a/webapp/src/widgets/editable.tsx
+++ b/webapp/src/widgets/editable.tsx
@@ -58,7 +58,7 @@ const Editable = (props: Props, ref: React.Ref<{focus: (selectAll?: boolean) => 
         saveOnBlur.current = true
     }
 
-    const {value, onChange, className, placeholderText} = props
+    const {value, onChange, className, placeholderText, readonly} = props
     let error = false
     if (props.validator) {
         error = !props.validator(value || '')
@@ -67,7 +67,7 @@ const Editable = (props: Props, ref: React.Ref<{focus: (selectAll?: boolean) => 
     return (
         <input
             ref={elementRef}
-            className={'Editable ' + (error ? 'error ' : '') + className}
+            className={'Editable ' + (error ? 'error ' : '') + (readonly ? 'readonly ' : '') + className}
             placeholder={placeholderText}
             onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
                 onChange(e.target.value)
@@ -90,7 +90,7 @@ const Editable = (props: Props, ref: React.Ref<{focus: (selectAll?: boolean) => 
                     blur()
                 }
             }}
-            readOnly={props.readonly}
+            readOnly={readonly}
             spellCheck={props.spellCheck}
         />
     )


### PR DESCRIPTION
#### Summary

This is an attempt to fix #410 by making the background of text input fields transparent when the field is read-only. Making it transparent will make the parent's background show through which works in conjunction with table cells which change background on hover.

Alternatively, we could also set a static color but I found this solution to work nicely irrespective of the parent's background.

![Screenshot 2021-05-21 at 19 41 28](https://user-images.githubusercontent.com/1137962/119177430-9ab94700-ba6c-11eb-9ac6-f83bd33bc82f.png)   ![Screenshot 2021-05-21 at 19 41 46](https://user-images.githubusercontent.com/1137962/119177431-9b51dd80-ba6c-11eb-8700-2510f91b5d94.png)


#### Ticket Link

Fixes #410