### PR TITLE
Add the ability to import checklists from Trello

### DIFF
--- a/import/trello/importTrello.ts
+++ b/import/trello/importTrello.ts
@@ -9,8 +9,8 @@ import {IPropertyOption, IPropertyTemplate, createBoard} from '../../webapp/src/
 import {createBoardView} from '../../webapp/src/blocks/boardView'
 import {createCard} from '../../webapp/src/blocks/card'
 import {createTextBlock} from '../../webapp/src/blocks/textBlock'
-import {createCheckboxBlock, CheckboxBlock} from '../../webapp/src/blocks/checkboxBlock'
-import {ChecklistElement, Trello} from './trello'
+import {createCheckboxBlock} from '../../webapp/src/blocks/checkboxBlock'
+import {Trello} from './trello'
 import {Utils} from './utils'
 
 // HACKHACK: To allow Utils.CreateGuid to work
@@ -138,14 +138,14 @@ function convert(input: Trello): Block[] {
         }
 
         // Add Checklists
-        if (card.idChecklists && card.idChecklists.length) {
+        if (card.idChecklists && card.idChecklists.length > 0) {
             card.idChecklists.forEach(checklistID => {
                 const lookup = input.checklists.find(e => e.id === checklistID)
-                if (lookup !== undefined) {
+                if (lookup) {
                     lookup.checkItems.forEach(trelloCheckBox=> {
                         const checkBlock = createCheckboxBlock()
                         checkBlock.title = trelloCheckBox.name
-                        if (trelloCheckBox.state == 'complete') {
+                        if (trelloCheckBox.state === 'complete') {
                             checkBlock.fields.value = true
                         } else {
                             checkBlock.fields.value = false

--- a/import/trello/importTrello.ts
+++ b/import/trello/importTrello.ts
@@ -9,7 +9,8 @@ import {IPropertyOption, IPropertyTemplate, createBoard} from '../../webapp/src/
 import {createBoardView} from '../../webapp/src/blocks/boardView'
 import {createCard} from '../../webapp/src/blocks/card'
 import {createTextBlock} from '../../webapp/src/blocks/textBlock'
-import {Trello} from './trello'
+import {createCheckboxBlock, CheckboxBlock} from '../../webapp/src/blocks/checkboxBlock'
+import {ChecklistElement, Trello} from './trello'
 import {Utils} from './utils'
 
 // HACKHACK: To allow Utils.CreateGuid to work
@@ -134,6 +135,29 @@ function convert(input: Trello): Block[] {
             blocks.push(text)
 
             outCard.fields.contentOrder = [text.id]
+        }
+
+        // Add Checklists
+        if (card.idChecklists && card.idChecklists.length) {
+            card.idChecklists.forEach(checklistID => {
+                const lookup = input.checklists.find(e => e.id === checklistID)
+                if (lookup !== undefined) {
+                    lookup.checkItems.forEach(trelloCheckBox=> {
+                        const checkBlock = createCheckboxBlock()
+                        checkBlock.title = trelloCheckBox.name
+                        if (trelloCheckBox.state == 'complete') {
+                            checkBlock.fields.value = true
+                        } else {
+                            checkBlock.fields.value = false
+                        }
+                        checkBlock.rootId = outCard.rootId
+                        checkBlock.parentId = outCard.id
+                        blocks.push(checkBlock)
+
+                        outCard.fields.contentOrder.push(checkBlock.id)
+                    })
+                }
+            })
         }
     })
 


### PR DESCRIPTION
#### Summary
Adds the ability to import checklists to Focalboard when importing from Trello. It's pretty simple code, but it's my first attempt at TypeScript, so appreciate any feedback. I'm not 100% sure of my `undefined` logic etc. But it does work :shrug: 

This is kind of related to https://github.com/mattermost/focalboard/issues/53 but there's no specific issue relating to this. I wrote it for my own needs and figured I should push it upstream.

I started looking at importing images as well, but they require auth now if the Trello board is private. That is a different kettle of fish, so decided to leave that out of this PR.