### PR TITLE
Run all CI on PRs to be merged with release branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ main, release-** ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, release-** ]
 
 jobs:
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -16,7 +16,7 @@ on:
     branches: [ main, release-** ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ main ]
+    branches: [ main, release-** ]
   schedule:
     - cron: '30 4 * * 0'
 

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ main, release-** ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, release-** ]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/lint-plugin.yml
+++ b/.github/workflows/lint-plugin.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ main, release-** ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, release-** ]
 
 jobs:
   golangci:

--- a/.github/workflows/lint-server.yml
+++ b/.github/workflows/lint-server.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ main, release-** ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, release-** ]
 
 jobs:
   golangci:


### PR DESCRIPTION
#### Summary
A recent cherry-pick via PR caused the release branch to have linter errors because CI was not run against PR's to be merged into release branches.  This PR ensures full CI is run for these cases.

#### Ticket Link
https://github.com/mattermost/focalboard/issues/1365