### PR TITLE
rename logger & audit config

### DIFF
--- a/config.json
+++ b/config.json
@@ -19,6 +19,6 @@
 	"enableLocalMode": true,
 	"localModeSocketLocation": "/var/tmp/focalboard_local.socket",
 	"authMode": "native",
-    "logging_file": "",
-    "audit_file": ""
+    "logging_cfg_file": "",
+    "audit_cfg_file": ""
 }

--- a/server/integrationtests/clienttestlib.go
+++ b/server/integrationtests/clienttestlib.go
@@ -58,7 +58,7 @@ func getTestConfig() *config.Configuration {
 		WebPath:        "./pack",
 		FilesDriver:    "local",
 		FilesPath:      "./files",
-		LoggingJSON:    logging,
+		LoggingCfgJSON: logging,
 	}
 }
 
@@ -66,7 +66,7 @@ func SetupTestHelper() *TestHelper {
 	sessionToken := "TESTTOKEN"
 	th := &TestHelper{}
 	logger := mlog.NewLogger()
-	logger.Configure("", getTestConfig().LoggingJSON)
+	logger.Configure("", getTestConfig().LoggingCfgJSON)
 	srv, err := server.New(getTestConfig(), sessionToken, logger)
 	if err != nil {
 		panic(err)

--- a/server/main/main.go
+++ b/server/main/main.go
@@ -95,12 +95,12 @@ func main() {
 	}
 
 	logger := mlog.NewLogger()
-	cfgJSON := config.LoggingJSON
-	if config.LoggingFile == "" && cfgJSON == "" {
+	cfgJSON := config.LoggingCfgJSON
+	if config.LoggingCfgFile == "" && cfgJSON == "" {
 		// if no logging defined, use default config (console output)
 		cfgJSON = defaultLoggingConfig()
 	}
-	err = logger.Configure(config.LoggingFile, cfgJSON)
+	err = logger.Configure(config.LoggingCfgFile, cfgJSON)
 	if err != nil {
 		log.Fatal("Error in config file for logger: ", err)
 		return
@@ -211,7 +211,7 @@ func startServer(webPath string, filesPath string, port int, singleUserToken, db
 	}
 
 	logger := mlog.NewLogger()
-	err = logger.Configure(config.LoggingFile, config.LoggingJSON)
+	err = logger.Configure(config.LoggingCfgFile, config.LoggingCfgJSON)
 	if err != nil {
 		log.Fatal("Error in config file for logger: ", err)
 		return

--- a/server/server/server.go
+++ b/server/server/server.go
@@ -120,7 +120,7 @@ func New(cfg *config.Configuration, singleUserToken string, logger *mlog.Logger)
 
 	// Init audit
 	auditService := audit.NewAudit()
-	if err := auditService.Configure(cfg.AuditFile, cfg.AuditJSON); err != nil {
+	if err := auditService.Configure(cfg.AuditCfgFile, cfg.AuditCfgJSON); err != nil {
 		return nil, errors.New("unable to initialize the audit service")
 	}
 

--- a/server/services/config/config.go
+++ b/server/services/config/config.go
@@ -49,11 +49,11 @@ type Configuration struct {
 
 	AuthMode string `json:"authMode" mapstructure:"authMode"`
 
-	LoggingFile string `json:"logging_file" mapstructure:"logging_file"`
-	LoggingJSON string `json:"logging_json" mapstructure:"logging_json"`
+	LoggingCfgFile string `json:"logging_cfg_file" mapstructure:"logging_cfg_file"`
+	LoggingCfgJSON string `json:"logging_cfg_json" mapstructure:"logging_cfg_json"`
 
-	AuditFile string `json:"audit_file" mapstructure:"audit_file"`
-	AuditJSON string `json:"audit_json" mapstructure:"audit_json"`
+	AuditCfgFile string `json:"audit_cfg_file" mapstructure:"audit_cfg_file"`
+	AuditCfgJSON string `json:"audit_cfg_json" mapstructure:"audit_cfg_json"`
 }
 
 // ReadConfigFile read the configuration from the filesystem.


### PR DESCRIPTION
#### Summary
Renamed the config key names for logger and audit config.  `config.json` lets you specify a path to logging/audit config or provide config via embedded JSON.

`logging_file` was used as the key name to specify a path to config file for logging.  It was confusing as it could be mistakenly thought to be the name of the file to output logs to.  It has been changed to `logging_cfg_file`.  Same reasoning for changing `audit_file` to `audit_cfg_file`.

#### Ticket Link
NONE