### PR TITLE
[GH-815] Fix kanban board height

### DIFF
--- a/webapp/src/components/kanban/kanban.scss
+++ b/webapp/src/components/kanban/kanban.scss
@@ -1,5 +1,6 @@
 .focalboard-body .Kanban {
     overflow: auto;
+    flex: 1;
 
     .octo-board-header {
         display: flex;


### PR DESCRIPTION
#### Summary
Fix for kaban board height: use `1` for `flex-grow`.

#### Ticket Link
Fixes #815 