### PR TITLE
Update responsibile_disclosure_policy.md

### DIFF
--- a/responsibile_disclosure_policy.md
+++ b/responsibile_disclosure_policy.md
@@ -1,6 +1,6 @@
 # Responsible Disclosure Policy
 
-Safety and data security is of utmost priority for the Focalboard community. If you are a security researcher and have discovered a security vulnerability in our code base, we appreciate your help in disclosing it to us in a responsible manner.
+Safety and data security are of utmost priority for the Focalboard community. If you are a security researcher and have discovered a security vulnerability in our codebase, we appreciate your help in disclosing it to us in a responsible manner.
 
 Please contact us at `chen [at] mattermost.com` to report any security vulnerabilities found in our open source code base. 
 
@@ -10,7 +10,7 @@ We will acknowledge receipt of your vulnerability report and send you regular up
 
 If your report is reproducible as an exploit and results in a change to the code base or documentation of a Focalboard product, we will–-at your option–-publicly acknowledge your responsible disclosure.
 
-After a fix is made, we ask security researchers to wait 30 days after a release before announcing the specific details of a vulnerability, and to provide Focalboard with a link to any such announcements. In releases containing security fixes, Focalboard announces an update is available, acknowledges the contributions of security researches, and it withholds specific details until 30 days after availability to give time for the community to apply updates.
+After a fix is made, we ask security researchers to wait 30 days after a release before announcing the specific details of a vulnerability, and to provide Focalboard with a link to any such announcements. In releases containing security fixes, Focalboard announces an update is available, acknowledges the contributions of security researchers, and it withholds specific details until 30 days after availability to give time for the community to apply updates.
 
 You are not allowed to search for vulnerabilities on any instance of Focalboard hosted by the team, users, or customers with the exception of non-disruptive testing on the community test server mentioned above.
 

--- a/responsible_disclosure_policy.md
+++ b/responsible_disclosure_policy.md
@@ -2,13 +2,13 @@
 
 Safety and data security are of utmost priority for the Focalboard community. If you are a security researcher and have discovered a security vulnerability in our codebase, we appreciate your help in disclosing it to us in a responsible manner.
 
-Please contact us at `chen [at] mattermost.com` to report any security vulnerabilities found in our open source code base. 
+Please contact us at `chen [at] mattermost.com` to report any security vulnerabilities found in our open source codebase.
 
 Please refrain from requesting compensation for reporting vulnerabilities.
 
 We will acknowledge receipt of your vulnerability report and send you regular updates about our progress.
 
-If your report is reproducible as an exploit and results in a change to the code base or documentation of a Focalboard product, we will–-at your option–-publicly acknowledge your responsible disclosure.
+If your report is reproducible as an exploit and results in a change to the codebase or documentation of a Focalboard product, we will–-at your option–-publicly acknowledge your responsible disclosure.
 
 After a fix is made, we ask security researchers to wait 30 days after a release before announcing the specific details of a vulnerability, and to provide Focalboard with a link to any such announcements. In releases containing security fixes, Focalboard announces an update is available, acknowledges the contributions of security researchers, and it withholds specific details until 30 days after availability to give time for the community to apply updates.
 


### PR DESCRIPTION
#### Summary
Update _responsibile_disclosure_policy.md_
 - Use "are" for plural
 - "codebase" and "code base" are two different things
 - I think "researches" was meant to be "researchers"
