### PR TITLE
Refactor App lifecycle

### DIFF
--- a/server/api/admin.go
+++ b/server/api/admin.go
@@ -41,7 +41,7 @@ func (a *API) handleAdminSetPassword(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err = a.app().UpdateUserPassword(username, requestData.Password)
+	err = a.app.UpdateUserPassword(username, requestData.Password)
 	if err != nil {
 		a.errorResponse(w, http.StatusInternalServerError, "", err)
 		return

--- a/server/api/auth.go
+++ b/server/api/auth.go
@@ -178,7 +178,7 @@ func (a *API) handleLogin(w http.ResponseWriter, r *http.Request) {
 	auditRec.AddMeta("type", loginData.Type)
 
 	if loginData.Type == "normal" {
-		token, err := a.app().Login(loginData.Username, loginData.Email, loginData.Password, loginData.MfaToken)
+		token, err := a.app.Login(loginData.Username, loginData.Email, loginData.Password, loginData.MfaToken)
 		if err != nil {
 			a.errorResponse(w, http.StatusUnauthorized, "incorrect login", err)
 			return
@@ -243,7 +243,7 @@ func (a *API) handleRegister(w http.ResponseWriter, r *http.Request) {
 
 	// Validate token
 	if len(registerData.Token) > 0 {
-		workspace, err := a.app().GetRootWorkspace()
+		workspace, err := a.app.GetRootWorkspace()
 		if err != nil {
 			a.errorResponse(w, http.StatusInternalServerError, "", err)
 			return
@@ -255,7 +255,7 @@ func (a *API) handleRegister(w http.ResponseWriter, r *http.Request) {
 		}
 	} else {
 		// No signup token, check if no active users
-		userCount, err := a.app().GetRegisteredUserCount()
+		userCount, err := a.app.GetRegisteredUserCount()
 		if err != nil {
 			a.errorResponse(w, http.StatusInternalServerError, "", err)
 			return
@@ -275,7 +275,7 @@ func (a *API) handleRegister(w http.ResponseWriter, r *http.Request) {
 	defer a.audit.LogRecord(audit.LevelAuth, auditRec)
 	auditRec.AddMeta("username", registerData.Username)
 
-	err = a.app().RegisterUser(registerData.Username, registerData.Email, registerData.Password)
+	err = a.app.RegisterUser(registerData.Username, registerData.Email, registerData.Password)
 	if err != nil {
 		a.errorResponse(w, http.StatusBadRequest, err.Error(), err)
 		return
@@ -348,7 +348,7 @@ func (a *API) handleChangePassword(w http.ResponseWriter, r *http.Request) {
 	auditRec := a.makeAuditRecord(r, "changePassword", audit.Fail)
 	defer a.audit.LogRecord(audit.LevelAuth, auditRec)
 
-	if err = a.app().ChangePassword(userID, requestData.OldPassword, requestData.NewPassword); err != nil {
+	if err = a.app.ChangePassword(userID, requestData.OldPassword, requestData.NewPassword); err != nil {
 		a.errorResponse(w, http.StatusBadRequest, err.Error(), err)
 		return
 	}
@@ -404,7 +404,7 @@ func (a *API) attachSession(handler func(w http.ResponseWriter, r *http.Request)
 			return
 		}
 
-		session, err := a.app().GetSession(token)
+		session, err := a.app.GetSession(token)
 		if err != nil {
 			if required {
 				a.errorResponse(w, http.StatusUnauthorized, "", err)

--- a/server/app/app.go
+++ b/server/app/app.go
@@ -2,15 +2,20 @@ package app
 
 import (
 	"github.com/mattermost/focalboard/server/auth"
+	"github.com/mattermost/focalboard/server/model"
 	"github.com/mattermost/focalboard/server/services/config"
 	"github.com/mattermost/focalboard/server/services/metrics"
 	"github.com/mattermost/focalboard/server/services/mlog"
 	"github.com/mattermost/focalboard/server/services/store"
 	"github.com/mattermost/focalboard/server/services/webhook"
-	"github.com/mattermost/focalboard/server/ws"
 
 	"github.com/mattermost/mattermost-server/v5/shared/filestore"
 )
+
+type WebsocketServer interface {
+	BroadcastBlockChange(workspaceID string, block model.Block)
+	BroadcastBlockDelete(workspaceID, blockID, parentID string)
+}
 
 type Services struct {
 	Auth         *auth.Auth
@@ -22,22 +27,22 @@ type Services struct {
 }
 
 type App struct {
-	config *config.Configuration
-	store  store.Store
-	auth   *auth.Auth
-	//wsServer     *ws.Server
+	config       *config.Configuration
+	store        store.Store
+	auth         *auth.Auth
+	wsServer     WebsocketServer
 	filesBackend filestore.FileBackend
 	webhook      *webhook.Client
 	metrics      *metrics.Metrics
 	logger       *mlog.Logger
 }
 
-func New(config *config.Configuration, wsServer *ws.Server, services Services) *App {
+func New(config *config.Configuration, wsServer WebsocketServer, services Services) *App {
 	return &App{
-		config: config,
-		store:  services.Store,
-		auth:   services.Auth,
-		//wsServer:     wsServer,
+		config:       config,
+		store:        services.Store,
+		auth:         services.Auth,
+		wsServer:     wsServer,
 		filesBackend: services.FilesBackend,
 		webhook:      services.Webhook,
 		metrics:      services.Metrics,

--- a/server/app/app.go
+++ b/server/app/app.go
@@ -22,10 +22,10 @@ type Services struct {
 }
 
 type App struct {
-	config       *config.Configuration
-	store        store.Store
-	auth         *auth.Auth
-	wsServer     *ws.Server
+	config *config.Configuration
+	store  store.Store
+	auth   *auth.Auth
+	//wsServer     *ws.Server
 	filesBackend filestore.FileBackend
 	webhook      *webhook.Client
 	metrics      *metrics.Metrics
@@ -34,10 +34,10 @@ type App struct {
 
 func New(config *config.Configuration, wsServer *ws.Server, services Services) *App {
 	return &App{
-		config:       config,
-		store:        services.Store,
-		auth:         services.Auth,
-		wsServer:     wsServer,
+		config: config,
+		store:  services.Store,
+		auth:   services.Auth,
+		//wsServer:     wsServer,
 		filesBackend: services.FilesBackend,
 		webhook:      services.Webhook,
 		metrics:      services.Metrics,

--- a/server/go.mod
+++ b/server/go.mod
@@ -27,7 +27,6 @@ require (
 	github.com/stretchr/testify v1.7.0
 	github.com/tidwall/gjson v1.7.3 // indirect
 	golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2
-	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
 	golang.org/x/sys v0.0.0-20210324051608-47abb6519492 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 )

--- a/server/go.sum
+++ b/server/go.sum
@@ -1179,7 +1179,6 @@ golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4Iltr
 golang.org/x/oauth2 v0.0.0-20190319182350-c85d3e98c914/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
-golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d h1:TzXSXBo42m9gQenoE3b9BGiEpg5IG2JkU5FkPIawgtw=
 golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/perf v0.0.0-20180704124530-6e6d33e29852/go.mod h1:JLpeXjPJfIyPr5TlbXLkXWLhP8nz10XfvxElABhCtcw=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -1378,7 +1377,6 @@ google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7
 google.golang.org/appengine v1.5.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.6.1/go.mod h1:i06prIuMbXzDqacNJfV5OdTW448YApPu5ww/cMBSeb0=
 google.golang.org/appengine v1.6.5/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
-google.golang.org/appengine v1.6.6 h1:lMO5rYAqUxkmaj76jAkRUvt5JZgFymx/+Q5Mzfivuhc=
 google.golang.org/appengine v1.6.6/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
 google.golang.org/genproto v0.0.0-20170818010345-ee236bd376b0/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=


### PR DESCRIPTION
#### Summary
This PR refactors the App lifecycle by not creating a new App instance each request.  One App is created at server creation time, and passed to any services needing it.

To avoid cyclical dependencies, the few server methods needed by App are provided via interface.

#### Ticket Link
https://focalboard-community.octo.mattermost.com/workspace/qgsck6cts3fwpqwyjiupjm5cde?id=47aa9bb4-6967-4a96-83c7-11bd6b20f1eb&v=ca1a5441-4c1c-4d0e-856e-88cc744576c8&c=8b6fc880-163b-4f70-8cfa-2be198b487be