### PR TITLE
Add retry mechanism when opening WSClient in plugin mode

### DIFF
--- a/mattermost-plugin/server/manifest.go
+++ b/mattermost-plugin/server/manifest.go
@@ -13,8 +13,8 @@ var manifest *model.Manifest
 const manifestStr = `
 {
   "id": "focalboard",
-  "name": "Focalboard",
-  "description": "This provides focalboard integration with mattermost.",
+  "name": "Mattermost Boards",
+  "description": "The Mattermost Boards plugin",
   "homepage_url": "https://github.com/mattermost/focalboard",
   "support_url": "https://github.com/mattermost/focalboard/issues",
   "release_notes_url": "https://github.com/mattermost/focalboard/releases",

--- a/webapp/src/wsclient.ts
+++ b/webapp/src/wsclient.ts
@@ -70,6 +70,7 @@ class WSClient {
         if (this.client !== null) {
             const {action, ...data} = command
             this.client.sendMessage(this.clientPrefix + action, data)
+            return
         }
 
         this.ws?.send(JSON.stringify(command))

--- a/webapp/src/wsclient.ts
+++ b/webapp/src/wsclient.ts
@@ -139,8 +139,7 @@ class WSClient {
                     Utils.log('WSClient Mattermost Websocket not ready, retrying')
                     setTimeout(setPluginOpen, this.mmWSRetryDelay)
                 } else {
-                    Utils.logError(`WSClient error on open: Mattermost Websocket client is not ready`)
-                    return
+                    Utils.logError('WSClient error on open: Mattermost Websocket client is not ready')
                 }
             }
 


### PR DESCRIPTION
#### Summary
The `WSClient` in plugin mode can start sending messages before the Mattermost WebSocket client is ready. This PR adds a retry mechanism for `WSClient` to be set as `open` only when the Mattermost WebScocket client is connected.

Fixes #1125 
