### PR TITLE
Added ability for calculation menu to open wherever there is available space

### DIFF
--- a/webapp/src/components/calculations/options.tsx
+++ b/webapp/src/components/calculations/options.tsx
@@ -102,7 +102,7 @@ const CalculationOptions = (props: Props): JSX.Element => {
             name={'calculation_options'}
             className={'CalculationOptions'}
             options={options}
-            menuPlacement={'top'}
+            menuPlacement={'auto'}
             isSearchable={false}
             components={{DropdownIndicator}}
             defaultMenuIsOpen={props.menuOpen}


### PR DESCRIPTION
#### Summary
Added ability for calculation menu to open wherever there is available space

#### Ticket Link
Fixes #930 

It opens the menu at the bottom by default and opens above if there is no space below

<img width="580" alt="Screenshot 2021-08-12 at 4 09 07 PM" src="https://user-images.githubusercontent.com/18575143/129183392-f850da58-5fc4-4dff-bb27-689b94b0f34e.png">

This changes the behaviour from the default top menu to the default bottom menu. Unfortunately, there is no way in react select to set default menu placement to top and open in the bottom only if there is no space.