### PR TITLE
Adding max-db-conns and max-idle-conns through environment variables

### DIFF
--- a/server/services/store/mattermostauthlayer/mattermostauthlayer.go
+++ b/server/services/store/mattermostauthlayer/mattermostauthlayer.go
@@ -42,14 +42,24 @@ func New(dbType, connectionString string, store store.Store) (*MattermostAuthLay
 	}
 	maxDBIdleConns, err := strconv.Atoi(os.Getenv("FOCALBOARD_DB_MAX_IDLE_CONNS"))
 	if err != nil {
-		maxDBIdleConns = 0
+		maxDBIdleConns = 20
 	}
 	maxDBOpenConns, err := strconv.Atoi(os.Getenv("FOCALBOARD_DB_MAX_OPEN_CONNS"))
 	if err != nil {
-		maxDBIdleConns = 0
+		maxDBOpenConns = 300
+	}
+	maxDBIdleTime, err := strconv.Atoi(os.Getenv("FOCALBOARD_DB_MAX_IDLE_TIME"))
+	if err != nil {
+		maxDBIdleTime = 300
+	}
+	maxDBLifetime, err := strconv.Atoi(os.Getenv("FOCALBOARD_DB_MAX_LIFETIME"))
+	if err != nil {
+		maxDBLifetime = 3600
 	}
 	db.SetMaxIdleConns(maxDBIdleConns)
 	db.SetMaxOpenConns(maxDBOpenConns)
+	db.SetConnMaxIdleTime(time.Duration(maxDBIdleTime) * time.Second)
+	db.SetConnMaxLifetime(time.Duration(maxDBLifetime) * time.Second)
 
 	err = db.Ping()
 	if err != nil {

--- a/server/services/store/mattermostauthlayer/mattermostauthlayer.go
+++ b/server/services/store/mattermostauthlayer/mattermostauthlayer.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"errors"
 	"log"
+	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -38,6 +40,16 @@ func New(dbType, connectionString string, store store.Store) (*MattermostAuthLay
 
 		return nil, err
 	}
+	maxDBIdleConns, err := strconv.Atoi(os.Getenv("FOCALBOARD_DB_MAX_IDLE_CONNS"))
+	if err != nil {
+		maxDBIdleConns = 0
+	}
+	maxDBOpenConns, err := strconv.Atoi(os.Getenv("FOCALBOARD_DB_MAX_OPEN_CONNS"))
+	if err != nil {
+		maxDBIdleConns = 0
+	}
+	db.SetMaxIdleConns(maxDBIdleConns)
+	db.SetMaxOpenConns(maxDBOpenConns)
 
 	err = db.Ping()
 	if err != nil {

--- a/server/services/store/sqlstore/sqlstore.go
+++ b/server/services/store/sqlstore/sqlstore.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"os"
 	"strconv"
+	"time"
 
 	sq "github.com/Masterminds/squirrel"
 	"github.com/mattermost/focalboard/server/services/mlog"
@@ -37,14 +38,24 @@ func New(dbType, connectionString string, tablePrefix string, logger *mlog.Logge
 	}
 	maxDBIdleConns, err := strconv.Atoi(os.Getenv("FOCALBOARD_DB_MAX_IDLE_CONNS"))
 	if err != nil {
-		maxDBIdleConns = 0
+		maxDBIdleConns = 20
 	}
 	maxDBOpenConns, err := strconv.Atoi(os.Getenv("FOCALBOARD_DB_MAX_OPEN_CONNS"))
 	if err != nil {
-		maxDBIdleConns = 0
+		maxDBOpenConns = 300
+	}
+	maxDBIdleTime, err := strconv.Atoi(os.Getenv("FOCALBOARD_DB_MAX_IDLE_TIME"))
+	if err != nil {
+		maxDBIdleTime = 300
+	}
+	maxDBLifetime, err := strconv.Atoi(os.Getenv("FOCALBOARD_DB_MAX_LIFETIME"))
+	if err != nil {
+		maxDBLifetime = 3600
 	}
 	db.SetMaxIdleConns(maxDBIdleConns)
 	db.SetMaxOpenConns(maxDBOpenConns)
+	db.SetConnMaxIdleTime(time.Duration(maxDBIdleTime) * time.Second)
+	db.SetConnMaxLifetime(time.Duration(maxDBLifetime) * time.Second)
 
 	err = db.Ping()
 	if err != nil {

--- a/server/services/store/sqlstore/sqlstore.go
+++ b/server/services/store/sqlstore/sqlstore.go
@@ -2,6 +2,8 @@ package sqlstore
 
 import (
 	"database/sql"
+	"os"
+	"strconv"
 
 	sq "github.com/Masterminds/squirrel"
 	"github.com/mattermost/focalboard/server/services/mlog"
@@ -33,6 +35,16 @@ func New(dbType, connectionString string, tablePrefix string, logger *mlog.Logge
 
 		return nil, err
 	}
+	maxDBIdleConns, err := strconv.Atoi(os.Getenv("FOCALBOARD_DB_MAX_IDLE_CONNS"))
+	if err != nil {
+		maxDBIdleConns = 0
+	}
+	maxDBOpenConns, err := strconv.Atoi(os.Getenv("FOCALBOARD_DB_MAX_OPEN_CONNS"))
+	if err != nil {
+		maxDBIdleConns = 0
+	}
+	db.SetMaxIdleConns(maxDBIdleConns)
+	db.SetMaxOpenConns(maxDBOpenConns)
 
 	err = db.Ping()
 	if err != nil {


### PR DESCRIPTION
This adds the environment variables to limit the number of connections to the database. This is a temporary fix, and this works just fine in regular on prem service, but in mattermost-plugin, because the database connection is "duplibcated" the value added in the environment variable is going to be duplicated.

This is only for the 0.7.1 version, the 0.8.0 version is going to come with the new shared db connections provided by @agnivade, so this can be perfectly deprecated.