### PR TITLE
[GH-641] Test for hiding and showing the sidebar

### DIFF
--- a/webapp/cypress/integration/createBoard.js
+++ b/webapp/cypress/integration/createBoard.js
@@ -31,6 +31,14 @@ describe('Create and delete board / card', () => {
             should('have.value', boardTitle);
     });
 
+    it('Can hide and show the sidebar with active board', () => {
+        // Hide and show the sidebar
+        cy.get('.Sidebar .heading ~ .Button').click();
+        cy.get('.Sidebar .heading').should('not.exist');
+        cy.get('.Sidebar .show-button').click();
+        cy.get('.Sidebar .heading').should('exist');
+    });
+
     it('Can rename the board view', () => {
         // Rename board view
         const boardViewTitle = `Test board (${timestamp})`;


### PR DESCRIPTION
#### Summary
Cypress test for hiding and showing the sidebar with active board added:
* active board is essential because it can cover the show  button,
* presence of sidebar heading is used to check if sidebar is visible.
* changing `z-index` of hidden sidebar back to `5` (as it was before the actual fix) _will be caught_ by this test in Cypress with the message:
```
Timed out retrying after 4050ms: cy.click() failed because this element:

<div class="octo-sidebar-header show-button">...</div>

is being covered by another element:

<div class="top-head">...</div>
```
#### Ticket Link
This test will help to avoid bugs like #641 
