### PR TITLE
Fix #1285. Don't set property for notIncludes filter.

### DIFF
--- a/webapp/src/cardFilter.ts
+++ b/webapp/src/cardFilter.ts
@@ -118,20 +118,6 @@ class CardFilter {
             return {id: filterClause.propertyId, value: filterClause.values[0]}
         }
         case 'notIncludes': {
-            if (filterClause.values.length < 1) {
-                return {id: filterClause.propertyId}
-            }
-            if (template.type === 'select') {
-                const option = template.options.find((o) => !filterClause.values.includes(o.id))
-                if (option) {
-                    return {id: filterClause.propertyId, value: option.id}
-                }
-
-                // No other options exist
-                return {id: filterClause.propertyId}
-            }
-
-            // TODO: Handle non-select types
             return {id: filterClause.propertyId}
         }
         case 'isEmpty': {


### PR DESCRIPTION
When the filter has a "notIncludes" clause, don't set a property value for new cards. The intent of this code is so that new cards appear with the current filter settings. However, the previous behavior of setting the value to another unfiltered value is unnecessary.