### PR TITLE
Adds a check to ensure that the URL view belongs to the board or redirects

### DIFF
--- a/webapp/src/pages/boardPage.tsx
+++ b/webapp/src/pages/boardPage.tsx
@@ -110,7 +110,8 @@ const BoardPage = (props: Props): JSX.Element => {
         }
 
         Utils.log(`attachToBoard: ${boardId}`)
-        if (!viewId && boardViews.length > 0) {
+        const viewIsFromBoard = boardViews.some(view => view.id === viewId)
+        if ((!viewId || !viewIsFromBoard) && boardViews.length > 0) {
             const newPath = generatePath(match.path, {...match.params, boardId, viewId: boardViews[0].id})
             history.replace(newPath)
             return


### PR DESCRIPTION
#### Summary
This PR adds a check when loading the board page to ensure that the view on the URL belongs to the board of it. This way, if you're navigating Boards and go from `board A view A` to `board B` (directly to the board instead of the view), instead of loading `board B` and `view A` (and generating a bad shared board URL as a result of this) it will catch the inconsistency and redirect to `view B`.

Fixes https://github.com/mattermost/focalboard/issues/1392