### PR TITLE
GH-964: Allow overflow in Gallery View

### DIFF
--- a/webapp/src/components/gallery/gallery.scss
+++ b/webapp/src/components/gallery/gallery.scss
@@ -1,6 +1,7 @@
 .focalboard-body .Gallery {
     display: flex;
     flex-wrap: wrap;
+    overflow: auto;
 
     .octo-gallery-new {
         border: 1px solid rgba(var(--center-channel-color-rgb), 0.09);


### PR DESCRIPTION
#### Summary
Allows overflow on the Gallery container.

This was previously supplied by the `BoardComponent` but set to `overflow: hidden` to fix double scrollbars.

The other views, `Board` and `Table` provide the overflow setting on the same class, so this is now more consistent with other views.

#### Ticket Link

  Fixes https://github.com/mattermost/focalboard/issues/964

![Screen Shot 2021-08-12 at 3 58 31 PM](https://user-images.githubusercontent.com/12704875/129275377-cdc4ac0c-28a2-484f-8c47-655c64c25690.png)
