### PR TITLE
Add GitLab ci to build internally and bump go to 1.16

### DIFF
--- a/.github/workflows/build-mac.yml
+++ b/.github/workflows/build-mac.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.15
+        go-version: 1.16
 
     - name: List Xcode versions
       run: ls -n /Applications/ | grep Xcode*

--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.15
+        go-version: 1.16
 
     - name: apt-get update
       run: sudo apt-get update

--- a/.github/workflows/build-win-wpf.yml
+++ b/.github/workflows/build-win-wpf.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.15
+        go-version: 1.16
 
     - name: Setup NuGet
       uses: nuget/setup-nuget@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.15
+        go-version: 1.16
 
     - name: Build Linux server
       run: make server-linux-package

--- a/.github/workflows/prod-release.yml
+++ b/.github/workflows/prod-release.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.15
+        go-version: 1.16
 
     - name: apt-get update
       run: sudo apt-get update

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,11 @@
+stages:
+  - build
+  - s3
+
+variables:
+  BUILD: "yes"
+
+include:
+  - project: mattermost/ci/focalboard
+    ref: main
+    file: private.yml

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,0 +1,33 @@
+# This dockerfile is used to build Focalboard for Linux
+# it builds all the parts inside the container and the last stage just holds the
+# package that can be extracted using docker cp command
+# ie
+# docker build -f Dockerfile.build --no-cache -t focalboard-build:dirty .
+# docker run --rm -v /tmp/dist:/tmp -d --name test focalboard-build:dirty /bin/sh -c 'sleep 1000'
+# docker cp test:/dist/focalboard-server-linux-amd64.tar.gz .
+
+# build frontend
+FROM node:16.1.0 AS frontend
+
+WORKDIR /webapp
+COPY webapp .
+
+RUN npm install --no-optional
+RUN npm run pack
+
+# build backend and package
+FROM golang:1.16.4 AS backend
+
+COPY . .
+COPY --from=frontend /webapp/pack webapp/pack
+
+# RUN apt-get update && apt-get install libgtk-3-dev libwebkit2gtk-4.0-dev -y
+RUN make server-linux
+RUN make server-linux-package-docker
+
+# just hold the packages to output later
+FROM alpine:3.12 AS dist
+
+WORKDIR /dist
+
+COPY --from=backend /go/dist/focalboard-server-linux-amd64.tar.gz .

--- a/Makefile
+++ b/Makefile
@@ -90,6 +90,19 @@ server-linux-package: server-linux webapp
 	cd package && tar -czvf ../dist/focalboard-server-linux-amd64.tar.gz ${PACKAGE_FOLDER}
 	rm -rf package
 
+server-linux-package-docker:
+	rm -rf package
+	mkdir -p package/${PACKAGE_FOLDER}/bin
+	cp bin/linux/focalboard-server package/${PACKAGE_FOLDER}/bin
+	cp -R webapp/pack package/${PACKAGE_FOLDER}/pack
+	cp server-config.json package/${PACKAGE_FOLDER}/config.json
+	cp build/MIT-COMPILED-LICENSE.md package/${PACKAGE_FOLDER}
+	cp NOTICE.txt package/${PACKAGE_FOLDER}
+	cp webapp/NOTICE.txt package/${PACKAGE_FOLDER}/webapp-NOTICE.txt
+	mkdir -p dist
+	cd package && tar -czvf ../dist/focalboard-server-linux-amd64.tar.gz ${PACKAGE_FOLDER}
+	rm -rf package
+
 server-enterprise-linux-package: server-linux webapp
 	rm -rf package
 	mkdir -p package/${PACKAGE_FOLDER}/bin

--- a/README.md
+++ b/README.md
@@ -4,25 +4,25 @@ Like what you see? :eyes: Give us a GitHub Star! :star:
 
 [![Focalboard](website/site/static/img/hero.jpg)](https://www.focalboard.com)
 
-[Focalboard](https://www.focalboard.com) is an open source, self-hosted alternative to Trello, Notion, and Asana. 
+[Focalboard](https://www.focalboard.com) is an open source, self-hosted alternative to Trello, Notion, and Asana.
 
 It helps define, organize, track and manage work across individuals and teams. Focalboard comes in two editions:
 
-* **Focalboard Personal Desktop**: A stand-alone desktop app for your todos and personal projects. This is a single-tenant locally run server running Focalboard for optimal speed and performance. 
+* **Focalboard Personal Desktop**: A stand-alone desktop app for your todos and personal projects. This is a single-tenant locally run server running Focalboard for optimal speed and performance.
 
 * **Focalboard Personal Server**: A self-hosted server for your team to collaborate.
 
 The same MIT-licensed binary powers both desktop and server editions.
 
-## Try out Focalboard 
+## Try out Focalboard
 
 **Focalboard Personal Desktop (Windows, Mac or Linux Desktop)**
 
-Try out **Focalboard Personal Desktop** by going to the Windows Store or the Apple AppStore, searching for `Focalboard` and installing to run the compiled version locally. 
+Try out **Focalboard Personal Desktop** by going to the Windows Store or the Apple AppStore, searching for `Focalboard` and installing to run the compiled version locally.
 
 If you're running a Linux Desktop, [download the latest `focalboard-linux.tar.gz` release](https://github.com/mattermost/focalboard/releases), unpack the `.tar.gz` archive, and open `focalboard-app` from the `focalboard-app` folder.
 
-Note: For Windows and Mac users, while we don't yet offer **Focalboard Personal Desktop** outside of Store-based installs, it is in [consideration for the future](https://github.com/mattermost/focalboard/issues/99) (please upvote the ticket if you're interested in this addition). 
+Note: For Windows and Mac users, while we don't yet offer **Focalboard Personal Desktop** outside of Store-based installs, it is in [consideration for the future](https://github.com/mattermost/focalboard/issues/99) (please upvote the ticket if you're interested in this addition).
 
 **Focalboard Personal Server (Ubuntu)**
 
@@ -88,9 +88,9 @@ Before checking-in commits, run: `make ci`, which is similar to the ci.yml workf
 
 * **Changelog**: See [CHANGELOG.md](CHANGELOG.md) for the latest updates
 * **Developer Discussion**: Join the [Developer Discussion](https://github.com/mattermost/focalboard/discussions) board
-* **Chat**: Join the [Focalboard community channel](https://community.mattermost.com/core/channels/focalboard) 
+* **Chat**: Join the [Focalboard community channel](https://community.mattermost.com/core/channels/focalboard)
 
-## Share your feedback 
+## Share your feedback
 
 File bugs, suggest features, join our forum, learn more [here](https://github.com/mattermost/focalboard/wiki/Share-your-feedback)!
 

--- a/server/go.mod
+++ b/server/go.mod
@@ -1,6 +1,6 @@
 module github.com/mattermost/focalboard/server
 
-go 1.15
+go 1.16
 
 require (
 	github.com/Masterminds/squirrel v1.5.0

--- a/server/go.tools.mod
+++ b/server/go.tools.mod
@@ -1,6 +1,6 @@
 module github.com/mattermost/focalboard/server
 
-go 1.15
+go 1.16
 
 require (
 	github.com/golang/mock v1.5.0


### PR DESCRIPTION
#### Summary
 - This PR adds the GitLab CI to build Focalboard internally, the internal pipeline is setup here: https://git.internal.mattermost.com/mattermost/ci/focalboard/-/merge_requests/1 and for now it builds for the main branch for Linux and Mac.

Added a dockerfile to build the Linux inside a container to not have many outside dependencies, all we need to build focalboard for Linux is in the dockerfile and the pipeline uses that to build.

trying to see if we can do the same for windows and mac, but since it depends on some C it is a bit hard to crosscompile it :/

 - Also bumps Go to 1.16

Missing to do
 - add windows build
 - add pipeline for release branch
 - add pipeline for the official release (when there is a tag)

but adding this now to we can validate the build


focalboard mirror is already in place: https://git.internal.mattermost.com/mattermost/ci-only/focalboard

#### Ticket Link
Jira: https://mattermost.atlassian.net/browse/DOPS-440

