### PR TITLE
[GH-779] Consistent date time format

### DIFF
--- a/webapp/src/components/cardDetail/comment.tsx
+++ b/webapp/src/components/cardDetail/comment.tsx
@@ -46,7 +46,9 @@ const Comment: FC<Props> = (props: Props) => {
                     src={userImageUrl}
                 />
                 <div className='comment-username'>{username}</div>
-                <div className='comment-date'>{(new Date(comment.createAt)).toLocaleString()}</div>
+                <div className='comment-date'>
+                    {Utils.displayDateTime(new Date(comment.createAt), intl)}
+                </div>
                 <MenuWrapper>
                     <IconButton icon={<OptionsIcon/>}/>
                     <Menu position='left'>

--- a/webapp/src/components/properties/createdAt/createdAt.tsx
+++ b/webapp/src/components/properties/createdAt/createdAt.tsx
@@ -3,16 +3,19 @@
 
 import React from 'react'
 
-const moment = require('moment')
+import {useIntl} from 'react-intl'
+
+import {Utils} from '../../../utils'
 
 type Props = {
     createAt: number
 }
 
 const CreatedAt = (props: Props): JSX.Element => {
+    const intl = useIntl()
     return (
         <div className='CreatedAt octo-propertyvalue'>
-            {moment(props.createAt).format('llll')}
+            {Utils.displayDateTime(new Date(props.createAt), intl)}
         </div>
     )
 }

--- a/webapp/src/components/properties/lastModifiedAt/__snapshots__/lastModifiedAt.test.tsx.snap
+++ b/webapp/src/components/properties/lastModifiedAt/__snapshots__/lastModifiedAt.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`componnets/properties/lastModifiedAt should match snapshot 1`] = `
   <div
     class="LastModifiedAt octo-propertyvalue"
   >
-    Thu, Jun 10, 2021 4:22 PM
+    June 10, 4:22 PM
   </div>
 </div>
 `;

--- a/webapp/src/components/properties/lastModifiedAt/lastModifiedAt.test.tsx
+++ b/webapp/src/components/properties/lastModifiedAt/lastModifiedAt.test.tsx
@@ -4,6 +4,8 @@
 import React from 'react'
 import {render} from '@testing-library/react'
 
+import {IntlProvider} from 'react-intl'
+
 import {CardTree, CardTreeContext, MutableCardTree} from '../../../viewModel/cardTree'
 
 import {MutableCard} from '../../../blocks/card'
@@ -13,6 +15,8 @@ import {MutableBoard} from '../../../blocks/board'
 import {MutableBlock} from '../../../blocks/block'
 
 import LastModifiedAt from './lastModifiedAt'
+
+const wrapIntl = (children: any) => <IntlProvider locale='en'>{children}</IntlProvider>
 
 describe('componnets/properties/lastModifiedAt', () => {
     test('should match snapshot', () => {
@@ -38,13 +42,13 @@ describe('componnets/properties/lastModifiedAt', () => {
         const cardTrees:{ [key: string]: CardTree | undefined } = {}
         cardTrees[card.id] = new MutableCardTree(card)
 
-        const component = (
+        const component = wrapIntl(
             <CardTreeContext.Provider value={cardTree}>
                 <LastModifiedAt
                     card={card}
                     cardTree={cardTree}
                 />
-            </CardTreeContext.Provider>
+            </CardTreeContext.Provider>,
         )
 
         const {container} = render(component)

--- a/webapp/src/components/properties/lastModifiedAt/lastModifiedAt.tsx
+++ b/webapp/src/components/properties/lastModifiedAt/lastModifiedAt.tsx
@@ -3,11 +3,12 @@
 
 import React from 'react'
 
+import {useIntl} from 'react-intl'
+
 import {Card} from '../../../blocks/card'
 import {CardTree} from '../../../viewModel/cardTree'
 import {IBlock} from '../../../blocks/block'
-
-const moment = require('moment')
+import {Utils} from '../../../utils'
 
 type Props = {
     card: Card,
@@ -15,6 +16,8 @@ type Props = {
 }
 
 const LastModifiedAt = (props: Props): JSX.Element => {
+    const intl = useIntl()
+
     let latestBlock: IBlock = props.card
     if (props.cardTree) {
         const sortedBlocks = props.cardTree.allBlocks.
@@ -26,7 +29,7 @@ const LastModifiedAt = (props: Props): JSX.Element => {
 
     return (
         <div className='LastModifiedAt octo-propertyvalue'>
-            {moment(latestBlock.updateAt).format('llll')}
+            {Utils.displayDateTime(new Date(latestBlock.updateAt), intl)}
         </div>
     )
 }

--- a/webapp/src/components/table/__snapshots__/table.test.tsx.snap
+++ b/webapp/src/components/table/__snapshots__/table.test.tsx.snap
@@ -198,7 +198,7 @@ exports[`components/table/Table extended should match snapshot with CreatedBy 1`
           <div
             class="CreatedAt octo-propertyvalue"
           >
-            Tue, Jun 15, 2021 4:22 PM
+            June 15, 4:22 PM
           </div>
         </div>
       </div>
@@ -276,7 +276,7 @@ exports[`components/table/Table extended should match snapshot with CreatedBy 1`
           <div
             class="CreatedAt octo-propertyvalue"
           >
-            Tue, Jun 15, 2021 4:22 PM
+            June 15, 4:22 PM
           </div>
         </div>
       </div>
@@ -786,7 +786,7 @@ exports[`components/table/Table extended should match snapshot with UpdatedAt 1`
           <div
             class="LastModifiedAt octo-propertyvalue"
           >
-            Sun, Jun 20, 2021 12:22 PM
+            June 20, 12:22 PM
           </div>
         </div>
       </div>
@@ -864,7 +864,7 @@ exports[`components/table/Table extended should match snapshot with UpdatedAt 1`
           <div
             class="LastModifiedAt octo-propertyvalue"
           >
-            Sun, Jun 20, 2021 12:22 PM
+            June 20, 12:22 PM
           </div>
         </div>
       </div>

--- a/webapp/src/utils.test.ts
+++ b/webapp/src/utils.test.ts
@@ -85,4 +85,21 @@ describe('utils', () => {
             expect(Utils.displayDate(date, intl)).toBe(`July 09, ${previousYear}`)
         })
     })
+
+    describe('display date and time', () => {
+        const intl = createIntl({locale: 'en-us'})
+
+        it('should show month, day and time for current year', () => {
+            const currentYear = new Date().getFullYear()
+            const date = new Date(currentYear, 6, 9, 15, 20)
+            expect(Utils.displayDateTime(date, intl)).toBe('July 09, 3:20 PM')
+        })
+
+        it('should show month, day, year and time for previous year', () => {
+            const currentYear = new Date().getFullYear()
+            const previousYear = currentYear - 1
+            const date = new Date(previousYear, 6, 9, 5, 35)
+            expect(Utils.displayDateTime(date, intl)).toBe(`July 09, ${previousYear}, 5:35 AM`)
+        })
+    })
 })

--- a/webapp/src/utils.ts
+++ b/webapp/src/utils.ts
@@ -121,24 +121,27 @@ class Utils {
 
     // Date and Time
 
-    static displayDate(date: Date, intl: IntlShape): string {
+    private static yearOption(date: Date) {
         const isCurrentYear = date.getFullYear() === new Date().getFullYear()
+        return isCurrentYear ? undefined : 'numeric'
+    }
+
+    static displayDate(date: Date, intl: IntlShape): string {
         return intl.formatDate(date, {
-            year: isCurrentYear ? undefined : 'numeric',
+            year: Utils.yearOption(date),
             month: 'long',
             day: '2-digit',
         })
     }
 
     static displayDateTime(date: Date, intl: IntlShape): string {
-        const text = intl.formatDate(date, {
-            year: 'numeric',
+        return intl.formatDate(date, {
+            year: Utils.yearOption(date),
             month: 'long',
             day: '2-digit',
             hour: 'numeric',
             minute: 'numeric',
         })
-        return text
     }
 
     static sleep(miliseconds: number): Promise<void> {

--- a/webapp/src/utils.ts
+++ b/webapp/src/utils.ts
@@ -133,7 +133,7 @@ class Utils {
     static displayDateTime(date: Date, intl: IntlShape): string {
         const text = intl.formatDate(date, {
             year: 'numeric',
-            month: 'short',
+            month: 'long',
             day: '2-digit',
             hour: 'numeric',
             minute: 'numeric',


### PR DESCRIPTION
#### Summary
Format for date and time changed:
* `Utils.displayDateTime` is used inside `Comment`/`CreatedAt`/`LastModifiedAt` components
* options for month and year are the same as in `Utils.displayDate` for consistency

Here is how it looks in the card dialog:
![image](https://user-images.githubusercontent.com/5587620/127118595-d7ca2cae-72c7-46b5-97d4-53793bf5d1f0.png) 
and on the board:
![image](https://user-images.githubusercontent.com/5587620/127118646-6da5f92a-93a9-4661-9915-cb555ff72980.png)

#### Ticket Link
Fixes #779