### PR TITLE
Fix #1217. Save dialog changes before closing.

### DIFF
--- a/webapp/src/components/dialog.tsx
+++ b/webapp/src/components/dialog.tsx
@@ -35,7 +35,9 @@ const Dialog = React.memo((props: Props) => {
                 className='wrapper'
                 onMouseDown={(e) => {
                     if (e.target === e.currentTarget) {
-                        props.onClose()
+                        setTimeout(() => {
+                            props.onClose()
+                        }, 0)
                     }
                 }}
             >

--- a/webapp/src/components/dialog.tsx
+++ b/webapp/src/components/dialog.tsx
@@ -33,11 +33,9 @@ const Dialog = React.memo((props: Props) => {
         <div className={`Dialog dialog-back ${props.className}`}>
             <div
                 className='wrapper'
-                onMouseDown={(e) => {
+                onClick={(e) => {
                     if (e.target === e.currentTarget) {
-                        setTimeout(() => {
-                            props.onClose()
-                        }, 0)
+                        props.onClose()
                     }
                 }}
             >


### PR DESCRIPTION
This resolves the timing issue in FireFox between the dialog background click and onBlur handing in MarkdownEditor.

Notes:
* When I added a breakpoint (in FireFox) to the onMouseDown handler in Dialog.tsx, the bug does not repro, even without this change
* Not sure which part of the onClose handler causes the update to abort.