### PR TITLE
GH-613 - fix double slash on buildURL

### DIFF
--- a/webapp/src/utils.test.ts
+++ b/webapp/src/utils.test.ts
@@ -34,4 +34,36 @@ describe('utils', () => {
             windowAsAny.openInNewBrowser = null
         })
     })
+
+    describe('test - buildURL', () => {
+        test('buildURL, no base', () => {
+            expect(Utils.buildURL('test', true)).toBe('http://localhost/test')
+            expect(Utils.buildURL('/test', true)).toBe('http://localhost/test')
+
+            expect(Utils.buildURL('test')).toBe('/test')
+            expect(Utils.buildURL('/test')).toBe('/test')
+        })
+
+        test('buildURL, base no slash', () => {
+            const windowAsAny = window as any
+            windowAsAny.baseURL = 'base'
+
+            expect(Utils.buildURL('test', true)).toBe('http://localhost/base/test')
+            expect(Utils.buildURL('/test', true)).toBe('http://localhost/base/test')
+
+            expect(Utils.buildURL('test')).toBe('base/test')
+            expect(Utils.buildURL('/test')).toBe('base/test')
+        })
+
+        test('buildUrl, base with slash', () => {
+            const windowAsAny = window as any
+            windowAsAny.baseURL = '/base/'
+
+            expect(Utils.buildURL('test', true)).toBe('http://localhost/base/test')
+            expect(Utils.buildURL('/test', true)).toBe('http://localhost/base/test')
+
+            expect(Utils.buildURL('test')).toBe('base/test')
+            expect(Utils.buildURL('/test')).toBe('base/test')
+        })
+    })
 })

--- a/webapp/src/utils.ts
+++ b/webapp/src/utils.ts
@@ -333,6 +333,9 @@ class Utils {
             finalPath = baseURL + '/' + path
         }
         if (absolute) {
+            if (finalPath.indexOf('/') === 0) {
+                finalPath = finalPath.slice(1)
+            }
             return window.location.origin + '/' + finalPath
         }
         return finalPath


### PR DESCRIPTION
#### Summary
Fixes a double slash when calling buildURL()

#### Ticket Link
  Fixes https://github.com/mattermost/focalboard/issues/613

