### PR TITLE
Expose 9092 port on docker container

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,7 +19,7 @@ FROM alpine:latest
 ARG PUID=2000
 ARG PGID=2000
 
-EXPOSE 8000/tcp
+EXPOSE 8000/tcp 9092/tcp
 
 RUN addgroup -g ${PGID} focalboard && \
     adduser -H -D -u ${PUID} -G focalboard focalboard

--- a/docker/docker-compose-db-nginx.yml
+++ b/docker/docker-compose-db-nginx.yml
@@ -6,14 +6,14 @@ services:
     container_name: focalboard
     depends_on:
       - focalboard-db
-    expose: 
+    expose:
       - 8000
     environment:
       - VIRTUAL_HOST=focalboard.local
       - VIRTUAL_PORT=8000
     volumes:
       - "./config.json:/opt/focalboard/config.json"
-  
+
   proxy:
     image: jwilder/nginx-proxy:latest
     container_name: focalboard-proxy

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     build:
       context: ./
     container_name: focalboard
-    ports: 
+    ports:
       - 80:8000
     environment:
       - VIRTUAL_HOST=focalboard.local


### PR DESCRIPTION
If this commit merged focalboard helm chart would be able to implement a metrics endpoint.

#### Summary

Expose 9092 port on docker container

#### Ticket Link
Follow-up to https://github.com/mattermost/focalboard/pull/414

