### PR TITLE
Fix #739: Don't show account options as plugin

### DIFF
--- a/webapp/src/components/sidebar/sidebar.tsx
+++ b/webapp/src/components/sidebar/sidebar.tsx
@@ -63,13 +63,15 @@ const Sidebar = React.memo((props: Props) => {
         )
     }
 
+    const hasWorkspace = Boolean(workspace && workspace.id !== '0')
     return (
         <div className='Sidebar octo-sidebar'>
             <div className='octo-sidebar-header'>
                 <div className='heading'>
                     <SidebarUserMenu
                         whiteLogo={whiteLogo}
-                        showVersionBadge={Boolean(workspace && workspace.id !== '0')}
+                        showVersionBadge={hasWorkspace}
+                        showAccountActions={!hasWorkspace}
                     />
                 </div>
 

--- a/webapp/src/components/sidebar/sidebarUserMenu.tsx
+++ b/webapp/src/components/sidebar/sidebarUserMenu.tsx
@@ -23,12 +23,13 @@ import './sidebarUserMenu.scss'
 type Props = {
     whiteLogo: boolean
     showVersionBadge: boolean
+    showAccountActions: boolean
 }
 
 const SidebarUserMenu = React.memo((props: Props) => {
     const history = useHistory()
     const [showRegistrationLinkDialog, setShowRegistrationLinkDialog] = useState(false)
-    const {whiteLogo, showVersionBadge} = props
+    const {whiteLogo, showVersionBadge, showAccountActions} = props
     const user = useAppSelector<IUser|null>(getCurrentUser)
     const intl = useIntl()
     return (
@@ -48,7 +49,7 @@ const SidebarUserMenu = React.memo((props: Props) => {
                         </div>
                     </div>
                     <Menu>
-                        {user && user.username !== 'single-user' && <>
+                        {showAccountActions && user && user.username !== 'single-user' && <>
                             <Menu.Label><b>{user.username}</b></Menu.Label>
                             <Menu.Text
                                 id='logout'


### PR DESCRIPTION
This hides the (non-functional) account actions in the Focalboard menu when running as a plugin.