### PR TITLE
MM-38807 Fix tiny icons caused by css pollution

### DIFF
--- a/mattermost-plugin/webapp/loaders/globalScssClassLoader.js
+++ b/mattermost-plugin/webapp/loaders/globalScssClassLoader.js
@@ -4,7 +4,7 @@
 function blockList(line) {
     return line.startsWith('.focalboard-body') ||
         line.startsWith('.GlobalHeaderComponent') ||
-        line.startsWith('.channel-header__icon .LogoIcon') ||
+        line.startsWith('.boards-rhs-icon') ||
         line.startsWith('.focalboard-plugin-root');
 }
 

--- a/mattermost-plugin/webapp/src/plugin.scss
+++ b/mattermost-plugin/webapp/src/plugin.scss
@@ -1,8 +1,5 @@
-.channel-header__icon .LogoIcon {
-    height: 24px;
-    font-size: 16px;
-    display: flex;
-    align-items: center;
+.boards-rhs-icon {
+    font-size: 20px;
 }
 
 .focalboard-body .feature-global-header>header {

--- a/webapp/src/widgets/icons/logo.tsx
+++ b/webapp/src/widgets/icons/logo.tsx
@@ -10,7 +10,7 @@ export default function LogoIcon(): JSX.Element {
     return (
         <CompassIcon
             icon='product-boards'
-            className='LogoIcon'
+            className='boards-rhs-icon'
         />
     )
 }


### PR DESCRIPTION
#### Summary
Fixing tiny icons caused by CSS pollution. 

Tiny icons on community:
![image](https://user-images.githubusercontent.com/3191642/134595138-3a40bf40-5c45-4ec4-9256-d2ed0cdc7e15.png)
Fixed version:
![image](https://user-images.githubusercontent.com/3191642/134595111-6f8d5811-7577-432f-b344-5af1b141104f.png)


#### Ticket Link

https://mattermost.atlassian.net/browse/MM-38807
