### PR TITLE
1112 - Updating button active state in viewHeader

### DIFF
--- a/mattermost-plugin/webapp/src/plugin.scss
+++ b/mattermost-plugin/webapp/src/plugin.scss
@@ -16,7 +16,7 @@
             color: rgba(var(--center-channel-text-rgb), 1);
 
             i {
-                color: inherit;
+                color: var(--link-color-rgb);
             }
 
             &:hover {

--- a/webapp/src/components/viewHeader/viewHeader.scss
+++ b/webapp/src/components/viewHeader/viewHeader.scss
@@ -10,7 +10,7 @@
     align-items: center;
 
     > div {
-        margin-right: 16px;
+        margin-right: 12px;
         white-space: nowrap;
 
         &:last-child {
@@ -20,12 +20,6 @@
 
     #groupByLabel {
         margin-left: 0.3em;
-    }
-
-    .Button {
-        &.active {
-            color: rgb(var(--center-channel-color-rgb));
-        }
     }
 
     .IconButton {

--- a/webapp/src/components/viewHeader/viewHeader.scss
+++ b/webapp/src/components/viewHeader/viewHeader.scss
@@ -22,6 +22,12 @@
         margin-left: 0.3em;
     }
 
+    .Button {
+        &.active {
+            color: rgb(var(--center-channel-color-rgb));
+        }
+    }
+
     .IconButton {
         background: none;
         padding: 0;

--- a/webapp/src/widgets/buttons/button.scss
+++ b/webapp/src/widgets/buttons/button.scss
@@ -1,4 +1,5 @@
 .Button {
+    font-family: 'Open Sans', sans-serif;
     display: flex;
     flex: 0 0 auto;
     align-items: center;

--- a/webapp/src/widgets/buttons/button.scss
+++ b/webapp/src/widgets/buttons/button.scss
@@ -13,6 +13,8 @@
     border: 0;
     transition: background 100ms ease-out 0s;
     color: inherit;
+    height: 32px;
+    padding: 0 10px;
 
     &:hover {
         background-color: rgba(var(--center-channel-color-rgb), 0.1);
@@ -42,7 +44,8 @@
     }
 
     &.active {
-        color: rgb(var(--link-color));
+        background: rgba(var(--button-bg-rgb), 0.08);
+        color: rgb(var(--button-bg-rgb));
         font-weight: 600;
     }
 


### PR DESCRIPTION
#### Summary
1112 - Updating button active state in viewHeader
The problem with this is, that the buttons by default use `semibold` weight on community, so styles conflict. I have given the button another style.

#### Ticket Link
Fixes https://github.com/mattermost/focalboard/issues/1112
Fixes https://github.com/mattermost/focalboard/issues/1095

#### Screenshot:
![Screenshot 2021-08-31 at 8 05 34 PM](https://user-images.githubusercontent.com/11034289/131527614-f2e8ddb7-fa78-4135-8347-0ef412be9fd2.png)
![Screenshot 2021-08-31 at 8 07 50 PM](https://user-images.githubusercontent.com/11034289/131527938-704c3160-763e-4d98-9589-0f6b89d94f2b.png)
