### PR TITLE
[GH-1033] Prevent opening card dialog when link for URL is clicked.

### DIFF
--- a/webapp/src/components/properties/link/link.tsx
+++ b/webapp/src/components/properties/link/link.tsx
@@ -25,6 +25,7 @@ const URLProperty = (props: Props): JSX.Element => {
                 href={Utils.ensureProtocol(props.value.trim())}
                 target='_blank'
                 rel='noreferrer'
+                onClick={(event) => event.stopPropagation()}
             >
                 <LinkIcon/>
             </a>


### PR DESCRIPTION
#### Summary
Stop event propagation for click on the link for URL property.

#### Ticket Link
Fixes #1033
