### PR TITLE
[GH-1240] Fix height of hidden add icon element

### DIFF
--- a/webapp/src/components/cardDetail/cardDetail.scss
+++ b/webapp/src/components/cardDetail/cardDetail.scss
@@ -6,7 +6,7 @@
     .add-buttons {
         display: flex;
         flex-direction: column;
-        min-height: 30px;
+        min-height: 32px;
         color: rgba(var(--center-channel-color-rgb), 0.4);
         width: 100%;
         align-items: flex-start;


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
This PR fixes the "juddering" effect on hovering over the add icons button by correcting the `min-height`of the element in hidden state

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Fixes #1240 

