### PR TITLE
[GH-705] Auto-name new property

### DIFF
--- a/webapp/src/components/cardDetail/__snapshots__/cardDetailProperties.test.tsx.snap
+++ b/webapp/src/components/cardDetail/__snapshots__/cardDetailProperties.test.tsx.snap
@@ -64,7 +64,7 @@ exports[`components/cardDetail/CardDetailProperties should match snapshot 1`] = 
 </div>
 `;
 
-exports[`components/cardDetail/CardDetailProperties shows menu with property types when adding new property 1`] = `
+exports[`components/cardDetail/CardDetailProperties should show property types menu 1`] = `
 <div>
   <div
     class="octo-propertylist CardDetailProperties"

--- a/webapp/src/components/cardDetail/__snapshots__/cardDetailProperties.test.tsx.snap
+++ b/webapp/src/components/cardDetail/__snapshots__/cardDetailProperties.test.tsx.snap
@@ -63,3 +63,361 @@ exports[`components/cardDetail/CardDetailProperties should match snapshot 1`] = 
   </div>
 </div>
 `;
+
+exports[`components/cardDetail/CardDetailProperties shows menu with property types when adding new property 1`] = `
+<div>
+  <div
+    class="octo-propertylist CardDetailProperties"
+  >
+    <div
+      class="octo-propertyrow"
+    >
+      <div
+        aria-label="menuwrapper"
+        class="MenuWrapper"
+        role="button"
+      >
+        <div
+          class="octo-propertyname"
+        >
+          <button
+            class="Button    "
+            type="button"
+          >
+            <span>
+              Owner
+            </span>
+          </button>
+        </div>
+      </div>
+      <div
+        class="octo-propertyvalue"
+        data-testid="select-non-editable"
+        tabindex="0"
+      >
+        <span
+          class="Label propColorDefault "
+        >
+          <span
+            class="Label-text"
+          >
+            Jean-Luc Picard
+          </span>
+        </span>
+      </div>
+    </div>
+    <div
+      aria-label="menuwrapper"
+      class="MenuWrapper"
+      role="button"
+    >
+      <div
+        class="octo-propertyname add-property"
+      >
+        <button
+          class="Button    "
+          type="button"
+        >
+          <span>
+            + Add a property
+          </span>
+        </button>
+      </div>
+      <div
+        class="Menu noselect bottom"
+      >
+        <div
+          class="menu-contents"
+        >
+          <div
+            class="menu-options"
+          >
+            <div
+              class="MenuOption LabelOption menu-option"
+            >
+              <div
+                class="noicon"
+              />
+              <div
+                class="menu-name"
+              >
+                <b>
+                  Select property type
+                </b>
+              </div>
+              <div
+                class="noicon"
+              />
+            </div>
+            <div
+              class="MenuOption MenuSeparator menu-separator"
+            />
+            <div
+              aria-label="Text"
+              class="MenuOption TextOption menu-option"
+              role="button"
+            >
+              <div
+                class="noicon"
+              />
+              <div
+                class="menu-name"
+              >
+                Text
+              </div>
+              <div
+                class="noicon"
+              />
+            </div>
+            <div
+              aria-label="Number"
+              class="MenuOption TextOption menu-option"
+              role="button"
+            >
+              <div
+                class="noicon"
+              />
+              <div
+                class="menu-name"
+              >
+                Number
+              </div>
+              <div
+                class="noicon"
+              />
+            </div>
+            <div
+              aria-label="Email"
+              class="MenuOption TextOption menu-option"
+              role="button"
+            >
+              <div
+                class="noicon"
+              />
+              <div
+                class="menu-name"
+              >
+                Email
+              </div>
+              <div
+                class="noicon"
+              />
+            </div>
+            <div
+              aria-label="Phone"
+              class="MenuOption TextOption menu-option"
+              role="button"
+            >
+              <div
+                class="noicon"
+              />
+              <div
+                class="menu-name"
+              >
+                Phone
+              </div>
+              <div
+                class="noicon"
+              />
+            </div>
+            <div
+              aria-label="URL"
+              class="MenuOption TextOption menu-option"
+              role="button"
+            >
+              <div
+                class="noicon"
+              />
+              <div
+                class="menu-name"
+              >
+                URL
+              </div>
+              <div
+                class="noicon"
+              />
+            </div>
+            <div
+              aria-label="Select"
+              class="MenuOption TextOption menu-option"
+              role="button"
+            >
+              <div
+                class="noicon"
+              />
+              <div
+                class="menu-name"
+              >
+                Select
+              </div>
+              <div
+                class="noicon"
+              />
+            </div>
+            <div
+              aria-label="Multi Select"
+              class="MenuOption TextOption menu-option"
+              role="button"
+            >
+              <div
+                class="noicon"
+              />
+              <div
+                class="menu-name"
+              >
+                Multi Select
+              </div>
+              <div
+                class="noicon"
+              />
+            </div>
+            <div
+              aria-label="Date"
+              class="MenuOption TextOption menu-option"
+              role="button"
+            >
+              <div
+                class="noicon"
+              />
+              <div
+                class="menu-name"
+              >
+                Date
+              </div>
+              <div
+                class="noicon"
+              />
+            </div>
+            <div
+              aria-label="Person"
+              class="MenuOption TextOption menu-option"
+              role="button"
+            >
+              <div
+                class="noicon"
+              />
+              <div
+                class="menu-name"
+              >
+                Person
+              </div>
+              <div
+                class="noicon"
+              />
+            </div>
+            <div
+              aria-label="Checkbox"
+              class="MenuOption TextOption menu-option"
+              role="button"
+            >
+              <div
+                class="noicon"
+              />
+              <div
+                class="menu-name"
+              >
+                Checkbox
+              </div>
+              <div
+                class="noicon"
+              />
+            </div>
+            <div
+              aria-label="Created time"
+              class="MenuOption TextOption menu-option"
+              role="button"
+            >
+              <div
+                class="noicon"
+              />
+              <div
+                class="menu-name"
+              >
+                Created time
+              </div>
+              <div
+                class="noicon"
+              />
+            </div>
+            <div
+              aria-label="Created by"
+              class="MenuOption TextOption menu-option"
+              role="button"
+            >
+              <div
+                class="noicon"
+              />
+              <div
+                class="menu-name"
+              >
+                Created by
+              </div>
+              <div
+                class="noicon"
+              />
+            </div>
+            <div
+              aria-label="Last updated time"
+              class="MenuOption TextOption menu-option"
+              role="button"
+            >
+              <div
+                class="noicon"
+              />
+              <div
+                class="menu-name"
+              >
+                Last updated time
+              </div>
+              <div
+                class="noicon"
+              />
+            </div>
+            <div
+              aria-label="Last updated by"
+              class="MenuOption TextOption menu-option"
+              role="button"
+            >
+              <div
+                class="noicon"
+              />
+              <div
+                class="menu-name"
+              >
+                Last updated by
+              </div>
+              <div
+                class="noicon"
+              />
+            </div>
+          </div>
+          <div
+            class="menu-spacer hideOnWidescreen"
+          />
+          <div
+            class="menu-options hideOnWidescreen"
+          >
+            <div
+              aria-label="Cancel"
+              class="MenuOption TextOption menu-option menu-cancel"
+              role="button"
+            >
+              <div
+                class="noicon"
+              />
+              <div
+                class="menu-name"
+              >
+                Cancel
+              </div>
+              <div
+                class="noicon"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/webapp/src/components/cardDetail/__snapshots__/cardDetailProperties.test.tsx.snap
+++ b/webapp/src/components/cardDetail/__snapshots__/cardDetailProperties.test.tsx.snap
@@ -43,16 +43,22 @@ exports[`components/cardDetail/CardDetailProperties should match snapshot 1`] = 
       </div>
     </div>
     <div
-      class="octo-propertyname add-property"
+      aria-label="menuwrapper"
+      class="MenuWrapper"
+      role="button"
     >
-      <button
-        class="Button    "
-        type="button"
+      <div
+        class="octo-propertyname add-property"
       >
-        <span>
-          + Add a property
-        </span>
-      </button>
+        <button
+          class="Button    "
+          type="button"
+        >
+          <span>
+            + Add a property
+          </span>
+        </button>
+      </div>
     </div>
   </div>
 </div>

--- a/webapp/src/components/cardDetail/cardDetail.scss
+++ b/webapp/src/components/cardDetail/cardDetail.scss
@@ -26,11 +26,6 @@
         display: flex;
         flex-direction: column;
         width: 100%;
-
-        .MenuWrapper {
-            position: relative;
-            align-self: center;
-        }
     }
 
     .octo-propertyrow {

--- a/webapp/src/components/cardDetail/cardDetailProperties.test.tsx
+++ b/webapp/src/components/cardDetail/cardDetailProperties.test.tsx
@@ -3,23 +3,17 @@
 import React from 'react'
 
 import {fireEvent, render} from '@testing-library/react'
-import {IntlProvider} from 'react-intl'
 import userEvent from '@testing-library/user-event'
+import {mocked} from 'ts-jest/utils'
 
+import {wrapIntl} from '../../testUtils'
 import {TestBlockFactory} from '../../test/testBlockFactory'
-import {FetchMock} from '../../test/fetchMock'
-
-import 'isomorphic-fetch'
+import mutator from '../../mutator'
 
 import CardDetailProperties from './cardDetailProperties'
 
-global.fetch = FetchMock.fn
-
-beforeEach(() => {
-    FetchMock.fn.mockReset()
-})
-
-const wrapIntl = (children: any) => <IntlProvider locale='en'>{children}</IntlProvider>
+jest.mock('../../mutator')
+const mockedMutator = mocked(mutator, true)
 
 describe('components/cardDetail/CardDetailProperties', () => {
     const board = TestBlockFactory.createBoard()
@@ -56,9 +50,6 @@ describe('components/cardDetail/CardDetailProperties', () => {
     const card = TestBlockFactory.createCard(board)
     card.fields.properties.property_id_1 = 'property_value_id_1'
 
-    const cardTemplate = TestBlockFactory.createCard(board)
-    cardTemplate.fields.isTemplate = true
-
     test('should match snapshot', async () => {
         const component = wrapIntl((
             <CardDetailProperties
@@ -78,11 +69,12 @@ describe('components/cardDetail/CardDetailProperties', () => {
     })
 
     test('rename select property', async () => {
+        const cards = [card]
         const component = wrapIntl((
             <CardDetailProperties
                 board={board!}
                 card={card}
-                cards={[card]}
+                cards={cards}
                 contents={[]}
                 comments={[]}
                 activeView={view}
@@ -96,22 +88,15 @@ describe('components/cardDetail/CardDetailProperties', () => {
         expect(propertyLabel).toBeDefined()
         fireEvent.click(propertyLabel!)
 
+        const newName = 'Owner - Renamed'
         const propertyNameInput = container.querySelector('.PropertyMenu.menu-textbox')
         expect(propertyNameInput).toBeDefined()
-        userEvent.type(propertyNameInput!, 'Owner - Renamed{enter}')
+        userEvent.type(propertyNameInput!, `${newName}{enter}`)
         fireEvent.click(propertyLabel!)
 
         // should be called once on renaming the property
-        expect(FetchMock.fn).toBeCalledTimes(1)
-
-        // Verify API call was made with renamed property
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
-        const lastAPICallPayload = JSON.parse(FetchMock.fn.mock.calls[0][1].body)
-        expect(lastAPICallPayload[0].fields.cardProperties[0].name).toBe('Owner - Renamed')
-        expect(lastAPICallPayload[0].fields.cardProperties[0].options.length).toBe(3)
-        expect(lastAPICallPayload[0].fields.cardProperties[0].options[0].value).toBe('Jean-Luc Picard')
-        expect(lastAPICallPayload[0].fields.cardProperties[0].options[1].value).toBe('William Riker')
-        expect(lastAPICallPayload[0].fields.cardProperties[0].options[2].value).toBe('Deanna Troi')
+        const propertyTemplate = board.fields.cardProperties[0]
+        expect(mockedMutator.changePropertyTypeAndName).toHaveBeenCalledTimes(1)
+        expect(mockedMutator.changePropertyTypeAndName).toHaveBeenCalledWith(board, cards, propertyTemplate, 'select', newName)
     })
 })

--- a/webapp/src/components/cardDetail/cardDetailProperties.test.tsx
+++ b/webapp/src/components/cardDetail/cardDetailProperties.test.tsx
@@ -2,13 +2,19 @@
 // See LICENSE.txt for license information.
 import React from 'react'
 
-import {fireEvent, render} from '@testing-library/react'
+import {render, screen} from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import '@testing-library/jest-dom'
 import {mocked} from 'ts-jest/utils'
+
+import {createIntl} from 'react-intl'
 
 import {wrapIntl} from '../../testUtils'
 import {TestBlockFactory} from '../../test/testBlockFactory'
 import mutator from '../../mutator'
+import {propertyTypesList, typeDisplayName} from '../../widgets/propertyMenu'
+
+import {PropertyType} from '../../blocks/board'
 
 import CardDetailProperties from './cardDetailProperties'
 
@@ -49,54 +55,66 @@ describe('components/cardDetail/CardDetailProperties', () => {
 
     const card = TestBlockFactory.createCard(board)
     card.fields.properties.property_id_1 = 'property_value_id_1'
+    const cards = [card]
 
-    test('should match snapshot', async () => {
-        const component = wrapIntl((
-            <CardDetailProperties
-                board={board!}
-                card={card}
-                cards={[card]}
-                contents={[]}
-                comments={[]}
-                activeView={view}
-                views={[view]}
-                readonly={false}
-            />
-        ))
+    const cardDetailProps = {
+        board,
+        card,
+        cards,
+        contents: [],
+        comments: [],
+        activeView: view,
+        views: [view],
+        readonly: false,
+    }
 
-        const {container} = render(component)
+    it('should match snapshot', async () => {
+        const {container} = render(
+            wrapIntl(
+                <CardDetailProperties {...cardDetailProps}/>,
+            ),
+        )
         expect(container).toMatchSnapshot()
     })
 
-    test('rename select property', async () => {
-        const cards = [card]
-        const component = wrapIntl((
-            <CardDetailProperties
-                board={board!}
-                card={card}
-                cards={cards}
-                contents={[]}
-                comments={[]}
-                activeView={view}
-                views={[view]}
-                readonly={false}
-            />
-        ))
+    it('can rename select property', async () => {
+        render(
+            wrapIntl(
+                <CardDetailProperties {...cardDetailProps}/>,
+            ),
+        )
 
-        const {container} = render(component)
-        const propertyLabel = container.querySelector('.MenuWrapper')
-        expect(propertyLabel).toBeDefined()
-        fireEvent.click(propertyLabel!)
+        const menuElement = screen.getByRole('button', {name: 'Owner'})
+        userEvent.click(menuElement)
 
         const newName = 'Owner - Renamed'
-        const propertyNameInput = container.querySelector('.PropertyMenu.menu-textbox')
-        expect(propertyNameInput).toBeDefined()
-        userEvent.type(propertyNameInput!, `${newName}{enter}`)
-        fireEvent.click(propertyLabel!)
+        const propertyNameInput = screen.getByRole('textbox')
+        userEvent.type(propertyNameInput, `${newName}{enter}`)
 
         // should be called once on renaming the property
         const propertyTemplate = board.fields.cardProperties[0]
         expect(mockedMutator.changePropertyTypeAndName).toHaveBeenCalledTimes(1)
         expect(mockedMutator.changePropertyTypeAndName).toHaveBeenCalledWith(board, cards, propertyTemplate, 'select', newName)
+    })
+
+    it('shows menu with property types when adding new property', () => {
+        const intl = createIntl({locale: 'en'})
+        const {container} = render(
+            wrapIntl(
+                <CardDetailProperties {...cardDetailProps}/>,
+            ),
+        )
+
+        const menuElement = screen.getByRole('button', {name: /add a property/i})
+        userEvent.click(menuElement)
+        expect(container).toMatchSnapshot()
+
+        const selectProperty = screen.getByText(/select property type/i)
+        expect(selectProperty).toBeInTheDocument()
+
+        propertyTypesList.forEach((type: PropertyType) => {
+            const typeButton = screen.getByRole('button', {name: typeDisplayName(intl, type)})
+            expect(typeButton).toBeInTheDocument()
+        })
     })
 })

--- a/webapp/src/components/cardDetail/cardDetailProperties.tsx
+++ b/webapp/src/components/cardDetail/cardDetailProperties.tsx
@@ -1,6 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
-import React from 'react'
+import React, {useEffect, useState} from 'react'
 import {FormattedMessage} from 'react-intl'
 
 import {Board, PropertyType, IPropertyTemplate} from '../../blocks/board'
@@ -28,6 +28,14 @@ type Props = {
 
 const CardDetailProperties = React.memo((props: Props) => {
     const {board, card, cards, views, activeView, contents, comments} = props
+    const [newTemplateId, setNewTemplateId] = useState('')
+
+    useEffect(() => {
+        const newProperty = board.fields.cardProperties.find((property) => property.id === newTemplateId)
+        if (newProperty) {
+            setNewTemplateId('')
+        }
+    }, [newTemplateId, board.fields.cardProperties])
 
     return (
         <div className='octo-propertylist CardDetailProperties'>
@@ -40,7 +48,7 @@ const CardDetailProperties = React.memo((props: Props) => {
                     >
                         {props.readonly && <div className='octo-propertyname'>{propertyTemplate.name}</div>}
                         {!props.readonly &&
-                            <MenuWrapper>
+                            <MenuWrapper isOpen={propertyTemplate.id === newTemplateId}>
                                 <div className='octo-propertyname'><Button>{propertyTemplate.name}</Button></div>
                                 <PropertyMenu
                                     propertyId={propertyTemplate.id}
@@ -68,8 +76,7 @@ const CardDetailProperties = React.memo((props: Props) => {
                 <div className='octo-propertyname add-property'>
                     <Button
                         onClick={async () => {
-                            // TODO: Show UI
-                            await mutator.insertPropertyTemplate(board, activeView)
+                            setNewTemplateId(await mutator.insertPropertyTemplate(board, activeView))
                         }}
                     >
                         <FormattedMessage

--- a/webapp/src/components/cardDetail/cardDetailProperties.tsx
+++ b/webapp/src/components/cardDetail/cardDetailProperties.tsx
@@ -11,7 +11,7 @@ import {CommentBlock} from '../../blocks/commentBlock'
 import mutator from '../../mutator'
 import Button from '../../widgets/buttons/button'
 import MenuWrapper from '../../widgets/menuWrapper'
-import PropertyMenu, {propertyTypes, typeDisplayName} from '../../widgets/propertyMenu'
+import PropertyMenu, {PropertyTypes, typeDisplayName} from '../../widgets/propertyMenu'
 
 import PropertyValueElement from '../propertyValueElement'
 import Menu from '../../widgets/menu'
@@ -86,32 +86,18 @@ const CardDetailProperties = React.memo((props: Props) => {
                         </Button>
                     </div>
                     <Menu>
-                        <Menu.Label>
-                            <b>
-                                {intl.formatMessage({id: 'PropertyMenu.selectType', defaultMessage: 'Select property type'})}
-                            </b>
-                        </Menu.Label>
-
-                        <Menu.Separator/>
-
-                        {
-                            propertyTypes.map((type) => (
-                                <Menu.Text
-                                    key={type}
-                                    id={type}
-                                    name={typeDisplayName(intl, type)}
-                                    onClick={async () => {
-                                        const template: IPropertyTemplate = {
-                                            id: Utils.createGuid(),
-                                            name: typeDisplayName(intl, type),
-                                            type,
-                                            options: [],
-                                        }
-                                        setNewTemplateId(await mutator.insertPropertyTemplate(board, activeView, -1, template))
-                                    }}
-                                />
-                            ))
-                        }
+                        <PropertyTypes
+                            label={intl.formatMessage({id: 'PropertyMenu.selectType', defaultMessage: 'Select property type'})}
+                            onTypeSelected={async (type) => {
+                                const template: IPropertyTemplate = {
+                                    id: Utils.createGuid(),
+                                    name: typeDisplayName(intl, type),
+                                    type,
+                                    options: [],
+                                }
+                                setNewTemplateId(await mutator.insertPropertyTemplate(board, activeView, -1, template))
+                            }}
+                        />
                     </Menu>
                 </MenuWrapper>
             }

--- a/webapp/src/mutator.ts
+++ b/webapp/src/mutator.ts
@@ -198,10 +198,10 @@ class Mutator {
 
     // Property Templates
 
-    async insertPropertyTemplate(board: Board, activeView: BoardView, index = -1, template?: IPropertyTemplate) {
+    async insertPropertyTemplate(board: Board, activeView: BoardView, index = -1, template?: IPropertyTemplate): Promise<string> {
         if (!activeView) {
             Utils.assertFailure('insertPropertyTemplate: no activeView')
-            return
+            return ''
         }
 
         const newTemplate = template || {
@@ -231,6 +231,7 @@ class Mutator {
         }
 
         await this.updateBlocks(changedBlocks, oldBlocks, description)
+        return newTemplate.id
     }
 
     async duplicatePropertyTemplate(board: Board, activeView: BoardView, propertyId: string) {

--- a/webapp/src/widgets/menuWrapper.tsx
+++ b/webapp/src/widgets/menuWrapper.tsx
@@ -10,11 +10,12 @@ type Props = {
     stopPropagationOnToggle?: boolean;
     className?: string
     disabled?: boolean
+    isOpen?: boolean
 }
 
 const MenuWrapper = React.memo((props: Props) => {
     const node = useRef<HTMLDivElement>(null)
-    const [open, setOpen] = useState(false)
+    const [open, setOpen] = useState(Boolean(props.isOpen))
 
     if (!Array.isArray(props.children) || props.children.length !== 2) {
         throw new Error('MenuWrapper needs exactly 2 children')

--- a/webapp/src/widgets/propertyMenu.tsx
+++ b/webapp/src/widgets/propertyMenu.tsx
@@ -44,7 +44,7 @@ function typeMenuTitle(intl: IntlShape, type: PropertyType): string {
     return `${intl.formatMessage({id: 'PropertyMenu.typeTitle', defaultMessage: 'Type'})}: ${typeDisplayName(intl, type)}`
 }
 
-const propertyTypes: PropertyType[] = [
+export const propertyTypesList: PropertyType[] = [
     'text',
     'number',
     'email',
@@ -77,7 +77,7 @@ export const PropertyTypes = (props: TypesProps): JSX.Element => {
             <Menu.Separator/>
 
             {
-                propertyTypes.map((type) => (
+                propertyTypesList.map((type) => (
                     <Menu.Text
                         key={type}
                         id={type}

--- a/webapp/src/widgets/propertyMenu.tsx
+++ b/webapp/src/widgets/propertyMenu.tsx
@@ -44,7 +44,7 @@ function typeMenuTitle(intl: IntlShape, type: PropertyType): string {
     return `${intl.formatMessage({id: 'PropertyMenu.typeTitle', defaultMessage: 'Type'})}: ${typeDisplayName(intl, type)}`
 }
 
-export const propertyTypes: PropertyType[] = [
+const propertyTypes: PropertyType[] = [
     'text',
     'number',
     'email',
@@ -60,6 +60,35 @@ export const propertyTypes: PropertyType[] = [
     'updatedTime',
     'updatedBy',
 ]
+
+type TypesProps = {
+    label: string
+    onTypeSelected: (type: PropertyType) => void
+}
+
+export const PropertyTypes = (props: TypesProps): JSX.Element => {
+    const intl = useIntl()
+    return (
+        <>
+            <Menu.Label>
+                <b>{props.label}</b>
+            </Menu.Label>
+
+            <Menu.Separator/>
+
+            {
+                propertyTypes.map((type) => (
+                    <Menu.Text
+                        key={type}
+                        id={type}
+                        name={typeDisplayName(intl, type)}
+                        onClick={() => props.onTypeSelected(type)}
+                    />
+                ))
+            }
+        </>
+    )
+}
 
 const PropertyMenu = React.memo((props: Props) => {
     const intl = useIntl()
@@ -100,24 +129,10 @@ const PropertyMenu = React.memo((props: Props) => {
                 id='type'
                 name={typeMenuTitle(intl, props.propertyType)}
             >
-                <Menu.Label>
-                    <b>
-                        {intl.formatMessage({id: 'PropertyMenu.changeType', defaultMessage: 'Change property type'})}
-                    </b>
-                </Menu.Label>
-
-                <Menu.Separator/>
-
-                {
-                    propertyTypes.map((type) => (
-                        <Menu.Text
-                            key={type}
-                            id={type}
-                            name={typeDisplayName(intl, type)}
-                            onClick={() => debouncedOnTypeAndNameChanged(type)()}
-                        />
-                    ))
-                }
+                <PropertyTypes
+                    label={intl.formatMessage({id: 'PropertyMenu.changeType', defaultMessage: 'Change property type'})}
+                    onTypeSelected={(type) => debouncedOnTypeAndNameChanged(type)()}
+                />
             </Menu.SubMenu>
             <Menu.Text
                 id='delete'

--- a/webapp/src/widgets/propertyMenu.tsx
+++ b/webapp/src/widgets/propertyMenu.tsx
@@ -17,7 +17,7 @@ type Props = {
     onDelete: (id: string) => void
 }
 
-function typeDisplayName(intl: IntlShape, type: PropertyType): string {
+export function typeDisplayName(intl: IntlShape, type: PropertyType): string {
     switch (type) {
     case 'text': return intl.formatMessage({id: 'PropertyType.Text', defaultMessage: 'Text'})
     case 'number': return intl.formatMessage({id: 'PropertyType.Number', defaultMessage: 'Number'})
@@ -44,6 +44,23 @@ function typeMenuTitle(intl: IntlShape, type: PropertyType): string {
     return `${intl.formatMessage({id: 'PropertyMenu.typeTitle', defaultMessage: 'Type'})}: ${typeDisplayName(intl, type)}`
 }
 
+export const propertyTypes: PropertyType[] = [
+    'text',
+    'number',
+    'email',
+    'phone',
+    'url',
+    'select',
+    'multiSelect',
+    'date',
+    'person',
+    'checkbox',
+    'createdTime',
+    'createdBy',
+    'updatedTime',
+    'updatedBy',
+]
+
 const PropertyMenu = React.memo((props: Props) => {
     const intl = useIntl()
     const nameTextbox = useRef<HTMLInputElement>(null)
@@ -60,23 +77,6 @@ const PropertyMenu = React.memo((props: Props) => {
         nameTextbox.current?.focus()
         nameTextbox.current?.setSelectionRange(0, name.length)
     }, [])
-
-    const propertyTypes = [
-        {type: 'text'},
-        {type: 'number'},
-        {type: 'email'},
-        {type: 'phone'},
-        {type: 'url'},
-        {type: 'select'},
-        {type: 'multiSelect'},
-        {type: 'date'},
-        {type: 'person'},
-        {type: 'checkbox'},
-        {type: 'createdTime'},
-        {type: 'createdBy'},
-        {type: 'updatedTime'},
-        {type: 'updatedBy'},
-    ]
 
     return (
         <Menu>
@@ -109,12 +109,12 @@ const PropertyMenu = React.memo((props: Props) => {
                 <Menu.Separator/>
 
                 {
-                    propertyTypes.map((propertyType) => (
+                    propertyTypes.map((type) => (
                         <Menu.Text
-                            key={propertyType.type}
-                            id={propertyType.type}
-                            name={typeDisplayName(intl, propertyType.type as PropertyType)}
-                            onClick={() => debouncedOnTypeAndNameChanged(propertyType.type as PropertyType)()}
+                            key={type}
+                            id={type}
+                            name={typeDisplayName(intl, type)}
+                            onClick={() => debouncedOnTypeAndNameChanged(type)()}
                         />
                     ))
                 }

--- a/webapp/src/widgets/propertyMenu.tsx
+++ b/webapp/src/widgets/propertyMenu.tsx
@@ -100,7 +100,9 @@ const PropertyMenu = React.memo((props: Props) => {
         defaultMessage: 'Delete',
     })
 
-    const debouncedOnTypeAndNameChanged = (newType: PropertyType) => debounce(() => props.onTypeAndNameChanged(newType, name), 150)
+    const debouncedOnTypeAndNameChanged = (newType: PropertyType, newName: string) => {
+        debounce(() => props.onTypeAndNameChanged(newType, newName), 150)()
+    }
 
     useEffect(() => {
         nameTextbox.current?.focus()
@@ -114,13 +116,18 @@ const PropertyMenu = React.memo((props: Props) => {
                 type='text'
                 className='PropertyMenu menu-textbox'
                 onClick={(e) => e.stopPropagation()}
-                onChange={(e) => setName(e.target.value)}
+                onChange={(e) => {
+                    setName(e.target.value)
+                }}
                 value={name}
                 onBlur={() => props.onTypeAndNameChanged(props.propertyType, name)}
                 onKeyDown={(e) => {
-                    if (e.keyCode === 13 || e.keyCode === 27) {
+                    if (e.key === 'Enter' || e.key === 'Escape') {
                         props.onTypeAndNameChanged(props.propertyType, name)
                         e.stopPropagation()
+                        if (e.key === 'Enter') {
+                            e.target.dispatchEvent(new Event('menuItemClicked'))
+                        }
                     }
                 }}
                 spellCheck={true}
@@ -131,7 +138,7 @@ const PropertyMenu = React.memo((props: Props) => {
             >
                 <PropertyTypes
                     label={intl.formatMessage({id: 'PropertyMenu.changeType', defaultMessage: 'Change property type'})}
-                    onTypeSelected={(type) => debouncedOnTypeAndNameChanged(type)()}
+                    onTypeSelected={(type) => debouncedOnTypeAndNameChanged(type, name)}
                 />
             </Menu.SubMenu>
             <Menu.Text


### PR DESCRIPTION
#### Summary
Changed workflow for adding new property:
- menu with all property types is shown and allows the user to select new property type
![image](https://user-images.githubusercontent.com/5587620/135723327-c9a9c660-3cad-4858-b314-003125f17a46.png)
- after selecting the type for new property its name is initialized from its type:
![image](https://user-images.githubusercontent.com/5587620/135723393-97240e75-5253-4c70-9081-425526e74379.png)
- pressing `Enter` closes this popup

#### Ticket Link
Fixes #705

@asaadmahmood please check this workflow from the UX perspective