### PR TITLE
Fix MySQL migration connection when the DSN doesn't contain any query parameters

### DIFF
--- a/server/services/store/sqlstore/migrate_test.go
+++ b/server/services/store/sqlstore/migrate_test.go
@@ -1,0 +1,35 @@
+package sqlstore
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetMySQLMigrationConnection(t *testing.T) {
+	testCases := []struct {
+		Scenario    string
+		DSN         string
+		ExpectedDSN string
+	}{
+		{
+			"Should append multiStatements param to the DSN path with existing params",
+			"user:rand?&ompasswith@character@unix(/var/run/mysqld/mysqld.sock)/focalboard?writeTimeout=30s",
+			"user:rand?&ompasswith@character@unix(/var/run/mysqld/mysqld.sock)/focalboard?writeTimeout=30s&multiStatements=true",
+		},
+		{
+			"Should append multiStatements param to the DSN path with no existing params",
+			"user:rand?&ompasswith@character@unix(/var/run/mysqld/mysqld.sock)/focalboard",
+			"user:rand?&ompasswith@character@unix(/var/run/mysqld/mysqld.sock)/focalboard?multiStatements=true",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Scenario, func(t *testing.T) {
+			res, err := appendMultipleStatementsFlag(tc.DSN)
+			require.NoError(t, err)
+			assert.Equal(t, tc.ExpectedDSN, res)
+		})
+	}
+}


### PR DESCRIPTION
#### Summary
This PR fixes a server panic that would happen in case the server is trying to connect to a MySQL database with no query parameters, when trying to append the `multiStatements` parameter.

Based on the [server fix applied for this same bug](https://github.com/mattermost/mattermost-server/pull/17723).
