### PR TITLE
Fix #1365. Run CI workflows on release branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: Check-in tests
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, release-** ]
   pull_request:
     branches: [ main ]
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,7 +13,7 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, release-** ]
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ main ]

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -2,7 +2,7 @@ name: Dev-Release
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, release-** ]
   pull_request:
     branches: [ main ]
   workflow_dispatch:

--- a/.github/workflows/lint-plugin.yml
+++ b/.github/workflows/lint-plugin.yml
@@ -2,7 +2,7 @@ name: golangci-lint
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, release-** ]
   pull_request:
     branches: [ main ]
 

--- a/.github/workflows/lint-server.yml
+++ b/.github/workflows/lint-server.yml
@@ -2,7 +2,7 @@ name: golangci-lint
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, release-** ]
   pull_request:
     branches: [ main ]
 


### PR DESCRIPTION
Update workflow files to run on `release-**` branches in addition to main. Per [GitHub docs here](https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#onpushpull_requestbranchestags).