### PR TITLE
Adds workspaceID to blocks and makes board page only reacts to the workspace updates

### DIFF
--- a/server/app/blocks.go
+++ b/server/app/blocks.go
@@ -76,7 +76,7 @@ func (a *App) InsertBlocks(c store.Container, blocks []model.Block, userID strin
 		if err != nil {
 			return err
 		}
-
+		blocks[i].WorkspaceID = c.WorkspaceID
 		needsNotify = append(needsNotify, blocks[i])
 
 		a.wsAdapter.BroadcastBlockChange(c.WorkspaceID, blocks[i])

--- a/server/model/block.go
+++ b/server/model/block.go
@@ -55,6 +55,10 @@ type Block struct {
 	// The deleted time. Set to indicate this block is deleted
 	// required: false
 	DeleteAt int64 `json:"deleteAt"`
+
+	// The workspace id that the block belongs to
+	// required: true
+	WorkspaceID string `json:"workspaceId"`
 }
 
 // BlockPatch is a patch for modify blocks

--- a/server/services/store/sqlstore/blocks.go
+++ b/server/services/store/sqlstore/blocks.go
@@ -32,22 +32,27 @@ func (be BlockNotFoundErr) Error() string {
 	return fmt.Sprintf("block not found (block id: %s", be.blockID)
 }
 
+func (s *SQLStore) blockFields() []string {
+	return []string{
+		"id",
+		"parent_id",
+		"root_id",
+		"created_by",
+		"modified_by",
+		s.escapeField("schema"),
+		"type",
+		"title",
+		"COALESCE(fields, '{}')",
+		"create_at",
+		"update_at",
+		"delete_at",
+		"COALESCE(workspace_id, '0')",
+	}
+}
+
 func (s *SQLStore) GetBlocksWithParentAndType(c store.Container, parentID string, blockType string) ([]model.Block, error) {
 	query := s.getQueryBuilder().
-		Select(
-			"id",
-			"parent_id",
-			"root_id",
-			"created_by",
-			"modified_by",
-			s.escapeField("schema"),
-			"type",
-			"title",
-			"COALESCE(fields, '{}')",
-			"create_at",
-			"update_at",
-			"delete_at",
-		).
+		Select(s.blockFields()...).
 		From(s.tablePrefix + "blocks").
 		Where(sq.Eq{"COALESCE(workspace_id, '0')": c.WorkspaceID}).
 		Where(sq.Eq{"parent_id": parentID}).
@@ -66,20 +71,7 @@ func (s *SQLStore) GetBlocksWithParentAndType(c store.Container, parentID string
 
 func (s *SQLStore) GetBlocksWithParent(c store.Container, parentID string) ([]model.Block, error) {
 	query := s.getQueryBuilder().
-		Select(
-			"id",
-			"parent_id",
-			"root_id",
-			"created_by",
-			"modified_by",
-			s.escapeField("schema"),
-			"type",
-			"title",
-			"COALESCE(fields, '{}')",
-			"create_at",
-			"update_at",
-			"delete_at",
-		).
+		Select(s.blockFields()...).
 		From(s.tablePrefix + "blocks").
 		Where(sq.Eq{"parent_id": parentID}).
 		Where(sq.Eq{"coalesce(workspace_id, '0')": c.WorkspaceID})
@@ -97,20 +89,7 @@ func (s *SQLStore) GetBlocksWithParent(c store.Container, parentID string) ([]mo
 
 func (s *SQLStore) GetBlocksWithRootID(c store.Container, rootID string) ([]model.Block, error) {
 	query := s.getQueryBuilder().
-		Select(
-			"id",
-			"parent_id",
-			"root_id",
-			"created_by",
-			"modified_by",
-			s.escapeField("schema"),
-			"type",
-			"title",
-			"COALESCE(fields, '{}')",
-			"create_at",
-			"update_at",
-			"delete_at",
-		).
+		Select(s.blockFields()...).
 		From(s.tablePrefix + "blocks").
 		Where(sq.Eq{"root_id": rootID}).
 		Where(sq.Eq{"coalesce(workspace_id, '0')": c.WorkspaceID})
@@ -128,20 +107,7 @@ func (s *SQLStore) GetBlocksWithRootID(c store.Container, rootID string) ([]mode
 
 func (s *SQLStore) GetBlocksWithType(c store.Container, blockType string) ([]model.Block, error) {
 	query := s.getQueryBuilder().
-		Select(
-			"id",
-			"parent_id",
-			"root_id",
-			"created_by",
-			"modified_by",
-			s.escapeField("schema"),
-			"type",
-			"title",
-			"COALESCE(fields, '{}')",
-			"create_at",
-			"update_at",
-			"delete_at",
-		).
+		Select(s.blockFields()...).
 		From(s.tablePrefix + "blocks").
 		Where(sq.Eq{"type": blockType}).
 		Where(sq.Eq{"coalesce(workspace_id, '0')": c.WorkspaceID})
@@ -160,20 +126,7 @@ func (s *SQLStore) GetBlocksWithType(c store.Container, blockType string) ([]mod
 // GetSubTree2 returns blocks within 2 levels of the given blockID.
 func (s *SQLStore) GetSubTree2(c store.Container, blockID string) ([]model.Block, error) {
 	query := s.getQueryBuilder().
-		Select(
-			"id",
-			"parent_id",
-			"root_id",
-			"created_by",
-			"modified_by",
-			s.escapeField("schema"),
-			"type",
-			"title",
-			"COALESCE(fields, '{}')",
-			"create_at",
-			"update_at",
-			"delete_at",
-		).
+		Select(s.blockFields()...).
 		From(s.tablePrefix + "blocks").
 		Where(sq.Or{sq.Eq{"id": blockID}, sq.Eq{"parent_id": blockID}}).
 		Where(sq.Eq{"coalesce(workspace_id, '0')": c.WorkspaceID})
@@ -205,6 +158,7 @@ func (s *SQLStore) GetSubTree3(c store.Container, blockID string) ([]model.Block
 		"l3.create_at",
 		"l3.update_at",
 		"l3.delete_at",
+		"COALESCE(l3.workspace_id, '0')",
 	).
 		From(s.tablePrefix + "blocks as l1").
 		Join(s.tablePrefix + "blocks as l2 on l2.parent_id = l1.id or l2.id = l1.id").
@@ -231,20 +185,7 @@ func (s *SQLStore) GetSubTree3(c store.Container, blockID string) ([]model.Block
 
 func (s *SQLStore) GetAllBlocks(c store.Container) ([]model.Block, error) {
 	query := s.getQueryBuilder().
-		Select(
-			"id",
-			"parent_id",
-			"root_id",
-			"created_by",
-			"modified_by",
-			s.escapeField("schema"),
-			"type",
-			"title",
-			"COALESCE(fields, '{}')",
-			"create_at",
-			"update_at",
-			"delete_at",
-		).
+		Select(s.blockFields()...).
 		From(s.tablePrefix + "blocks").
 		Where(sq.Eq{"coalesce(workspace_id, '0')": c.WorkspaceID})
 
@@ -279,7 +220,8 @@ func (s *SQLStore) blocksFromRows(rows *sql.Rows) ([]model.Block, error) {
 			&fieldsJSON,
 			&block.CreateAt,
 			&block.UpdateAt,
-			&block.DeleteAt)
+			&block.DeleteAt,
+			&block.WorkspaceID)
 		if err != nil {
 			// handle this error
 			s.logger.Error(`ERROR blocksFromRows`, mlog.Err(err))
@@ -568,20 +510,7 @@ func (s *SQLStore) GetBlockCountsByType() (map[string]int64, error) {
 
 func (s *SQLStore) GetBlock(c store.Container, blockID string) (*model.Block, error) {
 	query := s.getQueryBuilder().
-		Select(
-			"id",
-			"parent_id",
-			"root_id",
-			"created_by",
-			"modified_by",
-			s.escapeField("schema"),
-			"type",
-			"title",
-			"COALESCE(fields, '{}')",
-			"create_at",
-			"update_at",
-			"delete_at",
-		).
+		Select(s.blockFields()...).
 		From(s.tablePrefix + "blocks").
 		Where(sq.Eq{"id": blockID}).
 		Where(sq.Eq{"coalesce(workspace_id, '0')": c.WorkspaceID})

--- a/server/ws/plugin_adapter.go
+++ b/server/ws/plugin_adapter.go
@@ -358,6 +358,7 @@ func (pa *PluginAdapter) BroadcastBlockDelete(workspaceID, blockID, parentID str
 	block.ParentID = parentID
 	block.UpdateAt = now
 	block.DeleteAt = now
+	block.WorkspaceID = workspaceID
 
 	pa.BroadcastBlockChange(workspaceID, block)
 }

--- a/server/ws/server.go
+++ b/server/ws/server.go
@@ -470,6 +470,7 @@ func (ws *Server) BroadcastBlockDelete(workspaceID, blockID, parentID string) {
 	block.ParentID = parentID
 	block.UpdateAt = now
 	block.DeleteAt = now
+	block.WorkspaceID = workspaceID
 
 	ws.BroadcastBlockChange(workspaceID, block)
 }

--- a/webapp/src/blocks/block.ts
+++ b/webapp/src/blocks/block.ts
@@ -9,6 +9,7 @@ type ContentBlockTypes = typeof contentBlockTypes[number]
 type BlockTypes = typeof blockTypes[number]
 
 interface BlockPatch {
+    workspaceId?: string
     parentId?: string
     rootId?: string
     schema?: number
@@ -21,6 +22,7 @@ interface BlockPatch {
 
 interface Block {
     id: string
+    workspaceId: string
     parentId: string
     rootId: string
     createdBy: string
@@ -41,6 +43,7 @@ function createBlock(block?: Block): Block {
     return {
         id: block?.id || Utils.createGuid(),
         schema: 1,
+        workspaceId: block?.workspaceId || '',
         parentId: block?.parentId || '',
         rootId: block?.rootId || '',
         createdBy: block?.createdBy || '',

--- a/webapp/src/components/content/checkboxElement.test.tsx
+++ b/webapp/src/components/content/checkboxElement.test.tsx
@@ -17,6 +17,7 @@ const wrapIntl = (children: any) => <IntlProvider locale='en'>{children}</IntlPr
 describe('components/content/CheckboxElement', () => {
     const defaultBlock: ContentBlock = {
         id: 'test-id',
+        workspaceId: '',
         parentId: '',
         rootId: '',
         modifiedBy: 'test-user-id',

--- a/webapp/src/pages/boardPage.tsx
+++ b/webapp/src/pages/boardPage.tsx
@@ -152,12 +152,15 @@ const BoardPage = (props: Props) => {
         }
 
         const incrementalUpdate = (_: WSClient, blocks: Block[]) => {
+            // only takes into account the blocks that belong to the workspace
+            const workspaceBlocks = blocks.filter((b: Block) => b.workspaceId === '0' || b.workspaceId === workspaceId)
+
             batch(() => {
-                dispatch(updateBoards(blocks.filter((b: Block) => b.type === 'board' || b.deleteAt !== 0) as Board[]))
-                dispatch(updateViews(blocks.filter((b: Block) => b.type === 'view' || b.deleteAt !== 0) as BoardView[]))
-                dispatch(updateCards(blocks.filter((b: Block) => b.type === 'card' || b.deleteAt !== 0) as Card[]))
-                dispatch(updateComments(blocks.filter((b: Block) => b.type === 'comment' || b.deleteAt !== 0) as CommentBlock[]))
-                dispatch(updateContents(blocks.filter((b: Block) => b.type !== 'card' && b.type !== 'view' && b.type !== 'board' && b.type !== 'comment') as ContentBlock[]))
+                dispatch(updateBoards(workspaceBlocks.filter((b: Block) => b.type === 'board' || b.deleteAt !== 0) as Board[]))
+                dispatch(updateViews(workspaceBlocks.filter((b: Block) => b.type === 'view' || b.deleteAt !== 0) as BoardView[]))
+                dispatch(updateCards(workspaceBlocks.filter((b: Block) => b.type === 'card' || b.deleteAt !== 0) as Card[]))
+                dispatch(updateComments(workspaceBlocks.filter((b: Block) => b.type === 'comment' || b.deleteAt !== 0) as CommentBlock[]))
+                dispatch(updateContents(workspaceBlocks.filter((b: Block) => b.type !== 'card' && b.type !== 'view' && b.type !== 'board' && b.type !== 'comment') as ContentBlock[]))
             })
         }
 


### PR DESCRIPTION
#### Summary
This PR adds the `workspaceID` property to the blocks when they're retrieved from the store and makes the boards page react only to those updates that are aimed at the workspace that the user is currently in.

Fixes https://github.com/mattermost/focalboard/issues/1280
