### PR TITLE
GH-1448: change window to history

### DIFF
--- a/webapp/src/pages/registerPage.tsx
+++ b/webapp/src/pages/registerPage.tsx
@@ -20,7 +20,7 @@ const RegisterPage = React.memo(() => {
     const dispatch = useAppDispatch()
 
     const handleRegister = async (): Promise<void> => {
-        const queryString = new URLSearchParams(window.location.search)
+        const queryString = new URLSearchParams(history.location.search)
         const signupToken = queryString.get('t') || ''
 
         const response = await client.register(email, username, password, signupToken)


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
I wasn't able to figure out why the query params are getting stripped from the URL. But on the `RegisterPage.tsx` we use `useHistory()` which also has a location field storing the initial URL. I just changed the signupToken to use `history.location` instead of `window.location`

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

Fixes [Issue #1448](https://github.com/mattermost/focalboard/issues/1448)

