### PR TITLE
Ensure all code paths close *sql.Rows

### DIFF
--- a/mattermost-plugin/server/plugin.go
+++ b/mattermost-plugin/server/plugin.go
@@ -14,6 +14,7 @@ import (
 	"github.com/mattermost/focalboard/server/services/store/sqlstore"
 
 	pluginapi "github.com/mattermost/mattermost-plugin-api"
+
 	"github.com/mattermost/mattermost-server/v5/model"
 	"github.com/mattermost/mattermost-server/v5/plugin"
 )
@@ -125,7 +126,7 @@ func (p *Plugin) OnActivate() error {
 		return fmt.Errorf("error initializing the DB: %v", err)
 	}
 	if cfg.AuthMode == server.MattermostAuthMod {
-		layeredStore, err2 := mattermostauthlayer.New(cfg.DBType, sqlDB, db)
+		layeredStore, err2 := mattermostauthlayer.New(cfg.DBType, sqlDB, db, logger)
 		if err2 != nil {
 			return fmt.Errorf("error initializing the DB: %v", err2)
 		}

--- a/server/server/server.go
+++ b/server/server/server.go
@@ -198,7 +198,7 @@ func NewStore(config *config.Configuration, logger *mlog.Logger) (store.Store, e
 		return nil, err
 	}
 	if config.AuthMode == MattermostAuthMod {
-		layeredStore, err2 := mattermostauthlayer.New(config.DBType, db.(*sqlstore.SQLStore).DBHandle(), db)
+		layeredStore, err2 := mattermostauthlayer.New(config.DBType, db.(*sqlstore.SQLStore).DBHandle(), db, logger)
 		if err2 != nil {
 			return nil, err2
 		}

--- a/server/services/store/sqlstore/blocks.go
+++ b/server/services/store/sqlstore/blocks.go
@@ -41,6 +41,7 @@ func (s *SQLStore) GetBlocksWithParentAndType(c store.Container, parentID string
 
 		return nil, err
 	}
+	defer s.CloseRows(rows)
 
 	return s.blocksFromRows(rows)
 }
@@ -70,6 +71,7 @@ func (s *SQLStore) GetBlocksWithParent(c store.Container, parentID string) ([]mo
 
 		return nil, err
 	}
+	defer s.CloseRows(rows)
 
 	return s.blocksFromRows(rows)
 }
@@ -99,6 +101,7 @@ func (s *SQLStore) GetBlocksWithRootID(c store.Container, rootID string) ([]mode
 
 		return nil, err
 	}
+	defer s.CloseRows(rows)
 
 	return s.blocksFromRows(rows)
 }
@@ -128,6 +131,7 @@ func (s *SQLStore) GetBlocksWithType(c store.Container, blockType string) ([]mod
 
 		return nil, err
 	}
+	defer s.CloseRows(rows)
 
 	return s.blocksFromRows(rows)
 }
@@ -158,6 +162,7 @@ func (s *SQLStore) GetSubTree2(c store.Container, blockID string) ([]model.Block
 
 		return nil, err
 	}
+	defer s.CloseRows(rows)
 
 	return s.blocksFromRows(rows)
 }
@@ -196,6 +201,7 @@ func (s *SQLStore) GetSubTree3(c store.Container, blockID string) ([]model.Block
 
 		return nil, err
 	}
+	defer s.CloseRows(rows)
 
 	return s.blocksFromRows(rows)
 }
@@ -224,13 +230,12 @@ func (s *SQLStore) GetAllBlocks(c store.Container) ([]model.Block, error) {
 
 		return nil, err
 	}
+	defer s.CloseRows(rows)
 
 	return s.blocksFromRows(rows)
 }
 
 func (s *SQLStore) blocksFromRows(rows *sql.Rows) ([]model.Block, error) {
-	defer rows.Close()
-
 	results := []model.Block{}
 
 	for rows.Next() {
@@ -451,6 +456,7 @@ func (s *SQLStore) GetBlockCountsByType() (map[string]int64, error) {
 
 		return nil, err
 	}
+	defer s.CloseRows(rows)
 
 	m := make(map[string]int64)
 

--- a/server/services/store/sqlstore/system.go
+++ b/server/services/store/sqlstore/system.go
@@ -7,7 +7,7 @@ func (s *SQLStore) GetSystemSettings() (map[string]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
+	defer s.CloseRows(rows)
 
 	results := map[string]string{}
 

--- a/server/services/store/sqlstore/user.go
+++ b/server/services/store/sqlstore/user.go
@@ -64,6 +64,7 @@ func (s *SQLStore) getUsersByCondition(condition sq.Eq) ([]*model.User, error) {
 		log.Printf("getUsersByCondition ERROR: %v", err)
 		return nil, err
 	}
+	defer s.CloseRows(rows)
 
 	users, err := s.usersFromRows(rows)
 	if err != nil {
@@ -192,8 +193,6 @@ func (s *SQLStore) GetUsersByWorkspace(workspaceID string) ([]*model.User, error
 }
 
 func (s *SQLStore) usersFromRows(rows *sql.Rows) ([]*model.User, error) {
-	defer rows.Close()
-
 	users := []*model.User{}
 
 	for rows.Next() {

--- a/server/services/store/sqlstore/util.go
+++ b/server/services/store/sqlstore/util.go
@@ -1,0 +1,13 @@
+package sqlstore
+
+import (
+	"database/sql"
+
+	"github.com/mattermost/focalboard/server/services/mlog"
+)
+
+func (s *SQLStore) CloseRows(rows *sql.Rows) {
+	if err := rows.Close(); err != nil {
+		s.logger.Error("error closing MattermostAuthLayer row set", mlog.Err(err))
+	}
+}

--- a/server/services/store/sqlstore/workspaces.go
+++ b/server/services/store/sqlstore/workspaces.go
@@ -128,6 +128,7 @@ func (s *SQLStore) GetWorkspaceCount() (int64, error) {
 		s.logger.Error("ERROR GetWorkspaceCount", mlog.Err(err))
 		return 0, err
 	}
+	defer s.CloseRows(rows)
 
 	var count int64
 


### PR DESCRIPTION
#### Summary
This PR fixes a leak where not all code paths closed `*sql.Rows`.  

Some code paths implicitly closed rows by enumerating the whole set, which closes automatically.  However, an early return while iterating caused a leak.  

Other code paths explicitly closed the rows in a utility method that iterated the rows, therefore the close was not where the allocation occurred.  The hidden close caused some places to leak where the utility was no longer used.  

Another minor issue was that the error returned from `sql.Rows.Close()` was ignored.

This PR ensures all allocations of `sql.Rows` close the rows at the allocation site, and logs any errors.

#### Ticket Link
https://focalboard-community.octo.mattermost.com/workspace/qgsck6cts3fwpqwyjiupjm5cde?id=47aa9bb4-6967-4a96-83c7-11bd6b20f1eb&v=ca1a5441-4c1c-4d0e-856e-88cc744576c8&c=c65d1f7a-1318-48e6-8624-94b2c16ffe97