### PR TITLE
gh-1364 - remove file causing lint warnings

### DIFF
--- a/webapp/@custom_types/pgtools.d.ts
+++ b/webapp/@custom_types/pgtools.d.ts
@@ -1,6 +1,0 @@
-// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
-// See LICENSE.txt for license information.
-export function createdb(opts: any, dbName: any, cb?: any): any
-
-export function dropdb(opts: any, dbName: any, cb?: any): any
-


### PR DESCRIPTION
#### Summary
This pr removes the file `webapp/@custom_types/pgtools.d.ts`

I could not find any reference to this file anywhere. Not in package.json. Nor could I find any reference to the functions exported from this file. 

It is causing lint warnings, rather than attempt to fix, remove the file.

#### Ticket Link
  Fixes https://github.com/mattermost/focalboard/issues/1364

