### PR TITLE
Don't allow notifications for import

### DIFF
--- a/server/api/api.go
+++ b/server/api/api.go
@@ -392,7 +392,7 @@ func (a *API) handlePostBlocks(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	session := ctx.Value(sessionContextKey).(*model.Session)
 
-	err = a.app.InsertBlocks(*container, blocks, session.UserID)
+	err = a.app.InsertBlocks(*container, blocks, session.UserID, true)
 	if err != nil {
 		a.errorResponse(w, r.URL.Path, http.StatusInternalServerError, "", err)
 		return
@@ -898,7 +898,7 @@ func (a *API) handleImport(w http.ResponseWriter, r *http.Request) {
 
 	ctx := r.Context()
 	session := ctx.Value(sessionContextKey).(*model.Session)
-	err = a.app.InsertBlocks(*container, blocks, session.UserID)
+	err = a.app.InsertBlocks(*container, blocks, session.UserID, false)
 	if err != nil {
 		a.errorResponse(w, r.URL.Path, http.StatusInternalServerError, "", err)
 		return

--- a/server/app/blocks.go
+++ b/server/app/blocks.go
@@ -69,7 +69,7 @@ func (a *App) InsertBlock(c store.Container, block model.Block, userID string) e
 	return err
 }
 
-func (a *App) InsertBlocks(c store.Container, blocks []model.Block, userID string) error {
+func (a *App) InsertBlocks(c store.Container, blocks []model.Block, userID string, allowNotifications bool) error {
 	needsNotify := make([]model.Block, 0, len(blocks))
 	for i := range blocks {
 		err := a.store.InsertBlock(c, &blocks[i], userID)
@@ -87,7 +87,9 @@ func (a *App) InsertBlocks(c store.Container, blocks []model.Block, userID strin
 		for _, b := range needsNotify {
 			block := b
 			a.webhook.NotifyUpdate(block)
-			a.notifyBlockChanged(notify.Add, c, &block, nil, userID)
+			if allowNotifications {
+				a.notifyBlockChanged(notify.Add, c, &block, nil, userID)
+			}
 		}
 	}()
 


### PR DESCRIPTION
#### Summary
When importing blocks (i.e. import board) any @mentions present will generate notifications. This PR disables notifications for calls to the import API.

#### Ticket Link
https://community.mattermost.com/boards/workspace/qgsck6cts3fwpqwyjiupjm5cde/47aa9bb4-6967-4a96-83c7-11bd6b20f1eb/150d1464-6d59-4c39-810f-ee201439dbaf?c=2bd1458c-fe46-4a0a-85c3-71cc07133f5d