### PR TITLE
[GH-832] Add unit test for flashMessage component

### DIFF
--- a/webapp/src/components/__snapshots__/flashMessages.test.tsx.snap
+++ b/webapp/src/components/__snapshots__/flashMessages.test.tsx.snap
@@ -9,3 +9,47 @@ exports[`components/flashMessages renders a flash message with high severity 1`]
   </div>
 </div>
 `;
+
+exports[`components/flashMessages renders a flash message with low severity 1`] = `
+<div>
+  <div
+    class="FlashMessages low flashIn"
+  >
+    Mock Content
+  </div>
+</div>
+`;
+
+exports[`components/flashMessages renders a flash message with low severity and check onClick on flash works 1`] = `
+<div>
+  <div
+    class="FlashMessages low flashOut"
+  >
+    Mock Content
+  </div>
+</div>
+`;
+
+exports[`components/flashMessages renders a flash message with low severity and custom HTML in flash message 1`] = `
+<div>
+  <div
+    class="FlashMessages low flashIn"
+  >
+    <div
+      data-testid="mock-test-id"
+    >
+      Mock Content
+    </div>
+  </div>
+</div>
+`;
+
+exports[`components/flashMessages renders a flash message with normal severity 1`] = `
+<div>
+  <div
+    class="FlashMessages normal flashIn"
+  >
+    Mock Content
+  </div>
+</div>
+`;

--- a/webapp/src/components/flashMessages.test.tsx
+++ b/webapp/src/components/flashMessages.test.tsx
@@ -44,10 +44,12 @@ describe('components/flashMessages', () => {
         })
 
         expect(screen.queryByText('Mock Content')).toBeNull()
+    })
 
-        /**
-         * Check for normal severity
-         */
+    test('renders a flash message with normal severity', () => {
+        const {container} = render(
+            wrapIntl(<FlashMessages milliseconds={200}/>),
+        )
 
         act(() => {
             sendFlashMessage({content: 'Mock Content', severity: 'normal'})
@@ -55,15 +57,19 @@ describe('components/flashMessages', () => {
 
         expect(screen.getByText('Mock Content')).toHaveClass('normal')
 
+        expect(container).toMatchSnapshot()
+
         act(() => {
             jest.advanceTimersByTime(200)
         })
 
         expect(screen.queryByText('Mock Content')).toBeNull()
+    })
 
-        /**
-         * Check for low severity
-         */
+    test('renders a flash message with low severity', () => {
+        const {container} = render(
+            wrapIntl(<FlashMessages milliseconds={200}/>),
+        )
 
         act(() => {
             sendFlashMessage({content: 'Mock Content', severity: 'low'})
@@ -71,15 +77,19 @@ describe('components/flashMessages', () => {
 
         expect(screen.getByText('Mock Content')).toHaveClass('low')
 
+        expect(container).toMatchSnapshot()
+
         act(() => {
             jest.advanceTimersByTime(200)
         })
 
         expect(screen.queryByText('Mock Content')).toBeNull()
+    })
 
-        /**
-         * Check with a custom HTML in flash message
-         */
+    test('renders a flash message with low severity and custom HTML in flash message', () => {
+        const {container} = render(
+            wrapIntl(<FlashMessages milliseconds={200}/>),
+        )
 
         act(() => {
             sendFlashMessage({content: <div data-testid='mock-test-id'>{'Mock Content'}</div>, severity: 'low'})
@@ -87,21 +97,27 @@ describe('components/flashMessages', () => {
 
         expect(screen.getByTestId('mock-test-id')).toBeVisible()
 
+        expect(container).toMatchSnapshot()
+
         act(() => {
             jest.advanceTimersByTime(200)
         })
 
         expect(screen.queryByText('Mock Content')).toBeNull()
+    })
 
-        /**
-         * Check that onClick on flash works
-         */
+    test('renders a flash message with low severity and check onClick on flash works', () => {
+        const {container} = render(
+            wrapIntl(<FlashMessages milliseconds={200}/>),
+        )
 
         act(() => {
             sendFlashMessage({content: 'Mock Content', severity: 'low'})
         })
 
         userEvent.click(screen.getByText('Mock Content'))
+
+        expect(container).toMatchSnapshot()
 
         act(() => {
             jest.advanceTimersByTime(200)

--- a/webapp/src/components/flashMessages.tsx
+++ b/webapp/src/components/flashMessages.tsx
@@ -26,14 +26,20 @@ export const FlashMessages = React.memo((props: Props) => {
     const [timeoutId, setTimeoutId] = useState<ReturnType<typeof setTimeout>|null>(null)
 
     useEffect(() => {
+        let isSubscribed = true
         emitter.on('message', (newMessage: FlashMessage) => {
-            if (timeoutId) {
-                clearTimeout(timeoutId)
-                setTimeoutId(null)
+            if (isSubscribed) {
+                if (timeoutId) {
+                    clearTimeout(timeoutId)
+                    setTimeoutId(null)
+                }
+                setTimeoutId(setTimeout(handleFadeOut, props.milliseconds - 200))
+                setMessage(newMessage)
             }
-            setTimeoutId(setTimeout(handleFadeOut, props.milliseconds - 200))
-            setMessage(newMessage)
         })
+        return () => {
+            isSubscribed = false
+        }
     }, [])
 
     const handleFadeOut = (): void => {


### PR DESCRIPTION
#### Summary

The PR adds unit tests for the `flashMessages.tsx` component. Some initial feedbacks would be great as I am learning RTL and Jest. I tried splitting this into multiple tests but that was throwing some error.

Since even in the app, `FlasMessage` is rendered only once and multiple flash messages are fired on single render, IMO, sending multiple messages in single renders replicates more of real world use case. Still let me know if this can be refactored somehow. 

#### Ticket Link

Fixes https://github.com/mattermost/focalboard/issues/832


