### PR TITLE
[GH-1331] Fix for URL property on kanban card

### DIFF
--- a/webapp/src/components/kanban/kanbanCard.scss
+++ b/webapp/src/components/kanban/kanbanCard.scss
@@ -41,12 +41,14 @@
     }
 
     .octo-propertyvalue {
-        margin: 4px 0 0;
-        font-size: 12px;
-        line-height: 18px;
-
-        &:empty {
+        input[value=''] {
             display: none;
+        }
+
+        .Label.empty {
+            display: block;
+            padding: 0;
+            margin: 0;
         }
     }
 

--- a/webapp/src/components/properties/link/link.tsx
+++ b/webapp/src/components/properties/link/link.tsx
@@ -21,7 +21,8 @@ type Props = {
 
 const URLProperty = (props: Props): JSX.Element => {
     let link: ReactNode = null
-    if (props.value?.trim()) {
+    const hasValue = Boolean(props.value?.trim())
+    if (hasValue) {
         link = (
             <a
                 className='Link__button'
@@ -37,6 +38,7 @@ const URLProperty = (props: Props): JSX.Element => {
 
     return (
         <div className='URLProperty property-link url'>
+            {(hasValue || props.placeholder) &&
             <Editable
                 className='octo-propertyvalue'
                 placeholderText={props.placeholder}
@@ -47,7 +49,7 @@ const URLProperty = (props: Props): JSX.Element => {
                 onSave={props.onSave}
                 onCancel={props.onCancel}
                 validator={props.validator}
-            />
+            />}
             {link}
         </div>
     )

--- a/webapp/src/widgets/label.scss
+++ b/webapp/src/widgets/label.scss
@@ -14,7 +14,7 @@
 
     &.empty {
         color: rgba(var(--center-channel-color-rgb), 0.4);
-        padding: 3px;
+        padding: 1px;
         text-transform: none;
         font-weight: normal;
     }


### PR DESCRIPTION
#### Summary
Fix displaying properties on kanban cards:
  - hide URL property only when it is empty
  - hide empty labels for Select/Multi Select properties

Here is how it looks (non-empty URL property is visible, empty property values are collapsed):
![image](https://user-images.githubusercontent.com/5587620/135677889-5f9a4524-5377-4827-ad47-62dbb31683c9.png)

Also minor tweak for proper alignment of Select/Multi Select empty labels:
![image](https://user-images.githubusercontent.com/5587620/135678148-fb05b284-999f-4dce-adf5-65271f36de6a.png)

#### Ticket Link
Fixes #1331
