### PR TITLE
Fix GH-1006: Editing card template's description doesn't work

### DIFF
--- a/webapp/src/store/contents.ts
+++ b/webapp/src/store/contents.ts
@@ -5,7 +5,7 @@ import {createSlice, PayloadAction, createSelector} from '@reduxjs/toolkit'
 
 import {ContentBlock} from '../blocks/contentBlock'
 
-import {getCards} from './cards'
+import {getCards, getTemplates} from './cards'
 import {initialLoad, initialReadOnlyLoad} from './initialLoad'
 
 import {RootState} from './index'
@@ -58,8 +58,9 @@ export function getCardContents(cardId: string): (state: RootState) => Array<Con
     return createSelector(
         getContentsById,
         getCards,
-        (contents, cards): Array<ContentBlock|ContentBlock[]> => {
-            const card = cards[cardId]
+        getTemplates,
+        (contents, cards, templates): Array<ContentBlock|ContentBlock[]> => {
+            const card = {...cards, ...templates}[cardId]
             const result: Array<ContentBlock|ContentBlock[]> = []
             if (card?.fields?.contentOrder) {
                 for (const contentId of card.fields.contentOrder) {


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
When editing template card or creating a new one, content of template card doesn't show up. 
This fixes the problem by including template cards

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Fixes GH-1006
