### PR TITLE
Add clear button to value selectors

### DIFF
--- a/webapp/src/components/cardDetail/__snapshots__/cardDetailProperties.test.tsx.snap
+++ b/webapp/src/components/cardDetail/__snapshots__/cardDetailProperties.test.tsx.snap
@@ -31,7 +31,19 @@ exports[`components/cardDetail/CardDetailProperties should match snapshot 1`] = 
         <span
           class="Label propColorDefault "
         >
-          Jean-Luc Picard
+          <span
+            class="Label-text"
+          >
+            Jean-Luc Picard
+          </span>
+          <div
+            class="Button IconButton margin-left delete-value"
+            title="Clear"
+          >
+            <i
+              class="CompassIcon icon-close CloseIcon"
+            />
+          </div>
         </span>
       </div>
     </div>

--- a/webapp/src/components/propertyValueElement.tsx
+++ b/webapp/src/components/propertyValueElement.tsx
@@ -18,6 +18,8 @@ import Label from '../widgets/label'
 
 import EditableDayPicker from '../widgets/editableDayPicker'
 import Switch from '../widgets/switch'
+import IconButton from '../widgets/buttons/iconButton'
+import CloseIcon from '../widgets/icons/close'
 
 import UserProperty from './properties/user/user'
 import MultiSelectProperty from './properties/multiSelect'
@@ -73,6 +75,8 @@ const PropertyValueElement = (props:Props): JSX.Element => {
             saveTextPropertyRef.current && saveTextPropertyRef.current()
         }
     }, [])
+
+    const onDeleteValue = useCallback(() => mutator.changePropertyValue(card, propertyTemplate.id, ''), [card, propertyTemplate.id])
 
     const validateProp = (propType: string, val: string): boolean => {
         if (val === '') {
@@ -139,7 +143,17 @@ const PropertyValueElement = (props:Props): JSX.Element => {
                     tabIndex={0}
                     onClick={() => setOpen(true)}
                 >
-                    <Label color={displayValue ? propertyColorCssClassName : 'empty'}>{finalDisplayValue}</Label>
+                    <Label color={displayValue ? propertyColorCssClassName : 'empty'}>
+                        <span className='Label-text'>{finalDisplayValue}</span>
+                        {displayValue &&
+                            <IconButton
+                                onClick={onDeleteValue}
+                                onMouseDown={(e: React.MouseEvent) => e.stopPropagation()}
+                                icon={<CloseIcon/>}
+                                title='Clear'
+                                className='margin-left delete-value'
+                            />}
+                    </Label>
                 </div>
             )
         }
@@ -168,6 +182,7 @@ const PropertyValueElement = (props:Props): JSX.Element => {
                         mutator.changePropertyValue(card, propertyTemplate.id, option.id)
                     }
                 }
+                onDeleteValue={onDeleteValue}
             />
         )
     } else if (propertyTemplate.type === 'person') {

--- a/webapp/src/components/propertyValueElement.tsx
+++ b/webapp/src/components/propertyValueElement.tsx
@@ -145,7 +145,7 @@ const PropertyValueElement = (props:Props): JSX.Element => {
                 >
                     <Label color={displayValue ? propertyColorCssClassName : 'empty'}>
                         <span className='Label-text'>{finalDisplayValue}</span>
-                        {displayValue &&
+                        {displayValue && !props.readOnly &&
                             <IconButton
                                 onClick={onDeleteValue}
                                 onMouseDown={(e: React.MouseEvent) => e.stopPropagation()}

--- a/webapp/src/components/table/__snapshots__/table.test.tsx.snap
+++ b/webapp/src/components/table/__snapshots__/table.test.tsx.snap
@@ -174,7 +174,19 @@ exports[`components/table/Table extended should match snapshot with CreatedBy 1`
             <span
               class="Label propColorBrown "
             >
-              value 1
+              <span
+                class="Label-text"
+              >
+                value 1
+              </span>
+              <div
+                class="Button IconButton margin-left delete-value"
+                title="Clear"
+              >
+                <i
+                  class="CompassIcon icon-close CloseIcon"
+                />
+              </div>
             </span>
           </div>
         </div>
@@ -188,7 +200,11 @@ exports[`components/table/Table extended should match snapshot with CreatedBy 1`
           >
             <span
               class="Label empty "
-            />
+            >
+              <span
+                class="Label-text"
+              />
+            </span>
           </div>
         </div>
         <div
@@ -252,7 +268,19 @@ exports[`components/table/Table extended should match snapshot with CreatedBy 1`
             <span
               class="Label propColorBrown "
             >
-              value 1
+              <span
+                class="Label-text"
+              >
+                value 1
+              </span>
+              <div
+                class="Button IconButton margin-left delete-value"
+                title="Clear"
+              >
+                <i
+                  class="CompassIcon icon-close CloseIcon"
+                />
+              </div>
             </span>
           </div>
         </div>
@@ -266,7 +294,11 @@ exports[`components/table/Table extended should match snapshot with CreatedBy 1`
           >
             <span
               class="Label empty "
-            />
+            >
+              <span
+                class="Label-text"
+              />
+            </span>
           </div>
         </div>
         <div
@@ -468,7 +500,19 @@ exports[`components/table/Table extended should match snapshot with CreatedBy 2`
             <span
               class="Label propColorBrown "
             >
-              value 1
+              <span
+                class="Label-text"
+              >
+                value 1
+              </span>
+              <div
+                class="Button IconButton margin-left delete-value"
+                title="Clear"
+              >
+                <i
+                  class="CompassIcon icon-close CloseIcon"
+                />
+              </div>
             </span>
           </div>
         </div>
@@ -482,7 +526,11 @@ exports[`components/table/Table extended should match snapshot with CreatedBy 2`
           >
             <span
               class="Label empty "
-            />
+            >
+              <span
+                class="Label-text"
+              />
+            </span>
           </div>
         </div>
         <div
@@ -546,7 +594,19 @@ exports[`components/table/Table extended should match snapshot with CreatedBy 2`
             <span
               class="Label propColorBrown "
             >
-              value 1
+              <span
+                class="Label-text"
+              >
+                value 1
+              </span>
+              <div
+                class="Button IconButton margin-left delete-value"
+                title="Clear"
+              >
+                <i
+                  class="CompassIcon icon-close CloseIcon"
+                />
+              </div>
             </span>
           </div>
         </div>
@@ -560,7 +620,11 @@ exports[`components/table/Table extended should match snapshot with CreatedBy 2`
           >
             <span
               class="Label empty "
-            />
+            >
+              <span
+                class="Label-text"
+              />
+            </span>
           </div>
         </div>
         <div
@@ -762,7 +826,19 @@ exports[`components/table/Table extended should match snapshot with UpdatedAt 1`
             <span
               class="Label propColorBrown "
             >
-              value 1
+              <span
+                class="Label-text"
+              >
+                value 1
+              </span>
+              <div
+                class="Button IconButton margin-left delete-value"
+                title="Clear"
+              >
+                <i
+                  class="CompassIcon icon-close CloseIcon"
+                />
+              </div>
             </span>
           </div>
         </div>
@@ -776,7 +852,11 @@ exports[`components/table/Table extended should match snapshot with UpdatedAt 1`
           >
             <span
               class="Label empty "
-            />
+            >
+              <span
+                class="Label-text"
+              />
+            </span>
           </div>
         </div>
         <div
@@ -840,7 +920,19 @@ exports[`components/table/Table extended should match snapshot with UpdatedAt 1`
             <span
               class="Label propColorBrown "
             >
-              value 1
+              <span
+                class="Label-text"
+              >
+                value 1
+              </span>
+              <div
+                class="Button IconButton margin-left delete-value"
+                title="Clear"
+              >
+                <i
+                  class="CompassIcon icon-close CloseIcon"
+                />
+              </div>
             </span>
           </div>
         </div>
@@ -854,7 +946,11 @@ exports[`components/table/Table extended should match snapshot with UpdatedAt 1`
           >
             <span
               class="Label empty "
-            />
+            >
+              <span
+                class="Label-text"
+              />
+            </span>
           </div>
         </div>
         <div
@@ -1056,7 +1152,19 @@ exports[`components/table/Table extended should match snapshot with UpdatedBy 1`
             <span
               class="Label propColorBrown "
             >
-              value 1
+              <span
+                class="Label-text"
+              >
+                value 1
+              </span>
+              <div
+                class="Button IconButton margin-left delete-value"
+                title="Clear"
+              >
+                <i
+                  class="CompassIcon icon-close CloseIcon"
+                />
+              </div>
             </span>
           </div>
         </div>
@@ -1070,7 +1178,11 @@ exports[`components/table/Table extended should match snapshot with UpdatedBy 1`
           >
             <span
               class="Label empty "
-            />
+            >
+              <span
+                class="Label-text"
+              />
+            </span>
           </div>
         </div>
         <div
@@ -1134,7 +1246,19 @@ exports[`components/table/Table extended should match snapshot with UpdatedBy 1`
             <span
               class="Label propColorBrown "
             >
-              value 1
+              <span
+                class="Label-text"
+              >
+                value 1
+              </span>
+              <div
+                class="Button IconButton margin-left delete-value"
+                title="Clear"
+              >
+                <i
+                  class="CompassIcon icon-close CloseIcon"
+                />
+              </div>
             </span>
           </div>
         </div>
@@ -1148,7 +1272,11 @@ exports[`components/table/Table extended should match snapshot with UpdatedBy 1`
           >
             <span
               class="Label empty "
-            />
+            >
+              <span
+                class="Label-text"
+              />
+            </span>
           </div>
         </div>
         <div
@@ -1328,7 +1456,19 @@ exports[`components/table/Table should match snapshot 1`] = `
             <span
               class="Label propColorBrown "
             >
-              value 1
+              <span
+                class="Label-text"
+              >
+                value 1
+              </span>
+              <div
+                class="Button IconButton margin-left delete-value"
+                title="Clear"
+              >
+                <i
+                  class="CompassIcon icon-close CloseIcon"
+                />
+              </div>
             </span>
           </div>
         </div>
@@ -1342,7 +1482,11 @@ exports[`components/table/Table should match snapshot 1`] = `
           >
             <span
               class="Label empty "
-            />
+            >
+              <span
+                class="Label-text"
+              />
+            </span>
           </div>
         </div>
       </div>
@@ -1672,7 +1816,11 @@ exports[`components/table/Table should match snapshot, read-only 1`] = `
             <span
               class="Label propColorBrown "
             >
-              value 1
+              <span
+                class="Label-text"
+              >
+                value 1
+              </span>
             </span>
           </div>
         </div>
@@ -1686,7 +1834,11 @@ exports[`components/table/Table should match snapshot, read-only 1`] = `
           >
             <span
               class="Label empty "
-            />
+            >
+              <span
+                class="Label-text"
+              />
+            </span>
           </div>
         </div>
       </div>

--- a/webapp/src/components/table/__snapshots__/tableRow.test.tsx.snap
+++ b/webapp/src/components/table/__snapshots__/tableRow.test.tsx.snap
@@ -142,7 +142,19 @@ exports[`components/table/TableRow should match snapshot, display properties 1`]
         <span
           class="Label propColorBrown "
         >
-          value 1
+          <span
+            class="Label-text"
+          >
+            value 1
+          </span>
+          <div
+            class="Button IconButton margin-left delete-value"
+            title="Clear"
+          >
+            <i
+              class="CompassIcon icon-close CloseIcon"
+            />
+          </div>
         </span>
       </div>
     </div>
@@ -156,7 +168,11 @@ exports[`components/table/TableRow should match snapshot, display properties 1`]
       >
         <span
           class="Label empty "
-        />
+        >
+          <span
+            class="Label-text"
+          />
+        </span>
       </div>
     </div>
   </div>
@@ -306,7 +322,19 @@ exports[`components/table/TableRow should match snapshot, resizing column 1`] = 
         <span
           class="Label propColorBrown "
         >
-          value 1
+          <span
+            class="Label-text"
+          >
+            value 1
+          </span>
+          <div
+            class="Button IconButton margin-left delete-value"
+            title="Clear"
+          >
+            <i
+              class="CompassIcon icon-close CloseIcon"
+            />
+          </div>
         </span>
       </div>
     </div>
@@ -320,7 +348,11 @@ exports[`components/table/TableRow should match snapshot, resizing column 1`] = 
       >
         <span
           class="Label empty "
-        />
+        >
+          <span
+            class="Label-text"
+          />
+        </span>
       </div>
     </div>
   </div>

--- a/webapp/src/styles/main.scss
+++ b/webapp/src/styles/main.scss
@@ -164,6 +164,14 @@ html {
         &.empty {
             color: rgba(var(--body-color), 0.4);
         }
+        .IconButton.delete-value {
+            width: 16px;
+            min-width: 16px;
+            height: 16px;
+            i {
+                font-size: 16px;
+            }
+        }
     }
 
     /*-- Editable --*/

--- a/webapp/src/widgets/valueSelector.scss
+++ b/webapp/src/widgets/valueSelector.scss
@@ -19,6 +19,15 @@
         overflow: hidden;
         border-radius: var(--default-rad);
         max-width: 100%;
+
+        .IconButton.delete-value {
+            width: 16px;
+            min-width: 16px;
+            height: 16px;
+            i {
+                font-size: 16px;
+            }
+        }
     }
 
     .Label-no-padding {

--- a/webapp/src/widgets/valueSelector.tsx
+++ b/webapp/src/widgets/valueSelector.tsx
@@ -57,8 +57,8 @@ const ValueSelectorLabel = React.memo((props: LabelProps): JSX.Element => {
                         onClick={() => onDeleteValue(option)}
                         onMouseDown={(e) => e.stopPropagation()}
                         icon={<CloseIcon/>}
-                        title='Close'
-                        className='margin-left'
+                        title='Clear'
+                        className='margin-left delete-value'
                     />
                 }
             </Label>


### PR DESCRIPTION
Fixes #370 

For table view:
![imagen](https://user-images.githubusercontent.com/290303/127888908-2528ea3f-d8ed-4c29-8c16-a5ff51724696.png)

For read only cases like board card and gallery card:
![imagen](https://user-images.githubusercontent.com/290303/127889576-cf76ff63-e8a0-4397-99dd-f61dd7ac9f15.png)

For card view:
![imagen](https://user-images.githubusercontent.com/290303/127889641-0b552abd-8e0f-447e-bebe-72161d5709ae.png)
