### PR TITLE
Ignores manifest.go file on watch-plugin to avoid reboot loop

### DIFF
--- a/modd-watchplugin.conf
+++ b/modd-watchplugin.conf
@@ -1,4 +1,4 @@
-**/*.go !**/*_test.go {
+**/*.go !**/*_test.go !mattermost-plugin/server/manifest.go {
     indir: mattermost-plugin
     prep: make server deploy-from-watch
 }


### PR DESCRIPTION
#### Summary
In some cases both server and webapp commands can collide when first starting as the server watcher was watching for changes on the `manifest.go` file, which is generated by both targets.

This PR ignores that file so no build loop happens.
