### PR TITLE
Add step to delete default at sites-available

### DIFF
--- a/website/site/content/download/personal-edition/ubuntu.md
+++ b/website/site/content/download/personal-edition/ubuntu.md
@@ -104,6 +104,7 @@ If there is a default site, you may need to delete it
 
 ```
 sudo rm /etc/nginx/sites-enabled/default
+sudo rm /etc/nginx/sites-available/default
 ```
 
 Enable the Focalboard site, test the config, and reload NGINX:


### PR DESCRIPTION
The default site config needs to be deleted on both sites-available and sites-enabled otherwise the config test will fail.

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

