### PR TITLE
[GH-1555] Fix Share Dialog text overflow in german language

### DIFF
--- a/webapp/src/components/shareBoardComponent.scss
+++ b/webapp/src/components/shareBoardComponent.scss
@@ -4,6 +4,7 @@
     padding: 5px;
     color: rgb(var(--center-channel-color-rgb));
     max-width: 500px;
+    white-space: normal;
 
     .Switch {
         margin-left: 8px;


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
This PR fixes the overflow in the share board dialog by using `white-space` to break the text into multiple lines

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Fixes #1555 

