### PR TITLE
Fix #977. Show uncollapse button even with global nav.

### DIFF
--- a/webapp/src/components/workspace.scss
+++ b/webapp/src/components/workspace.scss
@@ -3,6 +3,7 @@
     display: flex;
     flex-direction: row;
     overflow: auto;
+    position: relative;
 
     > .mainFrame {
         flex: 1 1 auto;


### PR DESCRIPTION
Because the sidebar uses position: absolute, the uncollapse button is hidden when there is a global header. Solution is for the container (Workspace) to be position: relative.