### PR TITLE
Fix GH-955 and GH-936

### DIFF
--- a/webapp/src/components/markdownEditor.tsx
+++ b/webapp/src/components/markdownEditor.tsx
@@ -2,6 +2,7 @@
 // See LICENSE.txt for license information.
 import React, {useState, useRef, useMemo} from 'react'
 import SimpleMDE from 'react-simplemde-editor'
+import 'easymde/dist/easymde.min.css'
 
 import {Utils} from '../utils'
 import './markdownEditor.scss'

--- a/webapp/src/styles/main.scss
+++ b/webapp/src/styles/main.scss
@@ -62,10 +62,6 @@ html {
         text-decoration: none;
         color: var(--link-color-rgb);
 
-        &:visited {
-            color: var(--link-visited-color);
-        }
-
         &:hover {
             background-color: rgba(192, 192, 255, 0.2);
         }

--- a/webapp/src/styles/main.scss
+++ b/webapp/src/styles/main.scss
@@ -62,6 +62,10 @@ html {
         text-decoration: none;
         color: var(--link-color-rgb);
 
+        &:visited {
+            color: var(--link-visited-color-rgb);
+        }
+
         &:hover {
             background-color: rgba(192, 192, 255, 0.2);
         }

--- a/webapp/src/theme.ts
+++ b/webapp/src/theme.ts
@@ -176,7 +176,7 @@ export function setMattermostTheme(theme: any): Theme {
     document.documentElement.style.setProperty('--button-color-rgb', color(theme.buttonColor).rgb().array().join(', '))
     document.documentElement.style.setProperty('--sidebar-bg-rgb', color(theme.sidebarBg).rgb().array().join(', '))
     document.documentElement.style.setProperty('--sidebar-text-rgb', color(theme.sidebarText).rgb().array().join(', '))
-    document.documentElement.style.setProperty('--link-color-rgb', color(theme.linkColor).rgb().array().join(', '))
+    document.documentElement.style.setProperty('--link-color-rgb', theme.linkColor)
     document.documentElement.style.setProperty('--sidebar-text-active-border', color(theme.sidebarTextActiveBorder).rgb().array().join(', '))
 
     return setTheme({
@@ -188,7 +188,7 @@ export function setMattermostTheme(theme: any): Theme {
         sidebarBg: color(theme.sidebarBg).rgb().array().join(', '),
         sidebarFg: color(theme.sidebarColor || '#ffffff').rgb().array().join(', '),
         sidebarTextActiveBorder: color(theme.sidebarTextActiveBorder).rgb().array().join(', '),
-        link: color(theme.linkColor).rgb().array().join(', '),
+        link: theme.linkColor,
     })
 }
 


### PR DESCRIPTION
Fixes GH-955 

Fix CSS variable name to show proper color

Fixes GH-936

Needed to import SIMPLE MDE css file as per their instructions https://github.com/RIP21/react-simplemde-editor/blob/master/README.md#usage


Also a mismatch on --link-color-rgb . Standalone received a hex value, plugin received a RGB value. 
I had to make it so the plugin also passed down a hex value so the color got correctly set.