### PR TITLE
Fix #934. Sidebar hide-unhide as plugin.

### DIFF
--- a/webapp/src/components/sidebar/sidebar.scss
+++ b/webapp/src/components/sidebar/sidebar.scss
@@ -19,6 +19,8 @@
         width: 50px;
         background: none;
         padding: 0;
+        padding-left: 10px;
+        display: block !important;
 
         > div {
             padding: 0;
@@ -40,7 +42,11 @@
     }
 
     .WorkspaceTitle {
+        display: flex;
+        flex-direction: row;
+
         padding: 0 16px;
+        margin-bottom: 12px;
         font-weight: 600;
     }
 

--- a/webapp/src/components/sidebar/sidebar.tsx
+++ b/webapp/src/components/sidebar/sidebar.tsx
@@ -77,6 +77,15 @@ const Sidebar = React.memo((props: Props) => {
             {workspace && workspace.id !== '0' &&
                 <div className='WorkspaceTitle'>
                     {workspace.title}
+                    {Utils.isFocalboardPlugin() &&
+                    <>
+                        <div className='octo-spacer'/>
+                        <IconButton
+                            onClick={() => setHidden(true)}
+                            icon={<HideSidebarIcon/>}
+                        />
+                    </>
+                    }
                 </div>
             }
             <div className='octo-sidebar-list'>


### PR DESCRIPTION
Updated UI on the plugin:
* Add the hide button on the same row as the workspace (channel) name
* Fix showing the show-sidebar (hamburger) button when hidden (this was a css conflict with the .hidden class)