### PR TITLE
Move version label to top right for plugin

### DIFF
--- a/webapp/src/components/sidebar/sidebarUserMenu.tsx
+++ b/webapp/src/components/sidebar/sidebarUserMenu.tsx
@@ -46,12 +46,13 @@ const SidebarUserMenu = React.memo(() => {
                                     <LogoIcon/>
                                     <span>{'Boards'}</span>
                                 </>}
-                            <div className='versionFrame'>
-                                <div className='version'>
-                                    {`v${Constants.versionString}`}
-                                </div>
-                                {showVersionBadge && <div className='versionBadge'>{'BETA'}</div>}
-                            </div>
+                            {focalboardTitle &&
+                                <div className='versionFrame'>
+                                    <div className='version'>
+                                        {`v${Constants.versionString}`}
+                                    </div>
+                                    {showVersionBadge && <div className='versionBadge'>{'BETA'}</div>}
+                                </div>}
                         </div>
                     </div>
                     <Menu>

--- a/webapp/src/components/topBar.scss
+++ b/webapp/src/components/topBar.scss
@@ -13,4 +13,25 @@
     .HelpIcon {
         font-size: 20px;
     }
+
+    .versionFrame {
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+    }
+
+    .version {
+        font-size: 11px;
+        line-height: 11px;
+        font-weight: 500;
+        color: rgba(var(--center-channel-color-rgb), 0.7);
+    }
+
+    .versionBadge {
+        font-size: 10px;
+        line-height: 11px;
+        font-weight: 500;
+        margin-left: 3px;
+        color: rgba(var(--center-channel-color-rgb), 0.7);
+    }
 }

--- a/webapp/src/components/topBar.tsx
+++ b/webapp/src/components/topBar.tsx
@@ -6,11 +6,24 @@ import React from 'react'
 import './topBar.scss'
 import HelpIcon from '../widgets/icons/help'
 import {Utils} from '../utils'
+import {Constants} from '../constants'
 
 const TopBar = React.memo((): JSX.Element => {
     if (Utils.isFocalboardPlugin()) {
-        return <></>
+        return (
+            <div
+                className='TopBar'
+            >
+                <div className='versionFrame'>
+                    <div className='version'>
+                        {`v${Constants.versionString}`}
+                    </div>
+                    <div className='versionBadge'>{'BETA'}</div>
+                </div>
+            </div>
+        )
     }
+
     return (
         <div
             className='TopBar'


### PR DESCRIPTION
This moves the version label to the top right of the main page when running as a plugin:

<img width="825" alt="Version label" src="https://user-images.githubusercontent.com/46905241/129113157-e2d880d4-ce16-45ba-9dba-bdf8aa5e9cc3.png">
