### PR TITLE
Fix #1215. Don't sidebar collapse on Personal Server.

### DIFF
--- a/webapp/src/components/sidebar/sidebar.scss
+++ b/webapp/src/components/sidebar/sidebar.scss
@@ -140,7 +140,7 @@
     }
 
     @media screen and (min-width: 768px) {
-        .sidebarSwitcher {
+        .WorkspaceTitle .sidebarSwitcher {
             display: none;
         }
     }


### PR DESCRIPTION
Updated the css selector to only hide the collapse-sidebar button when there is a workspace. This might need to be refactored in the future to be more robust.