### PR TITLE
Prevented concurrent writes to websocket

### DIFF
--- a/server/ws/websockets.go
+++ b/server/ws/websockets.go
@@ -31,8 +31,8 @@ type wsClient struct {
 
 func (c *wsClient) WriteJSON(v interface{}) error {
 	c.lock.Lock()
+	defer c.lock.Unlock()
 	err := c.conn.WriteJSON(v)
-	c.lock.Unlock()
 	return err
 }
 


### PR DESCRIPTION
#### Summary
Prevented concurrent writes to websockets. This fixes the the plugin crash occurring when dragging and dropping multiple cards together.

The problem is caused by gorilla WebSocket not support concurrent writes to WebSockets - https://github.com/gorilla/websocket/issues/119

#### Ticket Link
#650 

