### PR TITLE
[GH-865] Add more tests unit to viewHeaderActionMenu

### DIFF
--- a/webapp/src/components/viewHeader/__snapshots__/viewHeaderActionsMenu.test.tsx.snap
+++ b/webapp/src/components/viewHeader/__snapshots__/viewHeaderActionsMenu.test.tsx.snap
@@ -1,5 +1,225 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`components/viewHeader/viewHeaderActionsMenu return menu and verify call to board archive 1`] = `
+<div>
+  <div
+    class="ModalWrapper"
+  >
+    <div
+      aria-label="menuwrapper"
+      class="MenuWrapper"
+      role="button"
+    >
+      <div
+        class="Button IconButton"
+        role="button"
+      >
+        <i
+          class="CompassIcon icon-dots-horizontal OptionsIcon"
+        />
+      </div>
+      <div
+        class="Menu noselect bottom"
+      >
+        <div
+          class="menu-contents"
+        >
+          <div
+            class="menu-options"
+          >
+            <div
+              aria-label="Export to CSV"
+              class="MenuOption TextOption menu-option"
+              role="button"
+            >
+              <div
+                class="noicon"
+              />
+              <div
+                class="menu-name"
+              >
+                Export to CSV
+              </div>
+              <div
+                class="noicon"
+              />
+            </div>
+            <div
+              aria-label="Export board archive"
+              class="MenuOption TextOption menu-option"
+              role="button"
+            >
+              <div
+                class="noicon"
+              />
+              <div
+                class="menu-name"
+              >
+                Export board archive
+              </div>
+              <div
+                class="noicon"
+              />
+            </div>
+            <div
+              aria-label="Share board"
+              class="MenuOption TextOption menu-option"
+              role="button"
+            >
+              <div
+                class="noicon"
+              />
+              <div
+                class="menu-name"
+              >
+                Share board
+              </div>
+              <div
+                class="noicon"
+              />
+            </div>
+          </div>
+          <div
+            class="menu-spacer hideOnWidescreen"
+          />
+          <div
+            class="menu-options hideOnWidescreen"
+          >
+            <div
+              aria-label="Cancel"
+              class="MenuOption TextOption menu-option menu-cancel"
+              role="button"
+            >
+              <div
+                class="noicon"
+              />
+              <div
+                class="menu-name"
+              >
+                Cancel
+              </div>
+              <div
+                class="noicon"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`components/viewHeader/viewHeaderActionsMenu return menu and verify call to csv exporter 1`] = `
+<div>
+  <div
+    class="ModalWrapper"
+  >
+    <div
+      aria-label="menuwrapper"
+      class="MenuWrapper"
+      role="button"
+    >
+      <div
+        class="Button IconButton"
+        role="button"
+      >
+        <i
+          class="CompassIcon icon-dots-horizontal OptionsIcon"
+        />
+      </div>
+      <div
+        class="Menu noselect bottom"
+      >
+        <div
+          class="menu-contents"
+        >
+          <div
+            class="menu-options"
+          >
+            <div
+              aria-label="Export to CSV"
+              class="MenuOption TextOption menu-option"
+              role="button"
+            >
+              <div
+                class="noicon"
+              />
+              <div
+                class="menu-name"
+              >
+                Export to CSV
+              </div>
+              <div
+                class="noicon"
+              />
+            </div>
+            <div
+              aria-label="Export board archive"
+              class="MenuOption TextOption menu-option"
+              role="button"
+            >
+              <div
+                class="noicon"
+              />
+              <div
+                class="menu-name"
+              >
+                Export board archive
+              </div>
+              <div
+                class="noicon"
+              />
+            </div>
+            <div
+              aria-label="Share board"
+              class="MenuOption TextOption menu-option"
+              role="button"
+            >
+              <div
+                class="noicon"
+              />
+              <div
+                class="menu-name"
+              >
+                Share board
+              </div>
+              <div
+                class="noicon"
+              />
+            </div>
+          </div>
+          <div
+            class="menu-spacer hideOnWidescreen"
+          />
+          <div
+            class="menu-options hideOnWidescreen"
+          >
+            <div
+              aria-label="Cancel"
+              class="MenuOption TextOption menu-option menu-cancel"
+              role="button"
+            >
+              <div
+                class="noicon"
+              />
+              <div
+                class="menu-name"
+              >
+                Cancel
+              </div>
+              <div
+                class="noicon"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`components/viewHeader/viewHeaderActionsMenu return menu with Share Boards 1`] = `
 <div>
   <div

--- a/webapp/src/components/viewHeader/viewHeaderActionsMenu.test.tsx
+++ b/webapp/src/components/viewHeader/viewHeaderActionsMenu.test.tsx
@@ -39,7 +39,9 @@ describe('components/viewHeader/viewHeaderActionsMenu', () => {
         },
     }
     const store = mockStateStore([], state)
-
+    beforeEach(() => {
+        jest.clearAllMocks()
+    })
     test('return menu with Share Boards', () => {
         const {container} = render(
             wrapIntl(

--- a/webapp/src/components/viewHeader/viewHeaderActionsMenu.test.tsx
+++ b/webapp/src/components/viewHeader/viewHeaderActionsMenu.test.tsx
@@ -1,23 +1,30 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React, {ReactElement} from 'react'
+import React from 'react'
 import {render, screen} from '@testing-library/react'
 import {Provider as ReduxProvider} from 'react-redux'
-import configureStore from 'redux-mock-store'
 
 import '@testing-library/jest-dom'
 import userEvent from '@testing-library/user-event'
 
-import {IntlProvider} from 'react-intl'
+import {mocked} from 'ts-jest/utils'
 
 import {TestBlockFactory} from '../../test/testBlockFactory'
 
+import {wrapIntl, mockStateStore} from '../../testUtils'
+
+import {Archiver} from '../../archiver'
+
+import {CsvExporter} from '../../csvExporter'
+
 import ViewHeaderActionsMenu from './viewHeaderActionsMenu'
 
-const wrapIntl = (children: ReactElement) => (
-    <IntlProvider locale='en'>{children}</IntlProvider>
-)
+jest.mock('../../archiver')
+jest.mock('../../csvExporter')
+const mockedArchiver = mocked(Archiver, true)
+const mockedCsvExporter = mocked(CsvExporter, true)
+
 const board = TestBlockFactory.createBoard()
 const activeView = TestBlockFactory.createBoardView(board)
 const card = TestBlockFactory.createCard(board)
@@ -27,11 +34,11 @@ describe('components/viewHeader/viewHeaderActionsMenu', () => {
         users: {
             me: {
                 id: 'user-id-1',
-                username: 'username_1'},
+                username: 'username_1',
+            },
         },
     }
-    const mockStore = configureStore([])
-    const store = mockStore(state)
+    const store = mockStateStore([], state)
 
     test('return menu with Share Boards', () => {
         const {container} = render(
@@ -46,7 +53,9 @@ describe('components/viewHeader/viewHeaderActionsMenu', () => {
                 </ReduxProvider>,
             ),
         )
-        const buttonElement = screen.getByRole('button', {name: 'menuwrapper'})
+        const buttonElement = screen.getByRole('button', {
+            name: 'menuwrapper',
+        })
         userEvent.click(buttonElement)
         expect(container).toMatchSnapshot()
     })
@@ -64,8 +73,52 @@ describe('components/viewHeader/viewHeaderActionsMenu', () => {
                 </ReduxProvider>,
             ),
         )
+        const buttonElement = screen.getByRole('button', {
+            name: 'menuwrapper',
+        })
+        userEvent.click(buttonElement)
+        expect(container).toMatchSnapshot()
+    })
+    test('return menu and verify call to csv exporter', () => {
+        const {container} = render(
+            wrapIntl(
+                <ReduxProvider store={store}>
+                    <ViewHeaderActionsMenu
+                        board={board}
+                        activeView={activeView}
+                        cards={[card]}
+                        showShared={true}
+                    />
+                </ReduxProvider>,
+            ),
+        )
         const buttonElement = screen.getByRole('button', {name: 'menuwrapper'})
         userEvent.click(buttonElement)
         expect(container).toMatchSnapshot()
+        const buttonExportCSV = screen.getByRole('button', {name: 'Export to CSV'})
+        userEvent.click(buttonExportCSV)
+        expect(mockedCsvExporter.exportTableCsv).toBeCalledTimes(1)
+    })
+
+    test('return menu and verify call to board archive', () => {
+        const {container} = render(
+            wrapIntl(
+                <ReduxProvider store={store}>
+                    <ViewHeaderActionsMenu
+                        board={board}
+                        activeView={activeView}
+                        cards={[card]}
+                        showShared={true}
+                    />
+                </ReduxProvider>,
+            ),
+        )
+        const buttonElement = screen.getByRole('button', {name: 'menuwrapper'})
+        userEvent.click(buttonElement)
+        expect(container).toMatchSnapshot()
+        const buttonExportBoardArchive = screen.getByRole('button', {name: 'Export board archive'})
+        userEvent.click(buttonExportBoardArchive)
+        expect(mockedArchiver.exportBoardArchive).toBeCalledTimes(1)
+        expect(mockedArchiver.exportBoardArchive).toBeCalledWith(board)
     })
 })

--- a/webapp/src/testUtils.tsx
+++ b/webapp/src/testUtils.tsx
@@ -2,6 +2,8 @@
 // See LICENSE.txt for license information.
 import {IntlProvider} from 'react-intl'
 import React from 'react'
+import configureStore, {MockStoreEnhanced} from 'redux-mock-store'
+import {Middleware} from 'redux'
 
 export const wrapIntl = (children?: React.ReactNode): JSX.Element => <IntlProvider locale='en'>{children}</IntlProvider>
 
@@ -9,9 +11,7 @@ export function mockDOM(): void {
     window.focus = jest.fn()
     document.createRange = () => {
         const range = new Range()
-
         range.getBoundingClientRect = jest.fn()
-
         range.getClientRects = () => {
             return {
                 item: () => null,
@@ -19,11 +19,9 @@ export function mockDOM(): void {
                 [Symbol.iterator]: jest.fn(),
             }
         }
-
         return range
     }
 }
-
 export function mockMatchMedia(result: any): void {
     // We check if system preference is dark or light theme.
     // This is required to provide it's definition since
@@ -38,4 +36,9 @@ export function mockMatchMedia(result: any): void {
             // })
         }),
     })
+}
+
+export function mockStateStore(middleware:Middleware[], state:unknown): MockStoreEnhanced<unknown, unknown> {
+    const mockStore = configureStore(middleware)
+    return mockStore(state)
 }


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Add other tests unit to viewHeaderActionMenu
#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Fixes #865 
