### PR TITLE
GH-1244 add setting -webkit-user-select and others for MenuWrapper

### DIFF
--- a/webapp/src/widgets/menuWrapper.scss
+++ b/webapp/src/widgets/menuWrapper.scss
@@ -6,10 +6,13 @@
         cursor: default;
     }
 
-    *:first-child {
+    
+    *:first-child { 
+        /* stylelint-disable property-no-vendor-prefix*/
         -webkit-user-select: text; /* Chrome all / Safari all */
         -moz-user-select: text; /* Firefox all */
         -ms-user-select: text; /* IE 10+ */
         user-select: text;
+        /* stylelint-enable property-no-vendor-prefix*/
     }
 }

--- a/webapp/src/widgets/menuWrapper.scss
+++ b/webapp/src/widgets/menuWrapper.scss
@@ -7,6 +7,9 @@
     }
 
     *:first-child {
+        -webkit-user-select: text; /* Chrome all / Safari all */
+        -moz-user-select: text; /* Firefox all */
+        -ms-user-select: text; /* IE 10+ */
         user-select: text;
     }
 }


### PR DESCRIPTION
#### Summary
Adds settings 
    -webkit-user-select: text; /* Chrome all / Safari all */
    -moz-user-select: text; /* Firefox all */
    -ms-user-select: text; /* IE 10+ */

for .MenuWrapper *:firstChild{}

All other places we set `user-select: text;`, we set these as well.

Related to -
https://github.com/mattermost/focalboard/pull/1094

#### Ticket Link

  Fixes https://github.com/mattermost/focalboard/issues/1244


