### PR TITLE
Add /run/secrets to config paths

### DIFF
--- a/server/services/config/config.go
+++ b/server/services/config/config.go
@@ -60,9 +60,10 @@ type Configuration struct {
 
 // ReadConfigFile read the configuration from the filesystem.
 func ReadConfigFile() (*Configuration, error) {
-	viper.SetConfigName("config") // name of config file (without extension)
-	viper.SetConfigType("json")   // REQUIRED if the config file does not have the extension in the name
-	viper.AddConfigPath(".")      // optionally look for config in the working directory
+	viper.SetConfigName("config")       // name of config file (without extension)
+	viper.SetConfigType("json")         // REQUIRED if the config file does not have the extension in the name
+	viper.AddConfigPath("/run/secrets") // check secrets folder for config files first (e.g., for docker)
+	viper.AddConfigPath(".")            // optionally look for config in the working directory
 	viper.SetEnvPrefix("focalboard")
 	viper.AutomaticEnv() // read config values from env like FOCALBOARD_SERVERROOT=...
 	viper.SetDefault("ServerRoot", DefaultServerRoot)


### PR DESCRIPTION
#### Summary
This makes it easier to use Docker secrets with Focalboard.
The change is backwards-compatible, since if there is no /run/secrets/config.json then
we use ./config.json as usual.
