### PR TITLE
solve lintern problems setting types

### DIFF
--- a/webapp/src/utils.ts
+++ b/webapp/src/utils.ts
@@ -151,7 +151,7 @@ class Utils {
     static htmlFromMarkdown(text: string): string {
         // HACKHACK: Somehow, marked doesn't encode angle brackets
         const renderer = new marked.Renderer()
-        renderer.link = (href, title, contents) => {
+        renderer.link = (href: string | null, title: string | null, contents: string | null) => {
             return '<a ' +
                 'target="_blank" ' +
                 'rel="noreferrer" ' +


### PR DESCRIPTION
#### Summary
I fix linter warnings for file utils.ts defining the type for a returned variables in line 154 based on the returned variable types from marked.Renderer().

#### Ticket Link
Fixes https://github.com/mattermost/focalboard/issues/1356


