### PR TITLE
InsertBlock per workspace logic

### DIFF
--- a/server/services/store/sqlstore/blocks.go
+++ b/server/services/store/sqlstore/blocks.go
@@ -392,7 +392,7 @@ func (s *SQLStore) InsertBlock(c store.Container, block *model.Block, userID str
 		// block with ID exists, so this is an update operation
 		query := s.getQueryBuilder().Update(s.tablePrefix+"blocks").
 			Where(sq.Eq{"id": block.ID}).
-			Set("workspace_id", c.WorkspaceID).
+			Where(sq.Eq{"COALESCE(workspace_id, '0')": c.WorkspaceID}).
 			Set("parent_id", block.ParentID).
 			Set("root_id", block.RootID).
 			Set("modified_by", block.ModifiedBy).


### PR DESCRIPTION
This reverts the InsertBlock logic to insert per workspace. This was changed in PR #583, and due to that change, blocks with the same ID in different workspaces would fail to update. It also exposes a security hole where the workspace of a block can be changed by an insert.

Currently, the primary key of a block is WorkspaceID+ID. If / when we change that, we will need to change it across the DB store system.