### PR TITLE
[GH-1291] Fix drag and drop for gallery card

### DIFF
--- a/webapp/src/components/gallery/galleryCard.scss
+++ b/webapp/src/components/gallery/galleryCard.scss
@@ -9,6 +9,9 @@
     margin-bottom: 10px;
     cursor: pointer;
 
+    // HACK: Fixes Chrome drag and drop preview
+    transform: translate3d(0, 0, 0);
+
     &.selected {
         background-color: rgba(90, 200, 255, 0.2);
     }
@@ -45,6 +48,7 @@
         opacity: 0.7;
         max-height: 160px;
         min-height: 160px;
+        pointer-events: none;
 
         .CheckboxElement {
             .Editable {


### PR DESCRIPTION
#### Summary
Fixes for drag and drop of gallery card:
  - use `translate3d` workaround for proper preview in Chrome
  - set `pointer-events` to `none` to prevent image opening in Firefox

#### Ticket Link
Fixes #1291 and #1265