### PR TITLE
GH-1131 - fix for displaying global nav in focalboard

### DIFF
--- a/mattermost-plugin/webapp/src/plugin.scss
+++ b/mattermost-plugin/webapp/src/plugin.scss
@@ -9,6 +9,8 @@
     z-index: 1000;
 
     .Menu {
+        position: unset;
+        min-width: unset;
         a,
         button {
             color: rgba(var(--center-channel-text-rgb), 1);


### PR DESCRIPTION
#### Summary
Updates CSS to unset menu setting that are causing an issue with the GlobalNav Bar.

#### Ticket Link
  Fixes https://github.com/mattermost/focalboard/issues/1131

