### PR TITLE
Fix #556: menu font size

### DIFF
--- a/webapp/src/widgets/menu/menu.scss
+++ b/webapp/src/widgets/menu/menu.scss
@@ -34,6 +34,8 @@
             flex-direction: row;
             align-items: center;
 
+            font-size: 14px;
+            line-height: 24px;
             font-weight: 400;
             height: 32px;
             padding: 4px 20px;


### PR DESCRIPTION
Not sure why this regressed, but explicitly setting the font size and line height for .menu-option now. We want to cherry pick this for the v0.7.0 release.