### PR TITLE
Fix failing unit test for viewHeader

### DIFF
--- a/webapp/src/components/viewHeader/viewHeader.test.tsx
+++ b/webapp/src/components/viewHeader/viewHeader.test.tsx
@@ -33,6 +33,12 @@ describe('components/viewHeader/viewHeader', () => {
         cards: {
             templates: [card],
         },
+        views: {
+            views: {
+                boardView: activeView,
+            },
+            current: 'boardView',
+        },
     }
     const store = mockStateStore([], state)
     test('return viewHeader', () => {


### PR DESCRIPTION
#### Summary
Views were added to the mocked store state because they are required by the code that is being tested.

#### Ticket Link
Not related to any ticket.