### PR TITLE
Fix #1482. Handle isEmpty filter correctly.

### DIFF
--- a/webapp/src/cardFilter.ts
+++ b/webapp/src/cardFilter.ts
@@ -59,10 +59,10 @@ class CardFilter {
             return (filter.values.find((cValue) => (Array.isArray(value) ? value.includes(cValue) : cValue === value)) === undefined)
         }
         case 'isEmpty': {
-            return value?.length <= 0
+            return (value || '').length <= 0
         }
         case 'isNotEmpty': {
-            return value?.length > 0
+            return (value || '').length > 0
         }
         default: {
             Utils.assertFailure(`Invalid filter condition ${filter.condition}`)


### PR DESCRIPTION
#### Summary
The root issue is that `value` is undefined if there's no value, and `value?.length` resolves to undefined, and `value?.length <= 0` resolves to false.

#### Ticket Link
#1482