### PR TITLE
Prevent plugin from crashing if SiteURL is not set

### DIFF
--- a/mattermost-plugin/server/plugin.go
+++ b/mattermost-plugin/server/plugin.go
@@ -98,7 +98,7 @@ func (p *Plugin) OnActivate() error {
 		return fmt.Errorf("error initializing the DB: %v", err)
 	}
 
-	baseURL := "."
+	baseURL := ""
 	if mmconfig.ServiceSettings.SiteURL != nil {
 		baseURL = *mmconfig.ServiceSettings.SiteURL
 	}

--- a/mattermost-plugin/server/plugin.go
+++ b/mattermost-plugin/server/plugin.go
@@ -98,8 +98,13 @@ func (p *Plugin) OnActivate() error {
 		return fmt.Errorf("error initializing the DB: %v", err)
 	}
 
+	baseURL := ""
+	if mmconfig.ServiceSettings.SiteURL != nil {
+		baseURL = *mmconfig.ServiceSettings.SiteURL
+	}
+
 	cfg := &config.Configuration{
-		ServerRoot:              *mmconfig.ServiceSettings.SiteURL + "/plugins/focalboard",
+		ServerRoot:              baseURL + "/plugins/focalboard",
 		Port:                    -1,
 		DBType:                  *mmconfig.SqlSettings.DriverName,
 		DBConfigString:          *mmconfig.SqlSettings.DataSource,
@@ -173,7 +178,7 @@ func defaultLoggingConfig() string {
 				"delim": " ",
 				"min_level_len": 5,
 				"min_msg_len": 40,
-				"enable_color": true				
+				"enable_color": true
 			},
 			"levels": [
 				{"id": 5, "name": "debug"},

--- a/mattermost-plugin/server/plugin.go
+++ b/mattermost-plugin/server/plugin.go
@@ -98,7 +98,7 @@ func (p *Plugin) OnActivate() error {
 		return fmt.Errorf("error initializing the DB: %v", err)
 	}
 
-	baseURL := ""
+	baseURL := "."
 	if mmconfig.ServiceSettings.SiteURL != nil {
 		baseURL = *mmconfig.ServiceSettings.SiteURL
 	}


### PR DESCRIPTION
#### Summary
This PR checks if the `SiteURL` property is set and uses an empty string if it's not, preventing the plugin from crash at start time due to a `nil` pointer.

#### Ticket Link
Possibly related to https://github.com/mattermost/focalboard/issues/648
