### PR TITLE
disable flakey test

### DIFF
--- a/server/integrationtests/blocks_test.go
+++ b/server/integrationtests/blocks_test.go
@@ -289,6 +289,8 @@ func TestDeleteBlock(t *testing.T) {
 }
 
 func TestGetSubtree(t *testing.T) {
+	t.Skip("TODO: fix flaky test")
+
 	th := SetupTestHelper().InitBasic()
 	defer th.TearDown()
 


### PR DESCRIPTION
#### Summary
Disables Flakey Server Test - TestGetSubTree
created ticket to fix and reenable (https://github.com/mattermost/focalboard/issues/1305)

#### Ticket Link

  Fixes https://github.com/mattermost/focalboard/issues/1232

