### PR TITLE
Change sorting icons.

### DIFF
--- a/webapp/src/components/table/tableHeader.tsx
+++ b/webapp/src/components/table/tableHeader.tsx
@@ -59,8 +59,8 @@ const TableHeader = React.memo((props: Props): JSX.Element => {
             <MenuWrapper disabled={props.readonly}>
                 <Label>
                     {props.name}
-                    {props.sorted === 'up' && <SortUpIcon/>}
-                    {props.sorted === 'down' && <SortDownIcon/>}
+                    {props.sorted === 'up' && <SortDownIcon/>}
+                    {props.sorted === 'down' && <SortUpIcon/>}
                 </Label>
                 <TableHeaderMenu
                     boardTree={props.boardTree}


### PR DESCRIPTION
#### Summary
Earlier, the sorting icon for `Sort ascending` was an arrow pointing downwards and opposite for `Sort descending`. Changed it so that the `Sort ascending` has arrow pointing upwards.

#### Ticket Link
Fixes : #561 

#### How has this been tested?

Refer to the screenshots below: (Ascending order shows an upward arrow and reverse for descending)

<img width="284" alt="Screenshot 2021-06-14 at 5 28 43 PM" src="https://user-images.githubusercontent.com/53044263/121889306-b562a100-cd36-11eb-83f9-2689981feecc.png">


<img width="275" alt="Screenshot 2021-06-14 at 5 28 54 PM" src="https://user-images.githubusercontent.com/53044263/121889312-b72c6480-cd36-11eb-9c5b-af6383ec8360.png">


