### PR TITLE
Fix Cards not Dragging to different Columns (GH-626)

### DIFF
--- a/webapp/src/components/kanban/kanban.tsx
+++ b/webapp/src/components/kanban/kanban.tsx
@@ -34,7 +34,11 @@ type Props = {
 
 const Kanban = (props: Props) => {
     const {boardTree} = props
-    const {cards, groupByProperty} = boardTree
+
+    const boardTreeRef = useRef<BoardTree>(boardTree)
+    boardTreeRef.current = boardTree
+
+    const {cards, groupByProperty} = boardTreeRef.current
 
     if (!groupByProperty) {
         Utils.assertFailure('Board views must have groupByProperty set')
@@ -44,7 +48,7 @@ const Kanban = (props: Props) => {
     const propertyValues = groupByProperty.options || []
     Utils.log(`${propertyValues.length} propertyValues`)
 
-    const {board, activeView, visibleGroups, hiddenGroups} = boardTree
+    const {board, activeView, visibleGroups, hiddenGroups} = boardTreeRef.current
     const visiblePropertyTemplates = board.cardProperties.filter((template) => activeView.visiblePropertyIds.includes(template.id))
     const isManualSort = activeView.sortOptions.length === 0
 
@@ -72,7 +76,7 @@ const Kanban = (props: Props) => {
     )
 
     const propertyNameChanged = async (option: IPropertyOption, text: string): Promise<void> => {
-        await mutator.changePropertyOptionValue(boardTree, boardTree.groupByProperty!, option, text)
+        await mutator.changePropertyOptionValue(boardTreeRef.current, boardTreeRef.current.groupByProperty!, option, text)
     }
 
     const addGroupClicked = async () => {
@@ -84,12 +88,12 @@ const Kanban = (props: Props) => {
             color: 'propColorDefault',
         }
 
-        await mutator.insertPropertyOption(boardTree, boardTree.groupByProperty!, option, 'add group')
+        await mutator.insertPropertyOption(boardTreeRef.current, boardTreeRef.current.groupByProperty!, option, 'add group')
     }
 
     const orderAfterMoveToColumn = (cardIds: string[], columnId?: string): string[] => {
         let cardOrder = activeView.cardOrder.slice()
-        const columnGroup = boardTree.visibleGroups.find((g) => g.option.id === columnId)
+        const columnGroup = boardTreeRef.current.visibleGroups.find((g) => g.option.id === columnId)
         const columnCards = columnGroup?.cards
         if (!columnCards || columnCards.length === 0) {
             return cardOrder
@@ -110,35 +114,36 @@ const Kanban = (props: Props) => {
         if (card) {
             draggedCardIds = Array.from(new Set(selectedCardIds).add(card.id))
         }
-
-        Utils.assertValue(boardTree)
+        Utils.assertValue(boardTreeRef.current)
 
         if (draggedCardIds.length > 0) {
-            const orderedCards = boardTree.orderedCards()
+            const orderedCards = boardTreeRef.current.orderedCards()
             const cardsById: { [key: string]: Card } = orderedCards.reduce((acc: { [key: string]: Card }, c: Card): { [key: string]: Card } => {
                 acc[c.id] = c
                 return acc
             }, {})
+
             const draggedCards: Card[] = draggedCardIds.map((o: string) => cardsById[o])
+
             await mutator.performAsUndoGroup(async () => {
                 const description = draggedCards.length > 1 ? `drag ${draggedCards.length} cards` : 'drag card'
                 const awaits = []
                 for (const draggedCard of draggedCards) {
                     Utils.log(`ondrop. Card: ${draggedCard.title}, column: ${optionId}`)
-                    const oldValue = draggedCard.properties[boardTree.groupByProperty!.id]
+                    const oldValue = draggedCard.properties[boardTreeRef.current.groupByProperty!.id]
                     if (optionId !== oldValue) {
-                        awaits.push(mutator.changePropertyValue(draggedCard, boardTree.groupByProperty!.id, optionId, description))
+                        awaits.push(mutator.changePropertyValue(draggedCard, boardTreeRef.current.groupByProperty!.id, optionId, description))
                     }
                 }
                 const newOrder = orderAfterMoveToColumn(draggedCardIds, optionId)
-                awaits.push(mutator.changeViewCardOrder(boardTree.activeView, newOrder, description))
+                awaits.push(mutator.changeViewCardOrder(boardTreeRef.current.activeView, newOrder, description))
                 await Promise.all(awaits)
             })
         } else if (dstOption) {
             Utils.log(`ondrop. Header option: ${dstOption.value}, column: ${option?.value}`)
 
             // Move option to new index
-            const visibleOptionIds = boardTree.visibleGroups.map((o) => o.option.id)
+            const visibleOptionIds = boardTreeRef.current.visibleGroups.map((o) => o.option.id)
 
             const srcIndex = visibleOptionIds.indexOf(dstOption.id)
             const destIndex = visibleOptionIds.indexOf(option.id)
@@ -160,7 +165,7 @@ const Kanban = (props: Props) => {
         const description = draggedCardIds.length > 1 ? `drag ${draggedCardIds.length} cards` : 'drag card'
 
         // Update dstCard order
-        const orderedCards = boardTree.orderedCards()
+        const orderedCards = boardTreeRef.current.orderedCards()
         const cardsById: { [key: string]: Card } = orderedCards.reduce((acc: { [key: string]: Card }, card: Card): { [key: string]: Card } => {
             acc[card.id] = card
             return acc
@@ -170,7 +175,7 @@ const Kanban = (props: Props) => {
         const isDraggingDown = cardOrder.indexOf(srcCard.id) <= cardOrder.indexOf(dstCard.id)
         cardOrder = cardOrder.filter((id) => !draggedCardIds.includes(id))
         let destIndex = cardOrder.indexOf(dstCard.id)
-        if (srcCard.properties[boardTree.groupByProperty!.id] === optionId && isDraggingDown) {
+        if (srcCard.properties[boardTreeRef.current.groupByProperty!.id] === optionId && isDraggingDown) {
             // If the cards are in the same column and dragging down, drop after the target dstCard
             destIndex += 1
         }
@@ -181,9 +186,9 @@ const Kanban = (props: Props) => {
             const awaits = []
             for (const draggedCard of draggedCards) {
                 Utils.log(`draggedCard: ${draggedCard.title}, column: ${optionId}`)
-                const oldOptionId = draggedCard.properties[boardTree.groupByProperty!.id]
+                const oldOptionId = draggedCard.properties[boardTreeRef.current.groupByProperty!.id]
                 if (optionId !== oldOptionId) {
-                    awaits.push(mutator.changePropertyValue(draggedCard, boardTree.groupByProperty!.id, optionId, description))
+                    awaits.push(mutator.changePropertyValue(draggedCard, boardTreeRef.current.groupByProperty!.id, optionId, description))
                 }
             }
             await Promise.all(awaits)
@@ -203,7 +208,7 @@ const Kanban = (props: Props) => {
                     <KanbanColumnHeader
                         key={group.option.id}
                         group={group}
-                        boardTree={boardTree}
+                        boardTree={boardTreeRef.current}
                         intl={props.intl}
                         addCard={props.addCard}
                         readonly={props.readonly}
@@ -289,7 +294,7 @@ const Kanban = (props: Props) => {
                         <KanbanHiddenColumnItem
                             key={group.option.id}
                             group={group}
-                            boardTree={boardTree}
+                            boardTree={boardTreeRef.current}
                             intl={props.intl}
                             readonly={props.readonly}
                             onDrop={(card: Card) => onDropToColumn(group.option, card)}


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
If you create a new card and then try to drag to a new group, it won't work because boardTree is out of sync. 
Sometimes boardTree is not in sync and it causes cards not being able to be dragged to different columns hence we need to useRef to fix this.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Fixes GH-626
