### PR TITLE
[GH-538] Fix for menu of side bar item

### DIFF
--- a/webapp/src/components/sidebar/sidebarBoardItem.scss
+++ b/webapp/src/components/sidebar/sidebarBoardItem.scss
@@ -10,10 +10,6 @@
         &:hover {
             background-color: rgba(var(--sidebar-fg), 0.08);
             display: flex;
-
-            .MenuWrapper {
-                display: block;
-            }
         }
 
         &.subitem {
@@ -52,10 +48,6 @@
             &:hover {
                 background-color: rgba(var(--sidebar-fg), 0.1);
             }
-        }
-
-        .MenuWrapper {
-            display: none;
         }
 
         .Menu.left {


### PR DESCRIPTION
#### Summary
Don't change visibility of `MenuWrapper` when hover state of its parent is changed.

#### Ticket Link
  Fixes #538 
