### PR TITLE
Fixed sorting icons

### DIFF
--- a/webapp/src/components/table/__snapshots__/table.test.tsx.snap
+++ b/webapp/src/components/table/__snapshots__/table.test.tsx.snap
@@ -43,7 +43,7 @@ exports[`components/table/Table should match snapshot 1`] = `
           >
             Property 1
             <svg
-              class="SortUpIcon Icon"
+              class="SortDownIcon Icon"
               viewBox="0 0 100 100"
               xmlns="http://www.w3.org/2000/svg"
             >
@@ -51,7 +51,7 @@ exports[`components/table/Table should match snapshot 1`] = `
                 points="50,20 50,80"
               />
               <polyline
-                points="30,40 50,20 70,40"
+                points="30,60 50,80 70,60"
               />
             </svg>
           </span>
@@ -77,7 +77,7 @@ exports[`components/table/Table should match snapshot 1`] = `
           >
             Property 2
             <svg
-              class="SortDownIcon Icon"
+              class="SortUpIcon Icon"
               viewBox="0 0 100 100"
               xmlns="http://www.w3.org/2000/svg"
             >
@@ -85,7 +85,7 @@ exports[`components/table/Table should match snapshot 1`] = `
                 points="50,20 50,80"
               />
               <polyline
-                points="30,60 50,80 70,60"
+                points="30,40 50,20 70,40"
               />
             </svg>
           </span>
@@ -225,7 +225,7 @@ exports[`components/table/Table should match snapshot with GroupBy 1`] = `
           >
             Property 1
             <svg
-              class="SortUpIcon Icon"
+              class="SortDownIcon Icon"
               viewBox="0 0 100 100"
               xmlns="http://www.w3.org/2000/svg"
             >
@@ -233,7 +233,7 @@ exports[`components/table/Table should match snapshot with GroupBy 1`] = `
                 points="50,20 50,80"
               />
               <polyline
-                points="30,40 50,20 70,40"
+                points="30,60 50,80 70,60"
               />
             </svg>
           </span>
@@ -259,7 +259,7 @@ exports[`components/table/Table should match snapshot with GroupBy 1`] = `
           >
             Property 2
             <svg
-              class="SortDownIcon Icon"
+              class="SortUpIcon Icon"
               viewBox="0 0 100 100"
               xmlns="http://www.w3.org/2000/svg"
             >
@@ -267,7 +267,7 @@ exports[`components/table/Table should match snapshot with GroupBy 1`] = `
                 points="50,20 50,80"
               />
               <polyline
-                points="30,60 50,80 70,60"
+                points="30,40 50,20 70,40"
               />
             </svg>
           </span>
@@ -390,7 +390,7 @@ exports[`components/table/Table should match snapshot, read-only 1`] = `
           >
             Property 1
             <svg
-              class="SortUpIcon Icon"
+              class="SortDownIcon Icon"
               viewBox="0 0 100 100"
               xmlns="http://www.w3.org/2000/svg"
             >
@@ -398,7 +398,7 @@ exports[`components/table/Table should match snapshot, read-only 1`] = `
                 points="50,20 50,80"
               />
               <polyline
-                points="30,40 50,20 70,40"
+                points="30,60 50,80 70,60"
               />
             </svg>
           </span>
@@ -420,7 +420,7 @@ exports[`components/table/Table should match snapshot, read-only 1`] = `
           >
             Property 2
             <svg
-              class="SortDownIcon Icon"
+              class="SortUpIcon Icon"
               viewBox="0 0 100 100"
               xmlns="http://www.w3.org/2000/svg"
             >
@@ -428,7 +428,7 @@ exports[`components/table/Table should match snapshot, read-only 1`] = `
                 points="50,20 50,80"
               />
               <polyline
-                points="30,60 50,80 70,60"
+                points="30,40 50,20 70,40"
               />
             </svg>
           </span>

--- a/webapp/src/components/table/table.tsx
+++ b/webapp/src/components/table/table.tsx
@@ -215,7 +215,7 @@ const Table = (props: Props) => {
     const titleSortOption = activeView.sortOptions.find((o) => o.propertyId === Constants.titleColumnId)
     let titleSorted: 'up' | 'down' | 'none' = 'none'
     if (titleSortOption) {
-        titleSorted = titleSortOption.reversed ? 'up' : 'down'
+        titleSorted = titleSortOption.reversed ? 'down' : 'up'
     }
 
     return (
@@ -253,7 +253,7 @@ const Table = (props: Props) => {
                         let sorted: 'up' | 'down' | 'none' = 'none'
                         const sortOption = activeView.sortOptions.find((o) => o.propertyId === template.id)
                         if (sortOption) {
-                            sorted = sortOption.reversed ? 'up' : 'down'
+                            sorted = sortOption.reversed ? 'down' : 'up'
                         }
 
                         return (

--- a/webapp/src/components/viewHeader/viewHeaderSortMenu.tsx
+++ b/webapp/src/components/viewHeader/viewHeaderSortMenu.tsx
@@ -66,7 +66,7 @@ const ViewHeaderSortMenu = React.memo((props: Props) => {
                     if (activeView.sortOptions.length > 0) {
                         const sortOption = activeView.sortOptions[0]
                         if (sortOption.propertyId === option.id) {
-                            rightIcon = sortOption.reversed ? <SortUpIcon/> : <SortDownIcon/>
+                            rightIcon = sortOption.reversed ? <SortDownIcon/> : <SortUpIcon/>
                         }
                     }
                     return (


### PR DESCRIPTION
#### Summary
Fixed ascending and descending sort icons.

1. Changed ascending icon to up arrow.
2. Changed descending arrow to down arrow.

Before-
![before](https://user-images.githubusercontent.com/18575143/122752658-dd11b600-d2ae-11eb-9082-1f132d19e814.gif)

After-
![after](https://user-images.githubusercontent.com/18575143/122752637-d4b97b00-d2ae-11eb-9e20-7d4cf257914d.gif)

#### Ticket Link
https://github.com/mattermost/focalboard/issues/561

