### PR TITLE
Fix #1206. Sort card comments.

### DIFF
--- a/webapp/src/store/comments.ts
+++ b/webapp/src/store/comments.ts
@@ -46,10 +46,6 @@ const commentsSlice = createSlice({
 export const {updateComments} = commentsSlice.actions
 export const {reducer} = commentsSlice
 
-export function getComments(state: RootState): CommentBlock[] {
-    return Object.values(state.comments.comments).sort((a, b) => a.title.localeCompare(b.title)) as CommentBlock[]
-}
-
 export function getCardComments(cardId: string): (state: RootState) => CommentBlock[] {
     return (state: RootState): CommentBlock[] => {
         return Object.values(state.comments.comments).

--- a/webapp/src/store/comments.ts
+++ b/webapp/src/store/comments.ts
@@ -52,6 +52,8 @@ export function getComments(state: RootState): CommentBlock[] {
 
 export function getCardComments(cardId: string): (state: RootState) => CommentBlock[] {
     return (state: RootState): CommentBlock[] => {
-        return Object.values(state.comments.comments).filter((c) => c.parentId === cardId)
+        return Object.values(state.comments.comments).
+            filter((c) => c.parentId === cardId).
+            sort((a, b) => a.createAt - b.createAt)
     }
 }


### PR DESCRIPTION
Sort card comments oldest-first. Also remove unused `getComments` method to avoid future confusion.

Fixes #1206 