### PR TITLE
MM-35819 mac win: Only injecting the session token when the href match the expected localhost

### DIFF
--- a/mac/Focalboard/ViewController.swift
+++ b/mac/Focalboard/ViewController.swift
@@ -107,8 +107,14 @@ class ViewController:
 
 	private func updateSessionTokenAndUserSettings() {
 		let appDelegate = NSApplication.shared.delegate as! AppDelegate
+		let url = URL(string: "http://localhost:\(appDelegate.serverPort)/")!
+		let sessionScript = """
+		if (window.location.href.toLowerCase().startsWith('\(url)'.toLowerCase())) {
+			localStorage.setItem('focalboardSessionId', '\(appDelegate.sessionToken)');
+		}
+		"""
 		let sessionTokenScript = WKUserScript(
-			source: "localStorage.setItem('focalboardSessionId', '\(appDelegate.sessionToken)');",
+			source: sessionScript,
 			injectionTime: .atDocumentStart,
 			forMainFrameOnly: true
 		)
@@ -126,8 +132,7 @@ class ViewController:
 	private func loadHomepage() {
 		NSLog("loadHomepage")
 		let appDelegate = NSApplication.shared.delegate as! AppDelegate
-		let port = appDelegate.serverPort
-		let url = URL(string: "http://localhost:\(port)/")!
+		let url = URL(string: "http://localhost:\(appDelegate.serverPort)/")!
 		let request = URLRequest(url: url)
 		refreshWebViewOnLoad = true
 		webView.load(request)

--- a/win-wpf/Focalboard/MainWindow.xaml.cs
+++ b/win-wpf/Focalboard/MainWindow.xaml.cs
@@ -134,7 +134,7 @@ namespace Focalboard {
 
 			webView.ContentLoading += WebView_ContentLoading;
 
-			var url = String.Format("http://localhost:{0}", port);
+			var url = String.Format("http://localhost:{0}/", port);
 			webView.Source = new Uri(url);
 		}
 
@@ -146,7 +146,10 @@ namespace Focalboard {
 
 		private void WebView_ContentLoading(object sender, CoreWebView2ContentLoadingEventArgs e) {
 			// Set focalboardSessionId
-			string script = $"localStorage.setItem('focalboardSessionId', '{sessionToken}');";
+			var url = String.Format("http://localhost:{0}/", port);
+			string script = $@"if (window.location.href.toLowerCase().startsWith('{url}'.toLowerCase())) {{
+				localStorage.setItem('focalboardSessionId', '{sessionToken}');
+			}}";
 			webView.ExecuteScriptAsync(script);
 		}
 	}


### PR DESCRIPTION
Similar to #460 (for Linux), this adds the same check for Mac and Windows.
