### PR TITLE
GH-1448 - Only call history replace if a plugin

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -92,7 +92,9 @@ const App = React.memo((): JSX.Element => {
         dispatch(fetchLanguage())
         dispatch(fetchMe())
         dispatch(fetchClientConfig())
-        history.replace(window.location.pathname.replace((window as any).frontendBaseURL, ''))
+        if (Utils.isFocalboardPlugin()) {
+            history.replace(window.location.pathname.replace((window as any).frontendBaseURL, ''))
+        }
     }, [])
 
     if (!inPluginLegacy) {


### PR DESCRIPTION
#### Summary
Fixes an issue where the registration token is removed from the URL. This removal results in the registration failing.

#### Ticket Link

  Fixes https://github.com/mattermost/focalboard/issues/1448
