### PR TITLE
GH-1090 - move center align to table-row-container

### DIFF
--- a/webapp/src/components/table/table.scss
+++ b/webapp/src/components/table/table.scss
@@ -89,7 +89,6 @@
         font-size: 14px;
         position: relative;
         text-overflow: ellipsis;
-        align-items: center;
 
         &:hover {
             background-color: rgba(var(--center-channel-color-rgb), 0.05);
@@ -191,6 +190,9 @@
 
     .table-row-container {
         width: fit-content;
+        .octo-table-cell {
+            align-items: center;
+        }
     }
 
     .octo-table-footer {


### PR DESCRIPTION
#### Summary
The Center alignment caused the Horizontal Grip to have a height of 0, making it disappear.
This PR moves the Center alignment to only be on cells within the `.table-row-container`, since the original fix was only necessary for those rows.

#### Ticket Link
https://github.com/mattermost/focalboard/issues/1090
