### PR TITLE
Move app history replace to happen only if not in plugin legacy mode

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -93,10 +93,13 @@ const App = React.memo((): JSX.Element => {
         dispatch(fetchLanguage())
         dispatch(fetchMe())
         dispatch(fetchClientConfig())
-        history.replace(window.location.pathname.replace((window as any).frontendBaseURL, ''))
     }, [])
 
     if (!inPluginLegacy) {
+        useEffect(() => {
+            history.replace(window.location.pathname.replace((window as any).frontendBaseURL, ''))
+        }, [])
+
         useEffect(() => {
             wsClient.open()
             return () => {


### PR DESCRIPTION
#### Summary
Removes the history replace for legacy plugin mode, fixing the shared boards URLs in the plugin.

Fixes https://github.com/mattermost/focalboard/issues/1438