### PR TITLE
GH-1312 - Update title when running a plugin

### DIFF
--- a/webapp/src/pages/boardPage.tsx
+++ b/webapp/src/pages/boardPage.tsx
@@ -132,7 +132,7 @@ const BoardPage = (props: Props) => {
             }
             document.title = title
         } else if (Utils.isFocalboardPlugin()) {
-            document.title = 'Mattermost - Boards'
+            document.title = 'Boards - Mattermost'
         } else {
             document.title = 'Focalboard'
         }

--- a/webapp/src/pages/boardPage.tsx
+++ b/webapp/src/pages/boardPage.tsx
@@ -131,6 +131,8 @@ const BoardPage = (props: Props) => {
                 title += ` | ${activeView.title}`
             }
             document.title = title
+        } else if (Utils.isFocalboardPlugin()) {
+            document.title = 'Mattermost - Boards'
         } else {
             document.title = 'Focalboard'
         }


### PR DESCRIPTION
#### Summary
Currently, the page title is "Focalboard". When running as a plugin, the page title should be "Boards - Mattermost" to align with the new branding. Personal Editions should continue to be titled "Focalboard"

This is only displayed when No Board is selected.

#### Ticket Link

  Fixes https://github.com/mattermost/focalboard/issues/1312

Plugin (notice url)
  
![Screen Shot 2021-09-22 at 12 30 48 PM](https://user-images.githubusercontent.com/12704875/134401353-99813de0-303e-497e-af02-2e8606b92d41.png)

Personal Server (notice url)

![Screen Shot 2021-09-22 at 12 30 05 PM](https://user-images.githubusercontent.com/12704875/134401357-8c0fbf43-2d65-41e2-bc51-39cdf171d0ff.png)


