### PR TITLE
Adds a link to the setup docs on the plugin's config header section

### DIFF
--- a/mattermost-plugin/plugin.json
+++ b/mattermost-plugin/plugin.json
@@ -19,7 +19,7 @@
         "bundle_path": "webapp/dist/main.js"
     },
     "settings_schema": {
-        "header": "",
+        "header": "For additional setup steps, please [see here](https://focalboard.com/fwlink/plugin-setup.html)",
         "footer": "",
         "settings": []
     }

--- a/mattermost-plugin/server/manifest.go
+++ b/mattermost-plugin/server/manifest.go
@@ -33,7 +33,7 @@ const manifestStr = `
     "bundle_path": "webapp/dist/main.js"
   },
   "settings_schema": {
-    "header": "",
+    "header": "For additional setup steps, please [see here](https://focalboard.com/fwlink/plugin-setup.html)",
     "footer": "",
     "settings": []
   }


### PR DESCRIPTION
#### Summary
This PR adds a link to the setup instructions on the System Console section of `focalboard`. It should be cherry-picked to `v0.7.0` after merge.

![2021-06-15-175314_965x283_scrot](https://user-images.githubusercontent.com/223323/122085314-e3151c00-ce02-11eb-9293-226fe45ea37f.png)

#### Ticket Link
[Focalboard card](https://focalboard-community.octo.mattermost.com/workspace/qgsck6cts3fwpqwyjiupjm5cde?id=47aa9bb4-6967-4a96-83c7-11bd6b20f1eb&v=612a901f-5c6d-4dde-8e35-3c16b6024a67&c=a67e26c8-4e40-4c86-8a5a-c336f36bcf99)