### PR TITLE
Fixes web files not found when plugin directory is custom

### DIFF
--- a/mattermost-plugin/server/plugin.go
+++ b/mattermost-plugin/server/plugin.go
@@ -90,7 +90,7 @@ func (p *Plugin) OnActivate() error {
 		DBTablePrefix:           "focalboard_",
 		UseSSL:                  false,
 		SecureCookie:            true,
-		WebPath:                 "./plugins/focalboard/pack",
+		WebPath:                 *mmconfig.PluginSettings.Directory + "/focalboard/pack",
 		FilesDriver:             *mmconfig.FileSettings.DriverName,
 		FilesPath:               *mmconfig.FileSettings.Directory,
 		FilesS3Config:           filesS3Config,


### PR DESCRIPTION
#### Summary
This PR solves plugin not correctly serving the frontend interface when used in a server with a custom plugin directory. Fixes #592 

#### Ticket Link
[Card](https://focalboard-community.octo.mattermost.com/workspace/qgsck6cts3fwpqwyjiupjm5cde?id=47aa9bb4-6967-4a96-83c7-11bd6b20f1eb&v=612a901f-5c6d-4dde-8e35-3c16b6024a67&c=f8ad1709-b903-4172-8076-1b82649de09a)
