### PR TITLE
Progress for webpack watch mode

### DIFF
--- a/webapp/package.json
+++ b/webapp/package.json
@@ -6,7 +6,7 @@
 	"scripts": {
 		"pack": "cross-env NODE_ENV=production webpack --config webpack.prod.js",
 		"packdev": "cross-env NODE_ENV=dev webpack --config webpack.dev.js",
-		"watchdev": "cross-env NODE_ENV=dev webpack --watch --config webpack.dev.js",
+		"watchdev": "cross-env NODE_ENV=dev webpack --watch --progress --config webpack.dev.js",
 		"test": "jest",
 		"updatesnapshot": "jest --updateSnapshot",
 		"check": "eslint --ext .tsx,.ts . --quiet --cache && stylelint **/*.scss",


### PR DESCRIPTION
#### Summary
Added `--progress` for `watchdev` npm script. This allows to show progress when webpack is in watch mode, similar to what is used in [webapp repo](https://github.com/mattermost/mattermost-webapp/blob/master/package.json#L285).

#### Ticket Link
No ticket link.