### PR TITLE
Remove plus icon from Kanban column header

### DIFF
--- a/webapp/src/components/kanban/kanbanColumnHeader.tsx
+++ b/webapp/src/components/kanban/kanbanColumnHeader.tsx
@@ -12,7 +12,6 @@ import mutator from '../../mutator'
 import {BoardTree, BoardTreeGroup} from '../../viewModel/boardTree'
 import Button from '../../widgets/buttons/button'
 import IconButton from '../../widgets/buttons/iconButton'
-import AddIcon from '../../widgets/icons/add'
 import DeleteIcon from '../../widgets/icons/delete'
 import HideIcon from '../../widgets/icons/hide'
 import OptionsIcon from '../../widgets/icons/options'
@@ -140,10 +139,6 @@ export default function KanbanColumnHeader(props: Props): JSX.Element {
                                 </>}
                         </Menu>
                     </MenuWrapper>
-                    <IconButton
-                        icon={<AddIcon/>}
-                        onClick={() => props.addCard(group.option.id)}
-                    />
                 </>
             }
         </div>


### PR DESCRIPTION
#### Summary

There are two icons for adding a card in Kanban view:
- one in the [column header](https://github.com/mattermost/focalboard/blob/e0ec1c03e088e99d5ff2f570ed089a4aed4cfba3/webapp/src/components/kanban/kanbanColumnHeader.tsx#L144) and
- one [below the last card](https://github.com/mattermost/focalboard/blob/e0ec1c03e088e99d5ff2f570ed089a4aed4cfba3/webapp/src/components/kanban/kanban.tsx#L270).

Esp. the column headers IMHO already look cluttered (title, card no., dots, plus sign) so I suggest to only keep the plus button below the last card.
