### PR TITLE
[GH-1581] fix menu widget

### DIFF
--- a/webapp/src/components/__snapshots__/blockIconSelector.test.tsx.snap
+++ b/webapp/src/components/__snapshots__/blockIconSelector.test.tsx.snap
@@ -48,79 +48,85 @@ exports[`components/blockIconSelector return menu on click 1`] = `
           <div
             class="menu-options"
           >
-            <div
-              aria-label="Random"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
-              <svg
-                class="EmojiIcon Icon"
-                viewBox="0 0 496 512"
-                xmlns="http://www.w3.org/2000/svg"
+            <div>
+              <div
+                aria-label="Random"
+                class="MenuOption TextOption menu-option"
+                role="button"
               >
-                <path
-                  d="M248 8C111 8 0 119 0 256s111 248 248 248 248-111 248-248S385 8 248 8zm0 448c-110.3 0-200-89.7-200-200S137.7 56 248 56s200 89.7 200 200-89.7 200-200 200zm-80-216c17.7 0 32-14.3 32-32s-14.3-32-32-32-32 14.3-32 32 14.3 32 32 32zm160 0c17.7 0 32-14.3 32-32s-14.3-32-32-32-32 14.3-32 32 14.3 32 32 32zm4 72.6c-20.8 25-51.5 39.4-84 39.4s-63.2-14.3-84-39.4c-8.5-10.2-23.7-11.5-33.8-3.1-10.2 8.5-11.5 23.6-3.1 33.8 30 36 74.1 56.6 120.9 56.6s90.9-20.6 120.9-56.6c8.5-10.2 7.1-25.3-3.1-33.8-10.1-8.4-25.3-7.1-33.8 3.1z"
+                <svg
+                  class="EmojiIcon Icon"
+                  viewBox="0 0 496 512"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M248 8C111 8 0 119 0 256s111 248 248 248 248-111 248-248S385 8 248 8zm0 448c-110.3 0-200-89.7-200-200S137.7 56 248 56s200 89.7 200 200-89.7 200-200 200zm-80-216c17.7 0 32-14.3 32-32s-14.3-32-32-32-32 14.3-32 32 14.3 32 32 32zm160 0c17.7 0 32-14.3 32-32s-14.3-32-32-32-32 14.3-32 32 14.3 32 32 32zm4 72.6c-20.8 25-51.5 39.4-84 39.4s-63.2-14.3-84-39.4c-8.5-10.2-23.7-11.5-33.8-3.1-10.2 8.5-11.5 23.6-3.1 33.8 30 36 74.1 56.6 120.9 56.6s90.9-20.6 120.9-56.6c8.5-10.2 7.1-25.3-3.1-33.8-10.1-8.4-25.3-7.1-33.8 3.1z"
+                  />
+                </svg>
+                <div
+                  class="menu-name"
+                >
+                  Random
+                </div>
+                <div
+                  class="noicon"
                 />
-              </svg>
-              <div
-                class="menu-name"
-              >
-                Random
               </div>
-              <div
-                class="noicon"
-              />
             </div>
-            <div
-              class="MenuOption SubMenuOption menu-option"
-              id="pick"
-            >
-              <svg
-                class="EmojiIcon Icon"
-                viewBox="0 0 496 512"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M248 8C111 8 0 119 0 256s111 248 248 248 248-111 248-248S385 8 248 8zm0 448c-110.3 0-200-89.7-200-200S137.7 56 248 56s200 89.7 200 200-89.7 200-200 200zm-80-216c17.7 0 32-14.3 32-32s-14.3-32-32-32-32 14.3-32 32 14.3 32 32 32zm160 0c17.7 0 32-14.3 32-32s-14.3-32-32-32-32 14.3-32 32 14.3 32 32 32zm4 72.6c-20.8 25-51.5 39.4-84 39.4s-63.2-14.3-84-39.4c-8.5-10.2-23.7-11.5-33.8-3.1-10.2 8.5-11.5 23.6-3.1 33.8 30 36 74.1 56.6 120.9 56.6s90.9-20.6 120.9-56.6c8.5-10.2 7.1-25.3-3.1-33.8-10.1-8.4-25.3-7.1-33.8 3.1z"
-                />
-              </svg>
+            <div>
               <div
-                class="menu-name"
+                class="MenuOption SubMenuOption menu-option "
+                id="pick"
               >
-                Pick icon
+                <svg
+                  class="EmojiIcon Icon"
+                  viewBox="0 0 496 512"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M248 8C111 8 0 119 0 256s111 248 248 248 248-111 248-248S385 8 248 8zm0 448c-110.3 0-200-89.7-200-200S137.7 56 248 56s200 89.7 200 200-89.7 200-200 200zm-80-216c17.7 0 32-14.3 32-32s-14.3-32-32-32-32 14.3-32 32 14.3 32 32 32zm160 0c17.7 0 32-14.3 32-32s-14.3-32-32-32-32 14.3-32 32 14.3 32 32 32zm4 72.6c-20.8 25-51.5 39.4-84 39.4s-63.2-14.3-84-39.4c-8.5-10.2-23.7-11.5-33.8-3.1-10.2 8.5-11.5 23.6-3.1 33.8 30 36 74.1 56.6 120.9 56.6s90.9-20.6 120.9-56.6c8.5-10.2 7.1-25.3-3.1-33.8-10.1-8.4-25.3-7.1-33.8 3.1z"
+                  />
+                </svg>
+                <div
+                  class="menu-name"
+                >
+                  Pick icon
+                </div>
+                <svg
+                  class="SubmenuTriangleIcon Icon"
+                  viewBox="0 0 100 100"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <polygon
+                    points="50,35 75,50 50,65"
+                  />
+                </svg>
               </div>
-              <svg
-                class="SubmenuTriangleIcon Icon"
-                viewBox="0 0 100 100"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <polygon
-                  points="50,35 75,50 50,65"
-                />
-              </svg>
             </div>
-            <div
-              aria-label="Remove icon"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
-              <svg
-                class="DeleteIcon Icon"
-                viewBox="0 0 448 512"
-                xmlns="http://www.w3.org/2000/svg"
+            <div>
+              <div
+                aria-label="Remove icon"
+                class="MenuOption TextOption menu-option"
+                role="button"
               >
-                <path
-                  d="M268 416h24a12 12 0 0 0 12-12V188a12 12 0 0 0-12-12h-24a12 12 0 0 0-12 12v216a12 12 0 0 0 12 12zM432 80h-82.41l-34-56.7A48 48 0 0 0 274.41 0H173.59a48 48 0 0 0-41.16 23.3L98.41 80H16A16 16 0 0 0 0 96v16a16 16 0 0 0 16 16h16v336a48 48 0 0 0 48 48h288a48 48 0 0 0 48-48V128h16a16 16 0 0 0 16-16V96a16 16 0 0 0-16-16zM171.84 50.91A6 6 0 0 1 177 48h94a6 6 0 0 1 5.15 2.91L293.61 80H154.39zM368 464H80V128h288zm-212-48h24a12 12 0 0 0 12-12V188a12 12 0 0 0-12-12h-24a12 12 0 0 0-12 12v216a12 12 0 0 0 12 12z"
+                <svg
+                  class="DeleteIcon Icon"
+                  viewBox="0 0 448 512"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M268 416h24a12 12 0 0 0 12-12V188a12 12 0 0 0-12-12h-24a12 12 0 0 0-12 12v216a12 12 0 0 0 12 12zM432 80h-82.41l-34-56.7A48 48 0 0 0 274.41 0H173.59a48 48 0 0 0-41.16 23.3L98.41 80H16A16 16 0 0 0 0 96v16a16 16 0 0 0 16 16h16v336a48 48 0 0 0 48 48h288a48 48 0 0 0 48-48V128h16a16 16 0 0 0 16-16V96a16 16 0 0 0-16-16zM171.84 50.91A6 6 0 0 1 177 48h94a6 6 0 0 1 5.15 2.91L293.61 80H154.39zM368 464H80V128h288zm-212-48h24a12 12 0 0 0 12-12V188a12 12 0 0 0-12-12h-24a12 12 0 0 0-12 12v216a12 12 0 0 0 12 12z"
+                  />
+                </svg>
+                <div
+                  class="menu-name"
+                >
+                  Remove icon
+                </div>
+                <div
+                  class="noicon"
                 />
-              </svg>
-              <div
-                class="menu-name"
-              >
-                Remove icon
               </div>
-              <div
-                class="noicon"
-              />
             </div>
           </div>
           <div
@@ -156,6 +162,8 @@ exports[`components/blockIconSelector return menu on click 1`] = `
 
 exports[`components/blockIconSelector return no element with no icon 1`] = `<div />`;
 
+exports[`components/blockIconSelector return no icon after click on remove menu 1`] = `<div />`;
+
 exports[`components/blockIconSelector return no menu in readonly 1`] = `
 <div>
   <div
@@ -171,7 +179,3 @@ exports[`components/blockIconSelector return no menu in readonly 1`] = `
   </div>
 </div>
 `;
-
-
-exports[`components/blockIconSelector return no icon after click on remove menu 1`] = `<div />`;
-

--- a/webapp/src/components/__snapshots__/blockIconSelector.test.tsx.snap
+++ b/webapp/src/components/__snapshots__/blockIconSelector.test.tsx.snap
@@ -75,7 +75,7 @@ exports[`components/blockIconSelector return menu on click 1`] = `
             </div>
             <div>
               <div
-                class="MenuOption SubMenuOption menu-option "
+                class="MenuOption SubMenuOption menu-option"
                 id="pick"
               >
                 <svg

--- a/webapp/src/components/__snapshots__/cardDialog.test.tsx.snap
+++ b/webapp/src/components/__snapshots__/cardDialog.test.tsx.snap
@@ -142,62 +142,68 @@ exports[`components/cardDialog return cardDialog menu content 1`] = `
                 <div
                   class="menu-options"
                 >
-                  <div
-                    aria-label="Delete"
-                    class="MenuOption TextOption menu-option"
-                    role="button"
-                  >
-                    <svg
-                      class="DeleteIcon Icon"
-                      viewBox="0 0 448 512"
-                      xmlns="http://www.w3.org/2000/svg"
+                  <div>
+                    <div
+                      aria-label="Delete"
+                      class="MenuOption TextOption menu-option"
+                      role="button"
                     >
-                      <path
-                        d="M268 416h24a12 12 0 0 0 12-12V188a12 12 0 0 0-12-12h-24a12 12 0 0 0-12 12v216a12 12 0 0 0 12 12zM432 80h-82.41l-34-56.7A48 48 0 0 0 274.41 0H173.59a48 48 0 0 0-41.16 23.3L98.41 80H16A16 16 0 0 0 0 96v16a16 16 0 0 0 16 16h16v336a48 48 0 0 0 48 48h288a48 48 0 0 0 48-48V128h16a16 16 0 0 0 16-16V96a16 16 0 0 0-16-16zM171.84 50.91A6 6 0 0 1 177 48h94a6 6 0 0 1 5.15 2.91L293.61 80H154.39zM368 464H80V128h288zm-212-48h24a12 12 0 0 0 12-12V188a12 12 0 0 0-12-12h-24a12 12 0 0 0-12 12v216a12 12 0 0 0 12 12z"
+                      <svg
+                        class="DeleteIcon Icon"
+                        viewBox="0 0 448 512"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M268 416h24a12 12 0 0 0 12-12V188a12 12 0 0 0-12-12h-24a12 12 0 0 0-12 12v216a12 12 0 0 0 12 12zM432 80h-82.41l-34-56.7A48 48 0 0 0 274.41 0H173.59a48 48 0 0 0-41.16 23.3L98.41 80H16A16 16 0 0 0 0 96v16a16 16 0 0 0 16 16h16v336a48 48 0 0 0 48 48h288a48 48 0 0 0 48-48V128h16a16 16 0 0 0 16-16V96a16 16 0 0 0-16-16zM171.84 50.91A6 6 0 0 1 177 48h94a6 6 0 0 1 5.15 2.91L293.61 80H154.39zM368 464H80V128h288zm-212-48h24a12 12 0 0 0 12-12V188a12 12 0 0 0-12-12h-24a12 12 0 0 0-12 12v216a12 12 0 0 0 12 12z"
+                        />
+                      </svg>
+                      <div
+                        class="menu-name"
+                      >
+                        Delete
+                      </div>
+                      <div
+                        class="noicon"
                       />
-                    </svg>
-                    <div
-                      class="menu-name"
-                    >
-                      Delete
                     </div>
-                    <div
-                      class="noicon"
-                    />
                   </div>
-                  <div
-                    aria-label="Copy link"
-                    class="MenuOption TextOption menu-option"
-                    role="button"
-                  >
-                    <i
-                      class="CompassIcon icon-link-variant LinkIcon"
-                    />
+                  <div>
                     <div
-                      class="menu-name"
+                      aria-label="Copy link"
+                      class="MenuOption TextOption menu-option"
+                      role="button"
                     >
-                      Copy link
+                      <i
+                        class="CompassIcon icon-link-variant LinkIcon"
+                      />
+                      <div
+                        class="menu-name"
+                      >
+                        Copy link
+                      </div>
+                      <div
+                        class="noicon"
+                      />
                     </div>
-                    <div
-                      class="noicon"
-                    />
                   </div>
-                  <div
-                    aria-label="New template from card"
-                    class="MenuOption TextOption menu-option"
-                    role="button"
-                  >
+                  <div>
                     <div
-                      class="noicon"
-                    />
-                    <div
-                      class="menu-name"
+                      aria-label="New template from card"
+                      class="MenuOption TextOption menu-option"
+                      role="button"
                     >
-                      New template from card
+                      <div
+                        class="noicon"
+                      />
+                      <div
+                        class="menu-name"
+                      >
+                        New template from card
+                      </div>
+                      <div
+                        class="noicon"
+                      />
                     </div>
-                    <div
-                      class="noicon"
-                    />
                   </div>
                 </div>
                 <div

--- a/webapp/src/components/__snapshots__/contentBlock.test.tsx.snap
+++ b/webapp/src/components/__snapshots__/contentBlock.test.tsx.snap
@@ -33,102 +33,110 @@ exports[`components/contentBlock return commentBlock and click on menuwrapper 1`
               <div
                 class="menu-options"
               >
-                <div
-                  aria-label="Move up"
-                  class="MenuOption TextOption menu-option"
-                  role="button"
-                >
-                  <svg
-                    class="SortUpIcon Icon"
-                    viewBox="0 0 100 100"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <polyline
-                      points="50,20 50,80"
-                    />
-                    <polyline
-                      points="30,40 50,20 70,40"
-                    />
-                  </svg>
+                <div>
                   <div
-                    class="menu-name"
+                    aria-label="Move up"
+                    class="MenuOption TextOption menu-option"
+                    role="button"
                   >
-                    Move up
+                    <svg
+                      class="SortUpIcon Icon"
+                      viewBox="0 0 100 100"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <polyline
+                        points="50,20 50,80"
+                      />
+                      <polyline
+                        points="30,40 50,20 70,40"
+                      />
+                    </svg>
+                    <div
+                      class="menu-name"
+                    >
+                      Move up
+                    </div>
+                    <div
+                      class="noicon"
+                    />
                   </div>
-                  <div
-                    class="noicon"
-                  />
                 </div>
-                <div
-                  aria-label="Move down"
-                  class="MenuOption TextOption menu-option"
-                  role="button"
-                >
-                  <svg
-                    class="SortDownIcon Icon"
-                    viewBox="0 0 100 100"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <polyline
-                      points="50,20 50,80"
-                    />
-                    <polyline
-                      points="30,60 50,80 70,60"
-                    />
-                  </svg>
+                <div>
                   <div
-                    class="menu-name"
+                    aria-label="Move down"
+                    class="MenuOption TextOption menu-option"
+                    role="button"
                   >
-                    Move down
+                    <svg
+                      class="SortDownIcon Icon"
+                      viewBox="0 0 100 100"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <polyline
+                        points="50,20 50,80"
+                      />
+                      <polyline
+                        points="30,60 50,80 70,60"
+                      />
+                    </svg>
+                    <div
+                      class="menu-name"
+                    >
+                      Move down
+                    </div>
+                    <div
+                      class="noicon"
+                    />
                   </div>
-                  <div
-                    class="noicon"
-                  />
                 </div>
-                <div
-                  class="MenuOption SubMenuOption menu-option"
-                  id="insertAbove"
-                >
-                  <i
-                    class="CompassIcon icon-plus AddIcon"
-                  />
+                <div>
                   <div
-                    class="menu-name"
+                    class="MenuOption SubMenuOption menu-option"
+                    id="insertAbove"
                   >
-                    Insert above
-                  </div>
-                  <svg
-                    class="SubmenuTriangleIcon Icon"
-                    viewBox="0 0 100 100"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <polygon
-                      points="50,35 75,50 50,65"
+                    <i
+                      class="CompassIcon icon-plus AddIcon"
                     />
-                  </svg>
+                    <div
+                      class="menu-name"
+                    >
+                      Insert above
+                    </div>
+                    <svg
+                      class="SubmenuTriangleIcon Icon"
+                      viewBox="0 0 100 100"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <polygon
+                        points="50,35 75,50 50,65"
+                      />
+                    </svg>
+                  </div>
                 </div>
-                <div
-                  aria-label="Delete"
-                  class="MenuOption TextOption menu-option"
-                  role="button"
-                >
-                  <svg
-                    class="DeleteIcon Icon"
-                    viewBox="0 0 448 512"
-                    xmlns="http://www.w3.org/2000/svg"
+                <div>
+                  <div
+                    aria-label="Delete"
+                    class="MenuOption TextOption menu-option"
+                    role="button"
                   >
-                    <path
-                      d="M268 416h24a12 12 0 0 0 12-12V188a12 12 0 0 0-12-12h-24a12 12 0 0 0-12 12v216a12 12 0 0 0 12 12zM432 80h-82.41l-34-56.7A48 48 0 0 0 274.41 0H173.59a48 48 0 0 0-41.16 23.3L98.41 80H16A16 16 0 0 0 0 96v16a16 16 0 0 0 16 16h16v336a48 48 0 0 0 48 48h288a48 48 0 0 0 48-48V128h16a16 16 0 0 0 16-16V96a16 16 0 0 0-16-16zM171.84 50.91A6 6 0 0 1 177 48h94a6 6 0 0 1 5.15 2.91L293.61 80H154.39zM368 464H80V128h288zm-212-48h24a12 12 0 0 0 12-12V188a12 12 0 0 0-12-12h-24a12 12 0 0 0-12 12v216a12 12 0 0 0 12 12z"
+                    <svg
+                      class="DeleteIcon Icon"
+                      viewBox="0 0 448 512"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M268 416h24a12 12 0 0 0 12-12V188a12 12 0 0 0-12-12h-24a12 12 0 0 0-12 12v216a12 12 0 0 0 12 12zM432 80h-82.41l-34-56.7A48 48 0 0 0 274.41 0H173.59a48 48 0 0 0-41.16 23.3L98.41 80H16A16 16 0 0 0 0 96v16a16 16 0 0 0 16 16h16v336a48 48 0 0 0 48 48h288a48 48 0 0 0 48-48V128h16a16 16 0 0 0 16-16V96a16 16 0 0 0-16-16zM171.84 50.91A6 6 0 0 1 177 48h94a6 6 0 0 1 5.15 2.91L293.61 80H154.39zM368 464H80V128h288zm-212-48h24a12 12 0 0 0 12-12V188a12 12 0 0 0-12-12h-24a12 12 0 0 0-12 12v216a12 12 0 0 0 12 12z"
+                      />
+                    </svg>
+                    <div
+                      class="menu-name"
+                    >
+                      Delete
+                    </div>
+                    <div
+                      class="noicon"
                     />
-                  </svg>
-                  <div
-                    class="menu-name"
-                  >
-                    Delete
                   </div>
-                  <div
-                    class="noicon"
-                  />
                 </div>
               </div>
               <div

--- a/webapp/src/components/__snapshots__/viewMenu.test.tsx.snap
+++ b/webapp/src/components/__snapshots__/viewMenu.test.tsx.snap
@@ -14,150 +14,162 @@ Object {
           <div
             class="menu-options"
           >
-            <div
-              aria-label="view title"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
-              <svg
-                class="TableIcon Icon"
-                viewBox="0 0 100 100"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <rect
-                  height="80"
-                  rx="5"
-                  ry="5"
-                  width="80"
-                  x="10"
-                  y="10"
-                />
-                <polyline
-                  points="37,10 37,90"
-                />
-                <polyline
-                  points="10,37 90,37"
-                />
-                <polyline
-                  points="10,63 90,63"
-                />
-              </svg>
+            <div>
               <div
-                class="menu-name"
+                aria-label="view title"
+                class="MenuOption TextOption menu-option"
+                role="button"
               >
-                view title
+                <svg
+                  class="TableIcon Icon"
+                  viewBox="0 0 100 100"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <rect
+                    height="80"
+                    rx="5"
+                    ry="5"
+                    width="80"
+                    x="10"
+                    y="10"
+                  />
+                  <polyline
+                    points="37,10 37,90"
+                  />
+                  <polyline
+                    points="10,37 90,37"
+                  />
+                  <polyline
+                    points="10,63 90,63"
+                  />
+                </svg>
+                <div
+                  class="menu-name"
+                >
+                  view title
+                </div>
+                <div
+                  class="noicon"
+                />
               </div>
+            </div>
+            <div>
               <div
-                class="noicon"
+                aria-label="view title"
+                class="MenuOption TextOption menu-option"
+                role="button"
+              >
+                <svg
+                  class="TableIcon Icon"
+                  viewBox="0 0 100 100"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <rect
+                    height="80"
+                    rx="5"
+                    ry="5"
+                    width="80"
+                    x="10"
+                    y="10"
+                  />
+                  <polyline
+                    points="37,10 37,90"
+                  />
+                  <polyline
+                    points="10,37 90,37"
+                  />
+                  <polyline
+                    points="10,63 90,63"
+                  />
+                </svg>
+                <div
+                  class="menu-name"
+                >
+                  view title
+                </div>
+                <div
+                  class="noicon"
+                />
+              </div>
+            </div>
+            <div>
+              <div
+                class="MenuOption MenuSeparator menu-separator"
               />
             </div>
-            <div
-              aria-label="view title"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
-              <svg
-                class="TableIcon Icon"
-                viewBox="0 0 100 100"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <rect
-                  height="80"
-                  rx="5"
-                  ry="5"
-                  width="80"
-                  x="10"
-                  y="10"
-                />
-                <polyline
-                  points="37,10 37,90"
-                />
-                <polyline
-                  points="10,37 90,37"
-                />
-                <polyline
-                  points="10,63 90,63"
-                />
-              </svg>
+            <div>
               <div
-                class="menu-name"
+                aria-label="Duplicate view"
+                class="MenuOption TextOption menu-option"
+                role="button"
               >
-                view title
+                <svg
+                  class="DuplicateIcon Icon"
+                  viewBox="0 0 512 512"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M464 0H144c-26.51 0-48 21.49-48 48v48H48c-26.51 0-48 21.49-48 48v320c0 26.51 21.49 48 48 48h320c26.51 0 48-21.49 48-48v-48h48c26.51 0 48-21.49 48-48V48c0-26.51-21.49-48-48-48zM362 464H54a6 6 0 0 1-6-6V150a6 6 0 0 1 6-6h42v224c0 26.51 21.49 48 48 48h224v42a6 6 0 0 1-6 6zm96-96H150a6 6 0 0 1-6-6V54a6 6 0 0 1 6-6h308a6 6 0 0 1 6 6v308a6 6 0 0 1-6 6z"
+                  />
+                </svg>
+                <div
+                  class="menu-name"
+                >
+                  Duplicate view
+                </div>
+                <div
+                  class="noicon"
+                />
               </div>
-              <div
-                class="noicon"
-              />
             </div>
-            <div
-              class="MenuOption MenuSeparator menu-separator"
-            />
-            <div
-              aria-label="Duplicate view"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
-              <svg
-                class="DuplicateIcon Icon"
-                viewBox="0 0 512 512"
-                xmlns="http://www.w3.org/2000/svg"
+            <div>
+              <div
+                aria-label="Delete view"
+                class="MenuOption TextOption menu-option"
+                role="button"
               >
-                <path
-                  d="M464 0H144c-26.51 0-48 21.49-48 48v48H48c-26.51 0-48 21.49-48 48v320c0 26.51 21.49 48 48 48h320c26.51 0 48-21.49 48-48v-48h48c26.51 0 48-21.49 48-48V48c0-26.51-21.49-48-48-48zM362 464H54a6 6 0 0 1-6-6V150a6 6 0 0 1 6-6h42v224c0 26.51 21.49 48 48 48h224v42a6 6 0 0 1-6 6zm96-96H150a6 6 0 0 1-6-6V54a6 6 0 0 1 6-6h308a6 6 0 0 1 6 6v308a6 6 0 0 1-6 6z"
+                <svg
+                  class="DeleteIcon Icon"
+                  viewBox="0 0 448 512"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M268 416h24a12 12 0 0 0 12-12V188a12 12 0 0 0-12-12h-24a12 12 0 0 0-12 12v216a12 12 0 0 0 12 12zM432 80h-82.41l-34-56.7A48 48 0 0 0 274.41 0H173.59a48 48 0 0 0-41.16 23.3L98.41 80H16A16 16 0 0 0 0 96v16a16 16 0 0 0 16 16h16v336a48 48 0 0 0 48 48h288a48 48 0 0 0 48-48V128h16a16 16 0 0 0 16-16V96a16 16 0 0 0-16-16zM171.84 50.91A6 6 0 0 1 177 48h94a6 6 0 0 1 5.15 2.91L293.61 80H154.39zM368 464H80V128h288zm-212-48h24a12 12 0 0 0 12-12V188a12 12 0 0 0-12-12h-24a12 12 0 0 0-12 12v216a12 12 0 0 0 12 12z"
+                  />
+                </svg>
+                <div
+                  class="menu-name"
+                >
+                  Delete view
+                </div>
+                <div
+                  class="noicon"
                 />
-              </svg>
-              <div
-                class="menu-name"
-              >
-                Duplicate view
               </div>
-              <div
-                class="noicon"
-              />
             </div>
-            <div
-              aria-label="Delete view"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
-              <svg
-                class="DeleteIcon Icon"
-                viewBox="0 0 448 512"
-                xmlns="http://www.w3.org/2000/svg"
+            <div>
+              <div
+                class="MenuOption SubMenuOption menu-option"
+                id="__addView"
               >
-                <path
-                  d="M268 416h24a12 12 0 0 0 12-12V188a12 12 0 0 0-12-12h-24a12 12 0 0 0-12 12v216a12 12 0 0 0 12 12zM432 80h-82.41l-34-56.7A48 48 0 0 0 274.41 0H173.59a48 48 0 0 0-41.16 23.3L98.41 80H16A16 16 0 0 0 0 96v16a16 16 0 0 0 16 16h16v336a48 48 0 0 0 48 48h288a48 48 0 0 0 48-48V128h16a16 16 0 0 0 16-16V96a16 16 0 0 0-16-16zM171.84 50.91A6 6 0 0 1 177 48h94a6 6 0 0 1 5.15 2.91L293.61 80H154.39zM368 464H80V128h288zm-212-48h24a12 12 0 0 0 12-12V188a12 12 0 0 0-12-12h-24a12 12 0 0 0-12 12v216a12 12 0 0 0 12 12z"
+                <i
+                  class="CompassIcon icon-plus AddIcon"
                 />
-              </svg>
-              <div
-                class="menu-name"
-              >
-                Delete view
+                <div
+                  class="menu-name"
+                >
+                  Add view
+                </div>
+                <svg
+                  class="SubmenuTriangleIcon Icon"
+                  viewBox="0 0 100 100"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <polygon
+                    points="50,35 75,50 50,65"
+                  />
+                </svg>
               </div>
-              <div
-                class="noicon"
-              />
-            </div>
-            <div
-              class="MenuOption SubMenuOption menu-option"
-              id="__addView"
-            >
-              <i
-                class="CompassIcon icon-plus AddIcon"
-              />
-              <div
-                class="menu-name"
-              >
-                Add view
-              </div>
-              <svg
-                class="SubmenuTriangleIcon Icon"
-                viewBox="0 0 100 100"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <polygon
-                  points="50,35 75,50 50,65"
-                />
-              </svg>
             </div>
           </div>
           <div
@@ -198,150 +210,162 @@ Object {
         <div
           class="menu-options"
         >
-          <div
-            aria-label="view title"
-            class="MenuOption TextOption menu-option"
-            role="button"
-          >
-            <svg
-              class="TableIcon Icon"
-              viewBox="0 0 100 100"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <rect
-                height="80"
-                rx="5"
-                ry="5"
-                width="80"
-                x="10"
-                y="10"
-              />
-              <polyline
-                points="37,10 37,90"
-              />
-              <polyline
-                points="10,37 90,37"
-              />
-              <polyline
-                points="10,63 90,63"
-              />
-            </svg>
+          <div>
             <div
-              class="menu-name"
+              aria-label="view title"
+              class="MenuOption TextOption menu-option"
+              role="button"
             >
-              view title
+              <svg
+                class="TableIcon Icon"
+                viewBox="0 0 100 100"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <rect
+                  height="80"
+                  rx="5"
+                  ry="5"
+                  width="80"
+                  x="10"
+                  y="10"
+                />
+                <polyline
+                  points="37,10 37,90"
+                />
+                <polyline
+                  points="10,37 90,37"
+                />
+                <polyline
+                  points="10,63 90,63"
+                />
+              </svg>
+              <div
+                class="menu-name"
+              >
+                view title
+              </div>
+              <div
+                class="noicon"
+              />
             </div>
+          </div>
+          <div>
             <div
-              class="noicon"
+              aria-label="view title"
+              class="MenuOption TextOption menu-option"
+              role="button"
+            >
+              <svg
+                class="TableIcon Icon"
+                viewBox="0 0 100 100"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <rect
+                  height="80"
+                  rx="5"
+                  ry="5"
+                  width="80"
+                  x="10"
+                  y="10"
+                />
+                <polyline
+                  points="37,10 37,90"
+                />
+                <polyline
+                  points="10,37 90,37"
+                />
+                <polyline
+                  points="10,63 90,63"
+                />
+              </svg>
+              <div
+                class="menu-name"
+              >
+                view title
+              </div>
+              <div
+                class="noicon"
+              />
+            </div>
+          </div>
+          <div>
+            <div
+              class="MenuOption MenuSeparator menu-separator"
             />
           </div>
-          <div
-            aria-label="view title"
-            class="MenuOption TextOption menu-option"
-            role="button"
-          >
-            <svg
-              class="TableIcon Icon"
-              viewBox="0 0 100 100"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <rect
-                height="80"
-                rx="5"
-                ry="5"
-                width="80"
-                x="10"
-                y="10"
-              />
-              <polyline
-                points="37,10 37,90"
-              />
-              <polyline
-                points="10,37 90,37"
-              />
-              <polyline
-                points="10,63 90,63"
-              />
-            </svg>
+          <div>
             <div
-              class="menu-name"
+              aria-label="Duplicate view"
+              class="MenuOption TextOption menu-option"
+              role="button"
             >
-              view title
+              <svg
+                class="DuplicateIcon Icon"
+                viewBox="0 0 512 512"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M464 0H144c-26.51 0-48 21.49-48 48v48H48c-26.51 0-48 21.49-48 48v320c0 26.51 21.49 48 48 48h320c26.51 0 48-21.49 48-48v-48h48c26.51 0 48-21.49 48-48V48c0-26.51-21.49-48-48-48zM362 464H54a6 6 0 0 1-6-6V150a6 6 0 0 1 6-6h42v224c0 26.51 21.49 48 48 48h224v42a6 6 0 0 1-6 6zm96-96H150a6 6 0 0 1-6-6V54a6 6 0 0 1 6-6h308a6 6 0 0 1 6 6v308a6 6 0 0 1-6 6z"
+                />
+              </svg>
+              <div
+                class="menu-name"
+              >
+                Duplicate view
+              </div>
+              <div
+                class="noicon"
+              />
             </div>
-            <div
-              class="noicon"
-            />
           </div>
-          <div
-            class="MenuOption MenuSeparator menu-separator"
-          />
-          <div
-            aria-label="Duplicate view"
-            class="MenuOption TextOption menu-option"
-            role="button"
-          >
-            <svg
-              class="DuplicateIcon Icon"
-              viewBox="0 0 512 512"
-              xmlns="http://www.w3.org/2000/svg"
+          <div>
+            <div
+              aria-label="Delete view"
+              class="MenuOption TextOption menu-option"
+              role="button"
             >
-              <path
-                d="M464 0H144c-26.51 0-48 21.49-48 48v48H48c-26.51 0-48 21.49-48 48v320c0 26.51 21.49 48 48 48h320c26.51 0 48-21.49 48-48v-48h48c26.51 0 48-21.49 48-48V48c0-26.51-21.49-48-48-48zM362 464H54a6 6 0 0 1-6-6V150a6 6 0 0 1 6-6h42v224c0 26.51 21.49 48 48 48h224v42a6 6 0 0 1-6 6zm96-96H150a6 6 0 0 1-6-6V54a6 6 0 0 1 6-6h308a6 6 0 0 1 6 6v308a6 6 0 0 1-6 6z"
+              <svg
+                class="DeleteIcon Icon"
+                viewBox="0 0 448 512"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M268 416h24a12 12 0 0 0 12-12V188a12 12 0 0 0-12-12h-24a12 12 0 0 0-12 12v216a12 12 0 0 0 12 12zM432 80h-82.41l-34-56.7A48 48 0 0 0 274.41 0H173.59a48 48 0 0 0-41.16 23.3L98.41 80H16A16 16 0 0 0 0 96v16a16 16 0 0 0 16 16h16v336a48 48 0 0 0 48 48h288a48 48 0 0 0 48-48V128h16a16 16 0 0 0 16-16V96a16 16 0 0 0-16-16zM171.84 50.91A6 6 0 0 1 177 48h94a6 6 0 0 1 5.15 2.91L293.61 80H154.39zM368 464H80V128h288zm-212-48h24a12 12 0 0 0 12-12V188a12 12 0 0 0-12-12h-24a12 12 0 0 0-12 12v216a12 12 0 0 0 12 12z"
+                />
+              </svg>
+              <div
+                class="menu-name"
+              >
+                Delete view
+              </div>
+              <div
+                class="noicon"
               />
-            </svg>
-            <div
-              class="menu-name"
-            >
-              Duplicate view
             </div>
-            <div
-              class="noicon"
-            />
           </div>
-          <div
-            aria-label="Delete view"
-            class="MenuOption TextOption menu-option"
-            role="button"
-          >
-            <svg
-              class="DeleteIcon Icon"
-              viewBox="0 0 448 512"
-              xmlns="http://www.w3.org/2000/svg"
+          <div>
+            <div
+              class="MenuOption SubMenuOption menu-option"
+              id="__addView"
             >
-              <path
-                d="M268 416h24a12 12 0 0 0 12-12V188a12 12 0 0 0-12-12h-24a12 12 0 0 0-12 12v216a12 12 0 0 0 12 12zM432 80h-82.41l-34-56.7A48 48 0 0 0 274.41 0H173.59a48 48 0 0 0-41.16 23.3L98.41 80H16A16 16 0 0 0 0 96v16a16 16 0 0 0 16 16h16v336a48 48 0 0 0 48 48h288a48 48 0 0 0 48-48V128h16a16 16 0 0 0 16-16V96a16 16 0 0 0-16-16zM171.84 50.91A6 6 0 0 1 177 48h94a6 6 0 0 1 5.15 2.91L293.61 80H154.39zM368 464H80V128h288zm-212-48h24a12 12 0 0 0 12-12V188a12 12 0 0 0-12-12h-24a12 12 0 0 0-12 12v216a12 12 0 0 0 12 12z"
+              <i
+                class="CompassIcon icon-plus AddIcon"
               />
-            </svg>
-            <div
-              class="menu-name"
-            >
-              Delete view
+              <div
+                class="menu-name"
+              >
+                Add view
+              </div>
+              <svg
+                class="SubmenuTriangleIcon Icon"
+                viewBox="0 0 100 100"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <polygon
+                  points="50,35 75,50 50,65"
+                />
+              </svg>
             </div>
-            <div
-              class="noicon"
-            />
-          </div>
-          <div
-            class="MenuOption SubMenuOption menu-option"
-            id="__addView"
-          >
-            <i
-              class="CompassIcon icon-plus AddIcon"
-            />
-            <div
-              class="menu-name"
-            >
-              Add view
-            </div>
-            <svg
-              class="SubmenuTriangleIcon Icon"
-              viewBox="0 0 100 100"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <polygon
-                points="50,35 75,50 50,65"
-              />
-            </svg>
           </div>
         </div>
         <div
@@ -439,83 +463,89 @@ Object {
           <div
             class="menu-options"
           >
-            <div
-              aria-label="view title"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
-              <svg
-                class="TableIcon Icon"
-                viewBox="0 0 100 100"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <rect
-                  height="80"
-                  rx="5"
-                  ry="5"
-                  width="80"
-                  x="10"
-                  y="10"
-                />
-                <polyline
-                  points="37,10 37,90"
-                />
-                <polyline
-                  points="10,37 90,37"
-                />
-                <polyline
-                  points="10,63 90,63"
-                />
-              </svg>
+            <div>
               <div
-                class="menu-name"
+                aria-label="view title"
+                class="MenuOption TextOption menu-option"
+                role="button"
               >
-                view title
+                <svg
+                  class="TableIcon Icon"
+                  viewBox="0 0 100 100"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <rect
+                    height="80"
+                    rx="5"
+                    ry="5"
+                    width="80"
+                    x="10"
+                    y="10"
+                  />
+                  <polyline
+                    points="37,10 37,90"
+                  />
+                  <polyline
+                    points="10,37 90,37"
+                  />
+                  <polyline
+                    points="10,63 90,63"
+                  />
+                </svg>
+                <div
+                  class="menu-name"
+                >
+                  view title
+                </div>
+                <div
+                  class="noicon"
+                />
               </div>
+            </div>
+            <div>
               <div
-                class="noicon"
+                aria-label="view title"
+                class="MenuOption TextOption menu-option"
+                role="button"
+              >
+                <svg
+                  class="TableIcon Icon"
+                  viewBox="0 0 100 100"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <rect
+                    height="80"
+                    rx="5"
+                    ry="5"
+                    width="80"
+                    x="10"
+                    y="10"
+                  />
+                  <polyline
+                    points="37,10 37,90"
+                  />
+                  <polyline
+                    points="10,37 90,37"
+                  />
+                  <polyline
+                    points="10,63 90,63"
+                  />
+                </svg>
+                <div
+                  class="menu-name"
+                >
+                  view title
+                </div>
+                <div
+                  class="noicon"
+                />
+              </div>
+            </div>
+            <div>
+              <div
+                class="MenuOption MenuSeparator menu-separator"
               />
             </div>
-            <div
-              aria-label="view title"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
-              <svg
-                class="TableIcon Icon"
-                viewBox="0 0 100 100"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <rect
-                  height="80"
-                  rx="5"
-                  ry="5"
-                  width="80"
-                  x="10"
-                  y="10"
-                />
-                <polyline
-                  points="37,10 37,90"
-                />
-                <polyline
-                  points="10,37 90,37"
-                />
-                <polyline
-                  points="10,63 90,63"
-                />
-              </svg>
-              <div
-                class="menu-name"
-              >
-                view title
-              </div>
-              <div
-                class="noicon"
-              />
-            </div>
-            <div
-              class="MenuOption MenuSeparator menu-separator"
-            />
           </div>
           <div
             class="menu-spacer hideOnWidescreen"
@@ -555,83 +585,89 @@ Object {
         <div
           class="menu-options"
         >
-          <div
-            aria-label="view title"
-            class="MenuOption TextOption menu-option"
-            role="button"
-          >
-            <svg
-              class="TableIcon Icon"
-              viewBox="0 0 100 100"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <rect
-                height="80"
-                rx="5"
-                ry="5"
-                width="80"
-                x="10"
-                y="10"
-              />
-              <polyline
-                points="37,10 37,90"
-              />
-              <polyline
-                points="10,37 90,37"
-              />
-              <polyline
-                points="10,63 90,63"
-              />
-            </svg>
+          <div>
             <div
-              class="menu-name"
+              aria-label="view title"
+              class="MenuOption TextOption menu-option"
+              role="button"
             >
-              view title
+              <svg
+                class="TableIcon Icon"
+                viewBox="0 0 100 100"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <rect
+                  height="80"
+                  rx="5"
+                  ry="5"
+                  width="80"
+                  x="10"
+                  y="10"
+                />
+                <polyline
+                  points="37,10 37,90"
+                />
+                <polyline
+                  points="10,37 90,37"
+                />
+                <polyline
+                  points="10,63 90,63"
+                />
+              </svg>
+              <div
+                class="menu-name"
+              >
+                view title
+              </div>
+              <div
+                class="noicon"
+              />
             </div>
+          </div>
+          <div>
             <div
-              class="noicon"
+              aria-label="view title"
+              class="MenuOption TextOption menu-option"
+              role="button"
+            >
+              <svg
+                class="TableIcon Icon"
+                viewBox="0 0 100 100"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <rect
+                  height="80"
+                  rx="5"
+                  ry="5"
+                  width="80"
+                  x="10"
+                  y="10"
+                />
+                <polyline
+                  points="37,10 37,90"
+                />
+                <polyline
+                  points="10,37 90,37"
+                />
+                <polyline
+                  points="10,63 90,63"
+                />
+              </svg>
+              <div
+                class="menu-name"
+              >
+                view title
+              </div>
+              <div
+                class="noicon"
+              />
+            </div>
+          </div>
+          <div>
+            <div
+              class="MenuOption MenuSeparator menu-separator"
             />
           </div>
-          <div
-            aria-label="view title"
-            class="MenuOption TextOption menu-option"
-            role="button"
-          >
-            <svg
-              class="TableIcon Icon"
-              viewBox="0 0 100 100"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <rect
-                height="80"
-                rx="5"
-                ry="5"
-                width="80"
-                x="10"
-                y="10"
-              />
-              <polyline
-                points="37,10 37,90"
-              />
-              <polyline
-                points="10,37 90,37"
-              />
-              <polyline
-                points="10,63 90,63"
-              />
-            </svg>
-            <div
-              class="menu-name"
-            >
-              view title
-            </div>
-            <div
-              class="noicon"
-            />
-          </div>
-          <div
-            class="MenuOption MenuSeparator menu-separator"
-          />
         </div>
         <div
           class="menu-spacer hideOnWidescreen"

--- a/webapp/src/components/cardDetail/__snapshots__/cardDetailContentsMenu.test.tsx.snap
+++ b/webapp/src/components/cardDetail/__snapshots__/cardDetailContentsMenu.test.tsx.snap
@@ -27,97 +27,105 @@ exports[`components/cardDetail/cardDetailContentsMenu return cardDetailContentsM
           <div
             class="menu-options"
           >
-            <div
-              aria-label="text"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
-              <svg
-                class="TextIcon Icon"
-                viewBox="0 0 448 512"
-                xmlns="http://www.w3.org/2000/svg"
+            <div>
+              <div
+                aria-label="text"
+                class="MenuOption TextOption menu-option"
+                role="button"
               >
-                <path
-                  d="M432 416H16a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h416a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16zm0-128H16a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h416a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16zm0-128H16a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h416a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16zm0-128H16A16 16 0 0 0 0 48v32a16 16 0 0 0 16 16h416a16 16 0 0 0 16-16V48a16 16 0 0 0-16-16z"
+                <svg
+                  class="TextIcon Icon"
+                  viewBox="0 0 448 512"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M432 416H16a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h416a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16zm0-128H16a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h416a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16zm0-128H16a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h416a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16zm0-128H16A16 16 0 0 0 0 48v32a16 16 0 0 0 16 16h416a16 16 0 0 0 16-16V48a16 16 0 0 0-16-16z"
+                  />
+                </svg>
+                <div
+                  class="menu-name"
+                >
+                  text
+                </div>
+                <div
+                  class="noicon"
                 />
-              </svg>
-              <div
-                class="menu-name"
-              >
-                text
               </div>
-              <div
-                class="noicon"
-              />
             </div>
-            <div
-              aria-label="image"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
-              <svg
-                class="ImageIcon Icon"
-                viewBox="0 0 512 512"
-                xmlns="http://www.w3.org/2000/svg"
+            <div>
+              <div
+                aria-label="image"
+                class="MenuOption TextOption menu-option"
+                role="button"
               >
-                <path
-                  d="M464 64H48C21.49 64 0 85.49 0 112v288c0 26.51 21.49 48 48 48h416c26.51 0 48-21.49 48-48V112c0-26.51-21.49-48-48-48zm-6 336H54a6 6 0 0 1-6-6V118a6 6 0 0 1 6-6h404a6 6 0 0 1 6 6v276a6 6 0 0 1-6 6zM128 152c-22.091 0-40 17.909-40 40s17.909 40 40 40 40-17.909 40-40-17.909-40-40-40zM96 352h320v-80l-87.515-87.515c-4.686-4.686-12.284-4.686-16.971 0L192 304l-39.515-39.515c-4.686-4.686-12.284-4.686-16.971 0L96 304v48z"
+                <svg
+                  class="ImageIcon Icon"
+                  viewBox="0 0 512 512"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M464 64H48C21.49 64 0 85.49 0 112v288c0 26.51 21.49 48 48 48h416c26.51 0 48-21.49 48-48V112c0-26.51-21.49-48-48-48zm-6 336H54a6 6 0 0 1-6-6V118a6 6 0 0 1 6-6h404a6 6 0 0 1 6 6v276a6 6 0 0 1-6 6zM128 152c-22.091 0-40 17.909-40 40s17.909 40 40 40 40-17.909 40-40-17.909-40-40-40zM96 352h320v-80l-87.515-87.515c-4.686-4.686-12.284-4.686-16.971 0L192 304l-39.515-39.515c-4.686-4.686-12.284-4.686-16.971 0L96 304v48z"
+                  />
+                </svg>
+                <div
+                  class="menu-name"
+                >
+                  image
+                </div>
+                <div
+                  class="noicon"
                 />
-              </svg>
-              <div
-                class="menu-name"
-              >
-                image
               </div>
-              <div
-                class="noicon"
-              />
             </div>
-            <div
-              aria-label="divider"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
-              <svg
-                class="DividerIcon Icon"
-                viewBox="0 0 448 512"
-                xmlns="http://www.w3.org/2000/svg"
+            <div>
+              <div
+                aria-label="divider"
+                class="MenuOption TextOption menu-option"
+                role="button"
               >
-                <path
-                  d="M 432,224 H 16 c -8.836556,0 -16,7.16344 -16,16 v 32 c 0,8.83656 7.163444,16 16,16 h 416 c 8.83656,0 16,-7.16344 16,-16 v -32 c 0,-8.83656 -7.16344,-16 -16,-16 z"
+                <svg
+                  class="DividerIcon Icon"
+                  viewBox="0 0 448 512"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M 432,224 H 16 c -8.836556,0 -16,7.16344 -16,16 v 32 c 0,8.83656 7.163444,16 16,16 h 416 c 8.83656,0 16,-7.16344 16,-16 v -32 c 0,-8.83656 -7.16344,-16 -16,-16 z"
+                  />
+                </svg>
+                <div
+                  class="menu-name"
+                >
+                  divider
+                </div>
+                <div
+                  class="noicon"
                 />
-              </svg>
-              <div
-                class="menu-name"
-              >
-                divider
               </div>
-              <div
-                class="noicon"
-              />
             </div>
-            <div
-              aria-label="checkbox"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
-              <svg
-                class="CheckIcon Icon"
-                viewBox="0 0 100 100"
-                xmlns="http://www.w3.org/2000/svg"
+            <div>
+              <div
+                aria-label="checkbox"
+                class="MenuOption TextOption menu-option"
+                role="button"
               >
-                <polyline
-                  points="20,60 40,80 80,40"
+                <svg
+                  class="CheckIcon Icon"
+                  viewBox="0 0 100 100"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <polyline
+                    points="20,60 40,80 80,40"
+                  />
+                </svg>
+                <div
+                  class="menu-name"
+                >
+                  checkbox
+                </div>
+                <div
+                  class="noicon"
                 />
-              </svg>
-              <div
-                class="menu-name"
-              >
-                checkbox
               </div>
-              <div
-                class="noicon"
-              />
             </div>
           </div>
           <div
@@ -178,97 +186,105 @@ exports[`components/cardDetail/cardDetailContentsMenu return cardDetailContentsM
           <div
             class="menu-options"
           >
-            <div
-              aria-label="text"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
-              <svg
-                class="TextIcon Icon"
-                viewBox="0 0 448 512"
-                xmlns="http://www.w3.org/2000/svg"
+            <div>
+              <div
+                aria-label="text"
+                class="MenuOption TextOption menu-option"
+                role="button"
               >
-                <path
-                  d="M432 416H16a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h416a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16zm0-128H16a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h416a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16zm0-128H16a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h416a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16zm0-128H16A16 16 0 0 0 0 48v32a16 16 0 0 0 16 16h416a16 16 0 0 0 16-16V48a16 16 0 0 0-16-16z"
+                <svg
+                  class="TextIcon Icon"
+                  viewBox="0 0 448 512"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M432 416H16a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h416a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16zm0-128H16a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h416a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16zm0-128H16a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h416a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16zm0-128H16A16 16 0 0 0 0 48v32a16 16 0 0 0 16 16h416a16 16 0 0 0 16-16V48a16 16 0 0 0-16-16z"
+                  />
+                </svg>
+                <div
+                  class="menu-name"
+                >
+                  text
+                </div>
+                <div
+                  class="noicon"
                 />
-              </svg>
-              <div
-                class="menu-name"
-              >
-                text
               </div>
-              <div
-                class="noicon"
-              />
             </div>
-            <div
-              aria-label="image"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
-              <svg
-                class="ImageIcon Icon"
-                viewBox="0 0 512 512"
-                xmlns="http://www.w3.org/2000/svg"
+            <div>
+              <div
+                aria-label="image"
+                class="MenuOption TextOption menu-option"
+                role="button"
               >
-                <path
-                  d="M464 64H48C21.49 64 0 85.49 0 112v288c0 26.51 21.49 48 48 48h416c26.51 0 48-21.49 48-48V112c0-26.51-21.49-48-48-48zm-6 336H54a6 6 0 0 1-6-6V118a6 6 0 0 1 6-6h404a6 6 0 0 1 6 6v276a6 6 0 0 1-6 6zM128 152c-22.091 0-40 17.909-40 40s17.909 40 40 40 40-17.909 40-40-17.909-40-40-40zM96 352h320v-80l-87.515-87.515c-4.686-4.686-12.284-4.686-16.971 0L192 304l-39.515-39.515c-4.686-4.686-12.284-4.686-16.971 0L96 304v48z"
+                <svg
+                  class="ImageIcon Icon"
+                  viewBox="0 0 512 512"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M464 64H48C21.49 64 0 85.49 0 112v288c0 26.51 21.49 48 48 48h416c26.51 0 48-21.49 48-48V112c0-26.51-21.49-48-48-48zm-6 336H54a6 6 0 0 1-6-6V118a6 6 0 0 1 6-6h404a6 6 0 0 1 6 6v276a6 6 0 0 1-6 6zM128 152c-22.091 0-40 17.909-40 40s17.909 40 40 40 40-17.909 40-40-17.909-40-40-40zM96 352h320v-80l-87.515-87.515c-4.686-4.686-12.284-4.686-16.971 0L192 304l-39.515-39.515c-4.686-4.686-12.284-4.686-16.971 0L96 304v48z"
+                  />
+                </svg>
+                <div
+                  class="menu-name"
+                >
+                  image
+                </div>
+                <div
+                  class="noicon"
                 />
-              </svg>
-              <div
-                class="menu-name"
-              >
-                image
               </div>
-              <div
-                class="noicon"
-              />
             </div>
-            <div
-              aria-label="divider"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
-              <svg
-                class="DividerIcon Icon"
-                viewBox="0 0 448 512"
-                xmlns="http://www.w3.org/2000/svg"
+            <div>
+              <div
+                aria-label="divider"
+                class="MenuOption TextOption menu-option"
+                role="button"
               >
-                <path
-                  d="M 432,224 H 16 c -8.836556,0 -16,7.16344 -16,16 v 32 c 0,8.83656 7.163444,16 16,16 h 416 c 8.83656,0 16,-7.16344 16,-16 v -32 c 0,-8.83656 -7.16344,-16 -16,-16 z"
+                <svg
+                  class="DividerIcon Icon"
+                  viewBox="0 0 448 512"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M 432,224 H 16 c -8.836556,0 -16,7.16344 -16,16 v 32 c 0,8.83656 7.163444,16 16,16 h 416 c 8.83656,0 16,-7.16344 16,-16 v -32 c 0,-8.83656 -7.16344,-16 -16,-16 z"
+                  />
+                </svg>
+                <div
+                  class="menu-name"
+                >
+                  divider
+                </div>
+                <div
+                  class="noicon"
                 />
-              </svg>
-              <div
-                class="menu-name"
-              >
-                divider
               </div>
-              <div
-                class="noicon"
-              />
             </div>
-            <div
-              aria-label="checkbox"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
-              <svg
-                class="CheckIcon Icon"
-                viewBox="0 0 100 100"
-                xmlns="http://www.w3.org/2000/svg"
+            <div>
+              <div
+                aria-label="checkbox"
+                class="MenuOption TextOption menu-option"
+                role="button"
               >
-                <polyline
-                  points="20,60 40,80 80,40"
+                <svg
+                  class="CheckIcon Icon"
+                  viewBox="0 0 100 100"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <polyline
+                    points="20,60 40,80 80,40"
+                  />
+                </svg>
+                <div
+                  class="menu-name"
+                >
+                  checkbox
+                </div>
+                <div
+                  class="noicon"
                 />
-              </svg>
-              <div
-                class="menu-name"
-              >
-                checkbox
               </div>
-              <div
-                class="noicon"
-              />
             </div>
           </div>
           <div

--- a/webapp/src/components/cardDetail/__snapshots__/cardDetailProperties.test.tsx.snap
+++ b/webapp/src/components/cardDetail/__snapshots__/cardDetailProperties.test.tsx.snap
@@ -131,263 +131,265 @@ exports[`components/cardDetail/CardDetailProperties should show property types m
             <div
               class="menu-options"
             >
-              <div
-                class="MenuOption LabelOption menu-option"
-              >
+              <div>
                 <div
-                  class="noicon"
-                />
-                <div
-                  class="menu-name"
+                  class="MenuOption LabelOption menu-option"
                 >
-                  <b>
-                    Select property type
-                  </b>
+                  <div
+                    class="noicon"
+                  />
+                  <div
+                    class="menu-name"
+                  >
+                    <b>
+                      Select property type
+                    </b>
+                  </div>
+                  <div
+                    class="noicon"
+                  />
                 </div>
                 <div
-                  class="noicon"
-                />
-              </div>
-              <div
-                class="MenuOption MenuSeparator menu-separator"
-              />
-              <div
-                aria-label="Text"
-                class="MenuOption TextOption menu-option"
-                role="button"
-              >
-                <div
-                  class="noicon"
+                  class="MenuOption MenuSeparator menu-separator"
                 />
                 <div
-                  class="menu-name"
+                  aria-label="Text"
+                  class="MenuOption TextOption menu-option"
+                  role="button"
                 >
-                  Text
+                  <div
+                    class="noicon"
+                  />
+                  <div
+                    class="menu-name"
+                  >
+                    Text
+                  </div>
+                  <div
+                    class="noicon"
+                  />
                 </div>
                 <div
-                  class="noicon"
-                />
-              </div>
-              <div
-                aria-label="Number"
-                class="MenuOption TextOption menu-option"
-                role="button"
-              >
-                <div
-                  class="noicon"
-                />
-                <div
-                  class="menu-name"
+                  aria-label="Number"
+                  class="MenuOption TextOption menu-option"
+                  role="button"
                 >
-                  Number
+                  <div
+                    class="noicon"
+                  />
+                  <div
+                    class="menu-name"
+                  >
+                    Number
+                  </div>
+                  <div
+                    class="noicon"
+                  />
                 </div>
                 <div
-                  class="noicon"
-                />
-              </div>
-              <div
-                aria-label="Email"
-                class="MenuOption TextOption menu-option"
-                role="button"
-              >
-                <div
-                  class="noicon"
-                />
-                <div
-                  class="menu-name"
+                  aria-label="Email"
+                  class="MenuOption TextOption menu-option"
+                  role="button"
                 >
-                  Email
+                  <div
+                    class="noicon"
+                  />
+                  <div
+                    class="menu-name"
+                  >
+                    Email
+                  </div>
+                  <div
+                    class="noicon"
+                  />
                 </div>
                 <div
-                  class="noicon"
-                />
-              </div>
-              <div
-                aria-label="Phone"
-                class="MenuOption TextOption menu-option"
-                role="button"
-              >
-                <div
-                  class="noicon"
-                />
-                <div
-                  class="menu-name"
+                  aria-label="Phone"
+                  class="MenuOption TextOption menu-option"
+                  role="button"
                 >
-                  Phone
+                  <div
+                    class="noicon"
+                  />
+                  <div
+                    class="menu-name"
+                  >
+                    Phone
+                  </div>
+                  <div
+                    class="noicon"
+                  />
                 </div>
                 <div
-                  class="noicon"
-                />
-              </div>
-              <div
-                aria-label="URL"
-                class="MenuOption TextOption menu-option"
-                role="button"
-              >
-                <div
-                  class="noicon"
-                />
-                <div
-                  class="menu-name"
+                  aria-label="URL"
+                  class="MenuOption TextOption menu-option"
+                  role="button"
                 >
-                  URL
+                  <div
+                    class="noicon"
+                  />
+                  <div
+                    class="menu-name"
+                  >
+                    URL
+                  </div>
+                  <div
+                    class="noicon"
+                  />
                 </div>
                 <div
-                  class="noicon"
-                />
-              </div>
-              <div
-                aria-label="Select"
-                class="MenuOption TextOption menu-option"
-                role="button"
-              >
-                <div
-                  class="noicon"
-                />
-                <div
-                  class="menu-name"
+                  aria-label="Select"
+                  class="MenuOption TextOption menu-option"
+                  role="button"
                 >
-                  Select
+                  <div
+                    class="noicon"
+                  />
+                  <div
+                    class="menu-name"
+                  >
+                    Select
+                  </div>
+                  <div
+                    class="noicon"
+                  />
                 </div>
                 <div
-                  class="noicon"
-                />
-              </div>
-              <div
-                aria-label="Multi Select"
-                class="MenuOption TextOption menu-option"
-                role="button"
-              >
-                <div
-                  class="noicon"
-                />
-                <div
-                  class="menu-name"
+                  aria-label="Multi Select"
+                  class="MenuOption TextOption menu-option"
+                  role="button"
                 >
-                  Multi Select
+                  <div
+                    class="noicon"
+                  />
+                  <div
+                    class="menu-name"
+                  >
+                    Multi Select
+                  </div>
+                  <div
+                    class="noicon"
+                  />
                 </div>
                 <div
-                  class="noicon"
-                />
-              </div>
-              <div
-                aria-label="Date"
-                class="MenuOption TextOption menu-option"
-                role="button"
-              >
-                <div
-                  class="noicon"
-                />
-                <div
-                  class="menu-name"
+                  aria-label="Date"
+                  class="MenuOption TextOption menu-option"
+                  role="button"
                 >
-                  Date
+                  <div
+                    class="noicon"
+                  />
+                  <div
+                    class="menu-name"
+                  >
+                    Date
+                  </div>
+                  <div
+                    class="noicon"
+                  />
                 </div>
                 <div
-                  class="noicon"
-                />
-              </div>
-              <div
-                aria-label="Person"
-                class="MenuOption TextOption menu-option"
-                role="button"
-              >
-                <div
-                  class="noicon"
-                />
-                <div
-                  class="menu-name"
+                  aria-label="Person"
+                  class="MenuOption TextOption menu-option"
+                  role="button"
                 >
-                  Person
+                  <div
+                    class="noicon"
+                  />
+                  <div
+                    class="menu-name"
+                  >
+                    Person
+                  </div>
+                  <div
+                    class="noicon"
+                  />
                 </div>
                 <div
-                  class="noicon"
-                />
-              </div>
-              <div
-                aria-label="Checkbox"
-                class="MenuOption TextOption menu-option"
-                role="button"
-              >
-                <div
-                  class="noicon"
-                />
-                <div
-                  class="menu-name"
+                  aria-label="Checkbox"
+                  class="MenuOption TextOption menu-option"
+                  role="button"
                 >
-                  Checkbox
+                  <div
+                    class="noicon"
+                  />
+                  <div
+                    class="menu-name"
+                  >
+                    Checkbox
+                  </div>
+                  <div
+                    class="noicon"
+                  />
                 </div>
                 <div
-                  class="noicon"
-                />
-              </div>
-              <div
-                aria-label="Created time"
-                class="MenuOption TextOption menu-option"
-                role="button"
-              >
-                <div
-                  class="noicon"
-                />
-                <div
-                  class="menu-name"
+                  aria-label="Created time"
+                  class="MenuOption TextOption menu-option"
+                  role="button"
                 >
-                  Created time
+                  <div
+                    class="noicon"
+                  />
+                  <div
+                    class="menu-name"
+                  >
+                    Created time
+                  </div>
+                  <div
+                    class="noicon"
+                  />
                 </div>
                 <div
-                  class="noicon"
-                />
-              </div>
-              <div
-                aria-label="Created by"
-                class="MenuOption TextOption menu-option"
-                role="button"
-              >
-                <div
-                  class="noicon"
-                />
-                <div
-                  class="menu-name"
+                  aria-label="Created by"
+                  class="MenuOption TextOption menu-option"
+                  role="button"
                 >
-                  Created by
+                  <div
+                    class="noicon"
+                  />
+                  <div
+                    class="menu-name"
+                  >
+                    Created by
+                  </div>
+                  <div
+                    class="noicon"
+                  />
                 </div>
                 <div
-                  class="noicon"
-                />
-              </div>
-              <div
-                aria-label="Last updated time"
-                class="MenuOption TextOption menu-option"
-                role="button"
-              >
-                <div
-                  class="noicon"
-                />
-                <div
-                  class="menu-name"
+                  aria-label="Last updated time"
+                  class="MenuOption TextOption menu-option"
+                  role="button"
                 >
-                  Last updated time
+                  <div
+                    class="noicon"
+                  />
+                  <div
+                    class="menu-name"
+                  >
+                    Last updated time
+                  </div>
+                  <div
+                    class="noicon"
+                  />
                 </div>
                 <div
-                  class="noicon"
-                />
-              </div>
-              <div
-                aria-label="Last updated by"
-                class="MenuOption TextOption menu-option"
-                role="button"
-              >
-                <div
-                  class="noicon"
-                />
-                <div
-                  class="menu-name"
+                  aria-label="Last updated by"
+                  class="MenuOption TextOption menu-option"
+                  role="button"
                 >
-                  Last updated by
+                  <div
+                    class="noicon"
+                  />
+                  <div
+                    class="menu-name"
+                  >
+                    Last updated by
+                  </div>
+                  <div
+                    class="noicon"
+                  />
                 </div>
-                <div
-                  class="noicon"
-                />
               </div>
             </div>
             <div

--- a/webapp/src/components/cardDetail/__snapshots__/comment.test.tsx.snap
+++ b/webapp/src/components/cardDetail/__snapshots__/comment.test.tsx.snap
@@ -47,28 +47,30 @@ exports[`components/cardDetail/comment return comment 1`] = `
             <div
               class="menu-options"
             >
-              <div
-                aria-label="Delete"
-                class="MenuOption TextOption menu-option"
-                role="button"
-              >
-                <svg
-                  class="DeleteIcon Icon"
-                  viewBox="0 0 448 512"
-                  xmlns="http://www.w3.org/2000/svg"
+              <div>
+                <div
+                  aria-label="Delete"
+                  class="MenuOption TextOption menu-option"
+                  role="button"
                 >
-                  <path
-                    d="M268 416h24a12 12 0 0 0 12-12V188a12 12 0 0 0-12-12h-24a12 12 0 0 0-12 12v216a12 12 0 0 0 12 12zM432 80h-82.41l-34-56.7A48 48 0 0 0 274.41 0H173.59a48 48 0 0 0-41.16 23.3L98.41 80H16A16 16 0 0 0 0 96v16a16 16 0 0 0 16 16h16v336a48 48 0 0 0 48 48h288a48 48 0 0 0 48-48V128h16a16 16 0 0 0 16-16V96a16 16 0 0 0-16-16zM171.84 50.91A6 6 0 0 1 177 48h94a6 6 0 0 1 5.15 2.91L293.61 80H154.39zM368 464H80V128h288zm-212-48h24a12 12 0 0 0 12-12V188a12 12 0 0 0-12-12h-24a12 12 0 0 0-12 12v216a12 12 0 0 0 12 12z"
+                  <svg
+                    class="DeleteIcon Icon"
+                    viewBox="0 0 448 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M268 416h24a12 12 0 0 0 12-12V188a12 12 0 0 0-12-12h-24a12 12 0 0 0-12 12v216a12 12 0 0 0 12 12zM432 80h-82.41l-34-56.7A48 48 0 0 0 274.41 0H173.59a48 48 0 0 0-41.16 23.3L98.41 80H16A16 16 0 0 0 0 96v16a16 16 0 0 0 16 16h16v336a48 48 0 0 0 48 48h288a48 48 0 0 0 48-48V128h16a16 16 0 0 0 16-16V96a16 16 0 0 0-16-16zM171.84 50.91A6 6 0 0 1 177 48h94a6 6 0 0 1 5.15 2.91L293.61 80H154.39zM368 464H80V128h288zm-212-48h24a12 12 0 0 0 12-12V188a12 12 0 0 0-12-12h-24a12 12 0 0 0-12 12v216a12 12 0 0 0 12 12z"
+                    />
+                  </svg>
+                  <div
+                    class="menu-name"
+                  >
+                    Delete
+                  </div>
+                  <div
+                    class="noicon"
                   />
-                </svg>
-                <div
-                  class="menu-name"
-                >
-                  Delete
                 </div>
-                <div
-                  class="noicon"
-                />
               </div>
             </div>
             <div
@@ -157,28 +159,30 @@ exports[`components/cardDetail/comment return comment and delete comment 1`] = `
             <div
               class="menu-options"
             >
-              <div
-                aria-label="Delete"
-                class="MenuOption TextOption menu-option"
-                role="button"
-              >
-                <svg
-                  class="DeleteIcon Icon"
-                  viewBox="0 0 448 512"
-                  xmlns="http://www.w3.org/2000/svg"
+              <div>
+                <div
+                  aria-label="Delete"
+                  class="MenuOption TextOption menu-option"
+                  role="button"
                 >
-                  <path
-                    d="M268 416h24a12 12 0 0 0 12-12V188a12 12 0 0 0-12-12h-24a12 12 0 0 0-12 12v216a12 12 0 0 0 12 12zM432 80h-82.41l-34-56.7A48 48 0 0 0 274.41 0H173.59a48 48 0 0 0-41.16 23.3L98.41 80H16A16 16 0 0 0 0 96v16a16 16 0 0 0 16 16h16v336a48 48 0 0 0 48 48h288a48 48 0 0 0 48-48V128h16a16 16 0 0 0 16-16V96a16 16 0 0 0-16-16zM171.84 50.91A6 6 0 0 1 177 48h94a6 6 0 0 1 5.15 2.91L293.61 80H154.39zM368 464H80V128h288zm-212-48h24a12 12 0 0 0 12-12V188a12 12 0 0 0-12-12h-24a12 12 0 0 0-12 12v216a12 12 0 0 0 12 12z"
+                  <svg
+                    class="DeleteIcon Icon"
+                    viewBox="0 0 448 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M268 416h24a12 12 0 0 0 12-12V188a12 12 0 0 0-12-12h-24a12 12 0 0 0-12 12v216a12 12 0 0 0 12 12zM432 80h-82.41l-34-56.7A48 48 0 0 0 274.41 0H173.59a48 48 0 0 0-41.16 23.3L98.41 80H16A16 16 0 0 0 0 96v16a16 16 0 0 0 16 16h16v336a48 48 0 0 0 48 48h288a48 48 0 0 0 48-48V128h16a16 16 0 0 0 16-16V96a16 16 0 0 0-16-16zM171.84 50.91A6 6 0 0 1 177 48h94a6 6 0 0 1 5.15 2.91L293.61 80H154.39zM368 464H80V128h288zm-212-48h24a12 12 0 0 0 12-12V188a12 12 0 0 0-12-12h-24a12 12 0 0 0-12 12v216a12 12 0 0 0 12 12z"
+                    />
+                  </svg>
+                  <div
+                    class="menu-name"
+                  >
+                    Delete
+                  </div>
+                  <div
+                    class="noicon"
                   />
-                </svg>
-                <div
-                  class="menu-name"
-                >
-                  Delete
                 </div>
-                <div
-                  class="noicon"
-                />
               </div>
             </div>
             <div

--- a/webapp/src/components/gallery/__snapshots__/gallery.test.tsx.snap
+++ b/webapp/src/components/gallery/__snapshots__/gallery.test.tsx.snap
@@ -119,68 +119,74 @@ exports[`src/components/gallery/Gallery should match snapshot 1`] = `
             <div
               class="menu-options"
             >
-              <div
-                aria-label="Delete"
-                class="MenuOption TextOption menu-option"
-                role="button"
-              >
-                <svg
-                  class="DeleteIcon Icon"
-                  viewBox="0 0 448 512"
-                  xmlns="http://www.w3.org/2000/svg"
+              <div>
+                <div
+                  aria-label="Delete"
+                  class="MenuOption TextOption menu-option"
+                  role="button"
                 >
-                  <path
-                    d="M268 416h24a12 12 0 0 0 12-12V188a12 12 0 0 0-12-12h-24a12 12 0 0 0-12 12v216a12 12 0 0 0 12 12zM432 80h-82.41l-34-56.7A48 48 0 0 0 274.41 0H173.59a48 48 0 0 0-41.16 23.3L98.41 80H16A16 16 0 0 0 0 96v16a16 16 0 0 0 16 16h16v336a48 48 0 0 0 48 48h288a48 48 0 0 0 48-48V128h16a16 16 0 0 0 16-16V96a16 16 0 0 0-16-16zM171.84 50.91A6 6 0 0 1 177 48h94a6 6 0 0 1 5.15 2.91L293.61 80H154.39zM368 464H80V128h288zm-212-48h24a12 12 0 0 0 12-12V188a12 12 0 0 0-12-12h-24a12 12 0 0 0-12 12v216a12 12 0 0 0 12 12z"
+                  <svg
+                    class="DeleteIcon Icon"
+                    viewBox="0 0 448 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M268 416h24a12 12 0 0 0 12-12V188a12 12 0 0 0-12-12h-24a12 12 0 0 0-12 12v216a12 12 0 0 0 12 12zM432 80h-82.41l-34-56.7A48 48 0 0 0 274.41 0H173.59a48 48 0 0 0-41.16 23.3L98.41 80H16A16 16 0 0 0 0 96v16a16 16 0 0 0 16 16h16v336a48 48 0 0 0 48 48h288a48 48 0 0 0 48-48V128h16a16 16 0 0 0 16-16V96a16 16 0 0 0-16-16zM171.84 50.91A6 6 0 0 1 177 48h94a6 6 0 0 1 5.15 2.91L293.61 80H154.39zM368 464H80V128h288zm-212-48h24a12 12 0 0 0 12-12V188a12 12 0 0 0-12-12h-24a12 12 0 0 0-12 12v216a12 12 0 0 0 12 12z"
+                    />
+                  </svg>
+                  <div
+                    class="menu-name"
+                  >
+                    Delete
+                  </div>
+                  <div
+                    class="noicon"
                   />
-                </svg>
-                <div
-                  class="menu-name"
-                >
-                  Delete
                 </div>
-                <div
-                  class="noicon"
-                />
               </div>
-              <div
-                aria-label="Duplicate"
-                class="MenuOption TextOption menu-option"
-                role="button"
-              >
-                <svg
-                  class="DuplicateIcon Icon"
-                  viewBox="0 0 512 512"
-                  xmlns="http://www.w3.org/2000/svg"
+              <div>
+                <div
+                  aria-label="Duplicate"
+                  class="MenuOption TextOption menu-option"
+                  role="button"
                 >
-                  <path
-                    d="M464 0H144c-26.51 0-48 21.49-48 48v48H48c-26.51 0-48 21.49-48 48v320c0 26.51 21.49 48 48 48h320c26.51 0 48-21.49 48-48v-48h48c26.51 0 48-21.49 48-48V48c0-26.51-21.49-48-48-48zM362 464H54a6 6 0 0 1-6-6V150a6 6 0 0 1 6-6h42v224c0 26.51 21.49 48 48 48h224v42a6 6 0 0 1-6 6zm96-96H150a6 6 0 0 1-6-6V54a6 6 0 0 1 6-6h308a6 6 0 0 1 6 6v308a6 6 0 0 1-6 6z"
+                  <svg
+                    class="DuplicateIcon Icon"
+                    viewBox="0 0 512 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M464 0H144c-26.51 0-48 21.49-48 48v48H48c-26.51 0-48 21.49-48 48v320c0 26.51 21.49 48 48 48h320c26.51 0 48-21.49 48-48v-48h48c26.51 0 48-21.49 48-48V48c0-26.51-21.49-48-48-48zM362 464H54a6 6 0 0 1-6-6V150a6 6 0 0 1 6-6h42v224c0 26.51 21.49 48 48 48h224v42a6 6 0 0 1-6 6zm96-96H150a6 6 0 0 1-6-6V54a6 6 0 0 1 6-6h308a6 6 0 0 1 6 6v308a6 6 0 0 1-6 6z"
+                    />
+                  </svg>
+                  <div
+                    class="menu-name"
+                  >
+                    Duplicate
+                  </div>
+                  <div
+                    class="noicon"
                   />
-                </svg>
-                <div
-                  class="menu-name"
-                >
-                  Duplicate
                 </div>
-                <div
-                  class="noicon"
-                />
               </div>
-              <div
-                aria-label="Copy link"
-                class="MenuOption TextOption menu-option"
-                role="button"
-              >
-                <i
-                  class="CompassIcon icon-link-variant LinkIcon"
-                />
+              <div>
                 <div
-                  class="menu-name"
+                  aria-label="Copy link"
+                  class="MenuOption TextOption menu-option"
+                  role="button"
                 >
-                  Copy link
+                  <i
+                    class="CompassIcon icon-link-variant LinkIcon"
+                  />
+                  <div
+                    class="menu-name"
+                  >
+                    Copy link
+                  </div>
+                  <div
+                    class="noicon"
+                  />
                 </div>
-                <div
-                  class="noicon"
-                />
               </div>
             </div>
             <div

--- a/webapp/src/components/gallery/__snapshots__/galleryCard.test.tsx.snap
+++ b/webapp/src/components/gallery/__snapshots__/galleryCard.test.tsx.snap
@@ -55,68 +55,74 @@ exports[`src/components/gallery/GalleryCard with a comment content should match 
           <div
             class="menu-options"
           >
-            <div
-              aria-label="Delete"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
-              <svg
-                class="DeleteIcon Icon"
-                viewBox="0 0 448 512"
-                xmlns="http://www.w3.org/2000/svg"
+            <div>
+              <div
+                aria-label="Delete"
+                class="MenuOption TextOption menu-option"
+                role="button"
               >
-                <path
-                  d="M268 416h24a12 12 0 0 0 12-12V188a12 12 0 0 0-12-12h-24a12 12 0 0 0-12 12v216a12 12 0 0 0 12 12zM432 80h-82.41l-34-56.7A48 48 0 0 0 274.41 0H173.59a48 48 0 0 0-41.16 23.3L98.41 80H16A16 16 0 0 0 0 96v16a16 16 0 0 0 16 16h16v336a48 48 0 0 0 48 48h288a48 48 0 0 0 48-48V128h16a16 16 0 0 0 16-16V96a16 16 0 0 0-16-16zM171.84 50.91A6 6 0 0 1 177 48h94a6 6 0 0 1 5.15 2.91L293.61 80H154.39zM368 464H80V128h288zm-212-48h24a12 12 0 0 0 12-12V188a12 12 0 0 0-12-12h-24a12 12 0 0 0-12 12v216a12 12 0 0 0 12 12z"
+                <svg
+                  class="DeleteIcon Icon"
+                  viewBox="0 0 448 512"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M268 416h24a12 12 0 0 0 12-12V188a12 12 0 0 0-12-12h-24a12 12 0 0 0-12 12v216a12 12 0 0 0 12 12zM432 80h-82.41l-34-56.7A48 48 0 0 0 274.41 0H173.59a48 48 0 0 0-41.16 23.3L98.41 80H16A16 16 0 0 0 0 96v16a16 16 0 0 0 16 16h16v336a48 48 0 0 0 48 48h288a48 48 0 0 0 48-48V128h16a16 16 0 0 0 16-16V96a16 16 0 0 0-16-16zM171.84 50.91A6 6 0 0 1 177 48h94a6 6 0 0 1 5.15 2.91L293.61 80H154.39zM368 464H80V128h288zm-212-48h24a12 12 0 0 0 12-12V188a12 12 0 0 0-12-12h-24a12 12 0 0 0-12 12v216a12 12 0 0 0 12 12z"
+                  />
+                </svg>
+                <div
+                  class="menu-name"
+                >
+                  Delete
+                </div>
+                <div
+                  class="noicon"
                 />
-              </svg>
-              <div
-                class="menu-name"
-              >
-                Delete
               </div>
-              <div
-                class="noicon"
-              />
             </div>
-            <div
-              aria-label="Duplicate"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
-              <svg
-                class="DuplicateIcon Icon"
-                viewBox="0 0 512 512"
-                xmlns="http://www.w3.org/2000/svg"
+            <div>
+              <div
+                aria-label="Duplicate"
+                class="MenuOption TextOption menu-option"
+                role="button"
               >
-                <path
-                  d="M464 0H144c-26.51 0-48 21.49-48 48v48H48c-26.51 0-48 21.49-48 48v320c0 26.51 21.49 48 48 48h320c26.51 0 48-21.49 48-48v-48h48c26.51 0 48-21.49 48-48V48c0-26.51-21.49-48-48-48zM362 464H54a6 6 0 0 1-6-6V150a6 6 0 0 1 6-6h42v224c0 26.51 21.49 48 48 48h224v42a6 6 0 0 1-6 6zm96-96H150a6 6 0 0 1-6-6V54a6 6 0 0 1 6-6h308a6 6 0 0 1 6 6v308a6 6 0 0 1-6 6z"
+                <svg
+                  class="DuplicateIcon Icon"
+                  viewBox="0 0 512 512"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M464 0H144c-26.51 0-48 21.49-48 48v48H48c-26.51 0-48 21.49-48 48v320c0 26.51 21.49 48 48 48h320c26.51 0 48-21.49 48-48v-48h48c26.51 0 48-21.49 48-48V48c0-26.51-21.49-48-48-48zM362 464H54a6 6 0 0 1-6-6V150a6 6 0 0 1 6-6h42v224c0 26.51 21.49 48 48 48h224v42a6 6 0 0 1-6 6zm96-96H150a6 6 0 0 1-6-6V54a6 6 0 0 1 6-6h308a6 6 0 0 1 6 6v308a6 6 0 0 1-6 6z"
+                  />
+                </svg>
+                <div
+                  class="menu-name"
+                >
+                  Duplicate
+                </div>
+                <div
+                  class="noicon"
                 />
-              </svg>
-              <div
-                class="menu-name"
-              >
-                Duplicate
               </div>
-              <div
-                class="noicon"
-              />
             </div>
-            <div
-              aria-label="Copy link"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
-              <i
-                class="CompassIcon icon-link-variant LinkIcon"
-              />
+            <div>
               <div
-                class="menu-name"
+                aria-label="Copy link"
+                class="MenuOption TextOption menu-option"
+                role="button"
               >
-                Copy link
+                <i
+                  class="CompassIcon icon-link-variant LinkIcon"
+                />
+                <div
+                  class="menu-name"
+                >
+                  Copy link
+                </div>
+                <div
+                  class="noicon"
+                />
               </div>
-              <div
-                class="noicon"
-              />
             </div>
           </div>
           <div
@@ -194,68 +200,74 @@ exports[`src/components/gallery/GalleryCard with an image content should match s
           <div
             class="menu-options"
           >
-            <div
-              aria-label="Delete"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
-              <svg
-                class="DeleteIcon Icon"
-                viewBox="0 0 448 512"
-                xmlns="http://www.w3.org/2000/svg"
+            <div>
+              <div
+                aria-label="Delete"
+                class="MenuOption TextOption menu-option"
+                role="button"
               >
-                <path
-                  d="M268 416h24a12 12 0 0 0 12-12V188a12 12 0 0 0-12-12h-24a12 12 0 0 0-12 12v216a12 12 0 0 0 12 12zM432 80h-82.41l-34-56.7A48 48 0 0 0 274.41 0H173.59a48 48 0 0 0-41.16 23.3L98.41 80H16A16 16 0 0 0 0 96v16a16 16 0 0 0 16 16h16v336a48 48 0 0 0 48 48h288a48 48 0 0 0 48-48V128h16a16 16 0 0 0 16-16V96a16 16 0 0 0-16-16zM171.84 50.91A6 6 0 0 1 177 48h94a6 6 0 0 1 5.15 2.91L293.61 80H154.39zM368 464H80V128h288zm-212-48h24a12 12 0 0 0 12-12V188a12 12 0 0 0-12-12h-24a12 12 0 0 0-12 12v216a12 12 0 0 0 12 12z"
+                <svg
+                  class="DeleteIcon Icon"
+                  viewBox="0 0 448 512"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M268 416h24a12 12 0 0 0 12-12V188a12 12 0 0 0-12-12h-24a12 12 0 0 0-12 12v216a12 12 0 0 0 12 12zM432 80h-82.41l-34-56.7A48 48 0 0 0 274.41 0H173.59a48 48 0 0 0-41.16 23.3L98.41 80H16A16 16 0 0 0 0 96v16a16 16 0 0 0 16 16h16v336a48 48 0 0 0 48 48h288a48 48 0 0 0 48-48V128h16a16 16 0 0 0 16-16V96a16 16 0 0 0-16-16zM171.84 50.91A6 6 0 0 1 177 48h94a6 6 0 0 1 5.15 2.91L293.61 80H154.39zM368 464H80V128h288zm-212-48h24a12 12 0 0 0 12-12V188a12 12 0 0 0-12-12h-24a12 12 0 0 0-12 12v216a12 12 0 0 0 12 12z"
+                  />
+                </svg>
+                <div
+                  class="menu-name"
+                >
+                  Delete
+                </div>
+                <div
+                  class="noicon"
                 />
-              </svg>
-              <div
-                class="menu-name"
-              >
-                Delete
               </div>
-              <div
-                class="noicon"
-              />
             </div>
-            <div
-              aria-label="Duplicate"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
-              <svg
-                class="DuplicateIcon Icon"
-                viewBox="0 0 512 512"
-                xmlns="http://www.w3.org/2000/svg"
+            <div>
+              <div
+                aria-label="Duplicate"
+                class="MenuOption TextOption menu-option"
+                role="button"
               >
-                <path
-                  d="M464 0H144c-26.51 0-48 21.49-48 48v48H48c-26.51 0-48 21.49-48 48v320c0 26.51 21.49 48 48 48h320c26.51 0 48-21.49 48-48v-48h48c26.51 0 48-21.49 48-48V48c0-26.51-21.49-48-48-48zM362 464H54a6 6 0 0 1-6-6V150a6 6 0 0 1 6-6h42v224c0 26.51 21.49 48 48 48h224v42a6 6 0 0 1-6 6zm96-96H150a6 6 0 0 1-6-6V54a6 6 0 0 1 6-6h308a6 6 0 0 1 6 6v308a6 6 0 0 1-6 6z"
+                <svg
+                  class="DuplicateIcon Icon"
+                  viewBox="0 0 512 512"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M464 0H144c-26.51 0-48 21.49-48 48v48H48c-26.51 0-48 21.49-48 48v320c0 26.51 21.49 48 48 48h320c26.51 0 48-21.49 48-48v-48h48c26.51 0 48-21.49 48-48V48c0-26.51-21.49-48-48-48zM362 464H54a6 6 0 0 1-6-6V150a6 6 0 0 1 6-6h42v224c0 26.51 21.49 48 48 48h224v42a6 6 0 0 1-6 6zm96-96H150a6 6 0 0 1-6-6V54a6 6 0 0 1 6-6h308a6 6 0 0 1 6 6v308a6 6 0 0 1-6 6z"
+                  />
+                </svg>
+                <div
+                  class="menu-name"
+                >
+                  Duplicate
+                </div>
+                <div
+                  class="noicon"
                 />
-              </svg>
-              <div
-                class="menu-name"
-              >
-                Duplicate
               </div>
-              <div
-                class="noicon"
-              />
             </div>
-            <div
-              aria-label="Copy link"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
-              <i
-                class="CompassIcon icon-link-variant LinkIcon"
-              />
+            <div>
               <div
-                class="menu-name"
+                aria-label="Copy link"
+                class="MenuOption TextOption menu-option"
+                role="button"
               >
-                Copy link
+                <i
+                  class="CompassIcon icon-link-variant LinkIcon"
+                />
+                <div
+                  class="menu-name"
+                >
+                  Copy link
+                </div>
+                <div
+                  class="noicon"
+                />
               </div>
-              <div
-                class="noicon"
-              />
             </div>
           </div>
           <div
@@ -369,68 +381,74 @@ exports[`src/components/gallery/GalleryCard with many contents should match snap
           <div
             class="menu-options"
           >
-            <div
-              aria-label="Delete"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
-              <svg
-                class="DeleteIcon Icon"
-                viewBox="0 0 448 512"
-                xmlns="http://www.w3.org/2000/svg"
+            <div>
+              <div
+                aria-label="Delete"
+                class="MenuOption TextOption menu-option"
+                role="button"
               >
-                <path
-                  d="M268 416h24a12 12 0 0 0 12-12V188a12 12 0 0 0-12-12h-24a12 12 0 0 0-12 12v216a12 12 0 0 0 12 12zM432 80h-82.41l-34-56.7A48 48 0 0 0 274.41 0H173.59a48 48 0 0 0-41.16 23.3L98.41 80H16A16 16 0 0 0 0 96v16a16 16 0 0 0 16 16h16v336a48 48 0 0 0 48 48h288a48 48 0 0 0 48-48V128h16a16 16 0 0 0 16-16V96a16 16 0 0 0-16-16zM171.84 50.91A6 6 0 0 1 177 48h94a6 6 0 0 1 5.15 2.91L293.61 80H154.39zM368 464H80V128h288zm-212-48h24a12 12 0 0 0 12-12V188a12 12 0 0 0-12-12h-24a12 12 0 0 0-12 12v216a12 12 0 0 0 12 12z"
+                <svg
+                  class="DeleteIcon Icon"
+                  viewBox="0 0 448 512"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M268 416h24a12 12 0 0 0 12-12V188a12 12 0 0 0-12-12h-24a12 12 0 0 0-12 12v216a12 12 0 0 0 12 12zM432 80h-82.41l-34-56.7A48 48 0 0 0 274.41 0H173.59a48 48 0 0 0-41.16 23.3L98.41 80H16A16 16 0 0 0 0 96v16a16 16 0 0 0 16 16h16v336a48 48 0 0 0 48 48h288a48 48 0 0 0 48-48V128h16a16 16 0 0 0 16-16V96a16 16 0 0 0-16-16zM171.84 50.91A6 6 0 0 1 177 48h94a6 6 0 0 1 5.15 2.91L293.61 80H154.39zM368 464H80V128h288zm-212-48h24a12 12 0 0 0 12-12V188a12 12 0 0 0-12-12h-24a12 12 0 0 0-12 12v216a12 12 0 0 0 12 12z"
+                  />
+                </svg>
+                <div
+                  class="menu-name"
+                >
+                  Delete
+                </div>
+                <div
+                  class="noicon"
                 />
-              </svg>
-              <div
-                class="menu-name"
-              >
-                Delete
               </div>
-              <div
-                class="noicon"
-              />
             </div>
-            <div
-              aria-label="Duplicate"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
-              <svg
-                class="DuplicateIcon Icon"
-                viewBox="0 0 512 512"
-                xmlns="http://www.w3.org/2000/svg"
+            <div>
+              <div
+                aria-label="Duplicate"
+                class="MenuOption TextOption menu-option"
+                role="button"
               >
-                <path
-                  d="M464 0H144c-26.51 0-48 21.49-48 48v48H48c-26.51 0-48 21.49-48 48v320c0 26.51 21.49 48 48 48h320c26.51 0 48-21.49 48-48v-48h48c26.51 0 48-21.49 48-48V48c0-26.51-21.49-48-48-48zM362 464H54a6 6 0 0 1-6-6V150a6 6 0 0 1 6-6h42v224c0 26.51 21.49 48 48 48h224v42a6 6 0 0 1-6 6zm96-96H150a6 6 0 0 1-6-6V54a6 6 0 0 1 6-6h308a6 6 0 0 1 6 6v308a6 6 0 0 1-6 6z"
+                <svg
+                  class="DuplicateIcon Icon"
+                  viewBox="0 0 512 512"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M464 0H144c-26.51 0-48 21.49-48 48v48H48c-26.51 0-48 21.49-48 48v320c0 26.51 21.49 48 48 48h320c26.51 0 48-21.49 48-48v-48h48c26.51 0 48-21.49 48-48V48c0-26.51-21.49-48-48-48zM362 464H54a6 6 0 0 1-6-6V150a6 6 0 0 1 6-6h42v224c0 26.51 21.49 48 48 48h224v42a6 6 0 0 1-6 6zm96-96H150a6 6 0 0 1-6-6V54a6 6 0 0 1 6-6h308a6 6 0 0 1 6 6v308a6 6 0 0 1-6 6z"
+                  />
+                </svg>
+                <div
+                  class="menu-name"
+                >
+                  Duplicate
+                </div>
+                <div
+                  class="noicon"
                 />
-              </svg>
-              <div
-                class="menu-name"
-              >
-                Duplicate
               </div>
-              <div
-                class="noicon"
-              />
             </div>
-            <div
-              aria-label="Copy link"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
-              <i
-                class="CompassIcon icon-link-variant LinkIcon"
-              />
+            <div>
               <div
-                class="menu-name"
+                aria-label="Copy link"
+                class="MenuOption TextOption menu-option"
+                role="button"
               >
-                Copy link
+                <i
+                  class="CompassIcon icon-link-variant LinkIcon"
+                />
+                <div
+                  class="menu-name"
+                >
+                  Copy link
+                </div>
+                <div
+                  class="noicon"
+                />
               </div>
-              <div
-                class="noicon"
-              />
             </div>
           </div>
           <div
@@ -512,68 +530,74 @@ exports[`src/components/gallery/GalleryCard with many images content should matc
           <div
             class="menu-options"
           >
-            <div
-              aria-label="Delete"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
-              <svg
-                class="DeleteIcon Icon"
-                viewBox="0 0 448 512"
-                xmlns="http://www.w3.org/2000/svg"
+            <div>
+              <div
+                aria-label="Delete"
+                class="MenuOption TextOption menu-option"
+                role="button"
               >
-                <path
-                  d="M268 416h24a12 12 0 0 0 12-12V188a12 12 0 0 0-12-12h-24a12 12 0 0 0-12 12v216a12 12 0 0 0 12 12zM432 80h-82.41l-34-56.7A48 48 0 0 0 274.41 0H173.59a48 48 0 0 0-41.16 23.3L98.41 80H16A16 16 0 0 0 0 96v16a16 16 0 0 0 16 16h16v336a48 48 0 0 0 48 48h288a48 48 0 0 0 48-48V128h16a16 16 0 0 0 16-16V96a16 16 0 0 0-16-16zM171.84 50.91A6 6 0 0 1 177 48h94a6 6 0 0 1 5.15 2.91L293.61 80H154.39zM368 464H80V128h288zm-212-48h24a12 12 0 0 0 12-12V188a12 12 0 0 0-12-12h-24a12 12 0 0 0-12 12v216a12 12 0 0 0 12 12z"
+                <svg
+                  class="DeleteIcon Icon"
+                  viewBox="0 0 448 512"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M268 416h24a12 12 0 0 0 12-12V188a12 12 0 0 0-12-12h-24a12 12 0 0 0-12 12v216a12 12 0 0 0 12 12zM432 80h-82.41l-34-56.7A48 48 0 0 0 274.41 0H173.59a48 48 0 0 0-41.16 23.3L98.41 80H16A16 16 0 0 0 0 96v16a16 16 0 0 0 16 16h16v336a48 48 0 0 0 48 48h288a48 48 0 0 0 48-48V128h16a16 16 0 0 0 16-16V96a16 16 0 0 0-16-16zM171.84 50.91A6 6 0 0 1 177 48h94a6 6 0 0 1 5.15 2.91L293.61 80H154.39zM368 464H80V128h288zm-212-48h24a12 12 0 0 0 12-12V188a12 12 0 0 0-12-12h-24a12 12 0 0 0-12 12v216a12 12 0 0 0 12 12z"
+                  />
+                </svg>
+                <div
+                  class="menu-name"
+                >
+                  Delete
+                </div>
+                <div
+                  class="noicon"
                 />
-              </svg>
-              <div
-                class="menu-name"
-              >
-                Delete
               </div>
-              <div
-                class="noicon"
-              />
             </div>
-            <div
-              aria-label="Duplicate"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
-              <svg
-                class="DuplicateIcon Icon"
-                viewBox="0 0 512 512"
-                xmlns="http://www.w3.org/2000/svg"
+            <div>
+              <div
+                aria-label="Duplicate"
+                class="MenuOption TextOption menu-option"
+                role="button"
               >
-                <path
-                  d="M464 0H144c-26.51 0-48 21.49-48 48v48H48c-26.51 0-48 21.49-48 48v320c0 26.51 21.49 48 48 48h320c26.51 0 48-21.49 48-48v-48h48c26.51 0 48-21.49 48-48V48c0-26.51-21.49-48-48-48zM362 464H54a6 6 0 0 1-6-6V150a6 6 0 0 1 6-6h42v224c0 26.51 21.49 48 48 48h224v42a6 6 0 0 1-6 6zm96-96H150a6 6 0 0 1-6-6V54a6 6 0 0 1 6-6h308a6 6 0 0 1 6 6v308a6 6 0 0 1-6 6z"
+                <svg
+                  class="DuplicateIcon Icon"
+                  viewBox="0 0 512 512"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M464 0H144c-26.51 0-48 21.49-48 48v48H48c-26.51 0-48 21.49-48 48v320c0 26.51 21.49 48 48 48h320c26.51 0 48-21.49 48-48v-48h48c26.51 0 48-21.49 48-48V48c0-26.51-21.49-48-48-48zM362 464H54a6 6 0 0 1-6-6V150a6 6 0 0 1 6-6h42v224c0 26.51 21.49 48 48 48h224v42a6 6 0 0 1-6 6zm96-96H150a6 6 0 0 1-6-6V54a6 6 0 0 1 6-6h308a6 6 0 0 1 6 6v308a6 6 0 0 1-6 6z"
+                  />
+                </svg>
+                <div
+                  class="menu-name"
+                >
+                  Duplicate
+                </div>
+                <div
+                  class="noicon"
                 />
-              </svg>
-              <div
-                class="menu-name"
-              >
-                Duplicate
               </div>
-              <div
-                class="noicon"
-              />
             </div>
-            <div
-              aria-label="Copy link"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
-              <i
-                class="CompassIcon icon-link-variant LinkIcon"
-              />
+            <div>
               <div
-                class="menu-name"
+                aria-label="Copy link"
+                class="MenuOption TextOption menu-option"
+                role="button"
               >
-                Copy link
+                <i
+                  class="CompassIcon icon-link-variant LinkIcon"
+                />
+                <div
+                  class="menu-name"
+                >
+                  Copy link
+                </div>
+                <div
+                  class="noicon"
+                />
               </div>
-              <div
-                class="noicon"
-              />
             </div>
           </div>
           <div
@@ -817,68 +841,74 @@ exports[`src/components/gallery/GalleryCard without block content should match s
           <div
             class="menu-options"
           >
-            <div
-              aria-label="Delete"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
-              <svg
-                class="DeleteIcon Icon"
-                viewBox="0 0 448 512"
-                xmlns="http://www.w3.org/2000/svg"
+            <div>
+              <div
+                aria-label="Delete"
+                class="MenuOption TextOption menu-option"
+                role="button"
               >
-                <path
-                  d="M268 416h24a12 12 0 0 0 12-12V188a12 12 0 0 0-12-12h-24a12 12 0 0 0-12 12v216a12 12 0 0 0 12 12zM432 80h-82.41l-34-56.7A48 48 0 0 0 274.41 0H173.59a48 48 0 0 0-41.16 23.3L98.41 80H16A16 16 0 0 0 0 96v16a16 16 0 0 0 16 16h16v336a48 48 0 0 0 48 48h288a48 48 0 0 0 48-48V128h16a16 16 0 0 0 16-16V96a16 16 0 0 0-16-16zM171.84 50.91A6 6 0 0 1 177 48h94a6 6 0 0 1 5.15 2.91L293.61 80H154.39zM368 464H80V128h288zm-212-48h24a12 12 0 0 0 12-12V188a12 12 0 0 0-12-12h-24a12 12 0 0 0-12 12v216a12 12 0 0 0 12 12z"
+                <svg
+                  class="DeleteIcon Icon"
+                  viewBox="0 0 448 512"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M268 416h24a12 12 0 0 0 12-12V188a12 12 0 0 0-12-12h-24a12 12 0 0 0-12 12v216a12 12 0 0 0 12 12zM432 80h-82.41l-34-56.7A48 48 0 0 0 274.41 0H173.59a48 48 0 0 0-41.16 23.3L98.41 80H16A16 16 0 0 0 0 96v16a16 16 0 0 0 16 16h16v336a48 48 0 0 0 48 48h288a48 48 0 0 0 48-48V128h16a16 16 0 0 0 16-16V96a16 16 0 0 0-16-16zM171.84 50.91A6 6 0 0 1 177 48h94a6 6 0 0 1 5.15 2.91L293.61 80H154.39zM368 464H80V128h288zm-212-48h24a12 12 0 0 0 12-12V188a12 12 0 0 0-12-12h-24a12 12 0 0 0-12 12v216a12 12 0 0 0 12 12z"
+                  />
+                </svg>
+                <div
+                  class="menu-name"
+                >
+                  Delete
+                </div>
+                <div
+                  class="noicon"
                 />
-              </svg>
-              <div
-                class="menu-name"
-              >
-                Delete
               </div>
-              <div
-                class="noicon"
-              />
             </div>
-            <div
-              aria-label="Duplicate"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
-              <svg
-                class="DuplicateIcon Icon"
-                viewBox="0 0 512 512"
-                xmlns="http://www.w3.org/2000/svg"
+            <div>
+              <div
+                aria-label="Duplicate"
+                class="MenuOption TextOption menu-option"
+                role="button"
               >
-                <path
-                  d="M464 0H144c-26.51 0-48 21.49-48 48v48H48c-26.51 0-48 21.49-48 48v320c0 26.51 21.49 48 48 48h320c26.51 0 48-21.49 48-48v-48h48c26.51 0 48-21.49 48-48V48c0-26.51-21.49-48-48-48zM362 464H54a6 6 0 0 1-6-6V150a6 6 0 0 1 6-6h42v224c0 26.51 21.49 48 48 48h224v42a6 6 0 0 1-6 6zm96-96H150a6 6 0 0 1-6-6V54a6 6 0 0 1 6-6h308a6 6 0 0 1 6 6v308a6 6 0 0 1-6 6z"
+                <svg
+                  class="DuplicateIcon Icon"
+                  viewBox="0 0 512 512"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M464 0H144c-26.51 0-48 21.49-48 48v48H48c-26.51 0-48 21.49-48 48v320c0 26.51 21.49 48 48 48h320c26.51 0 48-21.49 48-48v-48h48c26.51 0 48-21.49 48-48V48c0-26.51-21.49-48-48-48zM362 464H54a6 6 0 0 1-6-6V150a6 6 0 0 1 6-6h42v224c0 26.51 21.49 48 48 48h224v42a6 6 0 0 1-6 6zm96-96H150a6 6 0 0 1-6-6V54a6 6 0 0 1 6-6h308a6 6 0 0 1 6 6v308a6 6 0 0 1-6 6z"
+                  />
+                </svg>
+                <div
+                  class="menu-name"
+                >
+                  Duplicate
+                </div>
+                <div
+                  class="noicon"
                 />
-              </svg>
-              <div
-                class="menu-name"
-              >
-                Duplicate
               </div>
-              <div
-                class="noicon"
-              />
             </div>
-            <div
-              aria-label="Copy link"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
-              <i
-                class="CompassIcon icon-link-variant LinkIcon"
-              />
+            <div>
               <div
-                class="menu-name"
+                aria-label="Copy link"
+                class="MenuOption TextOption menu-option"
+                role="button"
               >
-                Copy link
+                <i
+                  class="CompassIcon icon-link-variant LinkIcon"
+                />
+                <div
+                  class="menu-name"
+                >
+                  Copy link
+                </div>
+                <div
+                  class="noicon"
+                />
               </div>
-              <div
-                class="noicon"
-              />
             </div>
           </div>
           <div

--- a/webapp/src/components/globalHeader/__snapshots__/globalHeaderSettingsMenu.test.tsx.snap
+++ b/webapp/src/components/globalHeader/__snapshots__/globalHeaderSettingsMenu.test.tsx.snap
@@ -560,7 +560,7 @@ exports[`components/sidebar/GlobalHeaderSettingsMenu settings menu open should m
             </div>
             <div>
               <div
-                class="MenuOption SubMenuOption menu-option open-left "
+                class="MenuOption SubMenuOption menu-option open-left"
                 id="lang"
               >
                 <svg

--- a/webapp/src/components/globalHeader/__snapshots__/globalHeaderSettingsMenu.test.tsx.snap
+++ b/webapp/src/components/globalHeader/__snapshots__/globalHeaderSettingsMenu.test.tsx.snap
@@ -26,410 +26,418 @@ exports[`components/sidebar/GlobalHeaderSettingsMenu languages menu open should 
           <div
             class="menu-options"
           >
-            <div
-              aria-label="Import archive"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
+            <div>
               <div
-                class="noicon"
-              />
-              <div
-                class="menu-name"
-              >
-                Import archive
-              </div>
-              <div
-                class="noicon"
-              />
-            </div>
-            <div
-              aria-label="Export archive"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
-              <div
-                class="noicon"
-              />
-              <div
-                class="menu-name"
-              >
-                Export archive
-              </div>
-              <div
-                class="noicon"
-              />
-            </div>
-            <div
-              class="MenuOption SubMenuOption menu-option open-left"
-              id="lang"
-            >
-              <svg
-                class="SubmenuTriangleIcon Icon"
-                viewBox="0 0 100 100"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <polygon
-                  points="50,35 75,50 50,65"
-                />
-              </svg>
-              <div
-                class="noicon"
-              />
-              <div
-                class="menu-name"
-              >
-                Set language
-              </div>
-              <div
-                class="SubMenu Menu noselect left-bottom"
+                aria-label="Import archive"
+                class="MenuOption TextOption menu-option"
+                role="button"
               >
                 <div
-                  class="menu-contents"
+                  class="noicon"
+                />
+                <div
+                  class="menu-name"
+                >
+                  Import archive
+                </div>
+                <div
+                  class="noicon"
+                />
+              </div>
+            </div>
+            <div>
+              <div
+                aria-label="Export archive"
+                class="MenuOption TextOption menu-option"
+                role="button"
+              >
+                <div
+                  class="noicon"
+                />
+                <div
+                  class="menu-name"
+                >
+                  Export archive
+                </div>
+                <div
+                  class="noicon"
+                />
+              </div>
+            </div>
+            <div>
+              <div
+                class="MenuOption SubMenuOption menu-option open-left menu-option-active"
+                id="lang"
+              >
+                <svg
+                  class="SubmenuTriangleIcon Icon"
+                  viewBox="0 0 100 100"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <polygon
+                    points="50,35 75,50 50,65"
+                  />
+                </svg>
+                <div
+                  class="noicon"
+                />
+                <div
+                  class="menu-name"
+                >
+                  Set language
+                </div>
+                <div
+                  class="SubMenu Menu noselect left-bottom"
                 >
                   <div
-                    class="menu-options"
+                    class="menu-contents"
                   >
                     <div
-                      aria-label="English"
-                      class="MenuOption TextOption menu-option"
-                      role="button"
+                      class="menu-options"
                     >
                       <div
-                        class="noicon"
-                      />
-                      <div
-                        class="menu-name"
+                        aria-label="English"
+                        class="MenuOption TextOption menu-option"
+                        role="button"
                       >
-                        English
-                      </div>
-                      <svg
-                        class="CheckIcon Icon"
-                        viewBox="0 0 100 100"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <polyline
-                          points="20,60 40,80 80,40"
+                        <div
+                          class="noicon"
                         />
-                      </svg>
-                    </div>
-                    <div
-                      aria-label="Español (Alpha)"
-                      class="MenuOption TextOption menu-option"
-                      role="button"
-                    >
-                      <div
-                        class="noicon"
-                      />
-                      <div
-                        class="menu-name"
-                      >
-                        Español (Alpha)
+                        <div
+                          class="menu-name"
+                        >
+                          English
+                        </div>
+                        <svg
+                          class="CheckIcon Icon"
+                          viewBox="0 0 100 100"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <polyline
+                            points="20,60 40,80 80,40"
+                          />
+                        </svg>
                       </div>
                       <div
-                        class="noicon"
-                      />
-                    </div>
-                    <div
-                      aria-label="Deutsch"
-                      class="MenuOption TextOption menu-option"
-                      role="button"
-                    >
-                      <div
-                        class="noicon"
-                      />
-                      <div
-                        class="menu-name"
+                        aria-label="Español (Alpha)"
+                        class="MenuOption TextOption menu-option"
+                        role="button"
                       >
-                        Deutsch
+                        <div
+                          class="noicon"
+                        />
+                        <div
+                          class="menu-name"
+                        >
+                          Español (Alpha)
+                        </div>
+                        <div
+                          class="noicon"
+                        />
                       </div>
                       <div
-                        class="noicon"
-                      />
-                    </div>
-                    <div
-                      aria-label="日本語"
-                      class="MenuOption TextOption menu-option"
-                      role="button"
-                    >
-                      <div
-                        class="noicon"
-                      />
-                      <div
-                        class="menu-name"
+                        aria-label="Deutsch"
+                        class="MenuOption TextOption menu-option"
+                        role="button"
                       >
-                        日本語
+                        <div
+                          class="noicon"
+                        />
+                        <div
+                          class="menu-name"
+                        >
+                          Deutsch
+                        </div>
+                        <div
+                          class="noicon"
+                        />
                       </div>
                       <div
-                        class="noicon"
-                      />
-                    </div>
-                    <div
-                      aria-label="Français (Beta)"
-                      class="MenuOption TextOption menu-option"
-                      role="button"
-                    >
-                      <div
-                        class="noicon"
-                      />
-                      <div
-                        class="menu-name"
+                        aria-label="日本語"
+                        class="MenuOption TextOption menu-option"
+                        role="button"
                       >
-                        Français (Beta)
+                        <div
+                          class="noicon"
+                        />
+                        <div
+                          class="menu-name"
+                        >
+                          日本語
+                        </div>
+                        <div
+                          class="noicon"
+                        />
                       </div>
                       <div
-                        class="noicon"
-                      />
-                    </div>
-                    <div
-                      aria-label="Nederlands"
-                      class="MenuOption TextOption menu-option"
-                      role="button"
-                    >
-                      <div
-                        class="noicon"
-                      />
-                      <div
-                        class="menu-name"
+                        aria-label="Français (Beta)"
+                        class="MenuOption TextOption menu-option"
+                        role="button"
                       >
-                        Nederlands
+                        <div
+                          class="noicon"
+                        />
+                        <div
+                          class="menu-name"
+                        >
+                          Français (Beta)
+                        </div>
+                        <div
+                          class="noicon"
+                        />
                       </div>
                       <div
-                        class="noicon"
-                      />
-                    </div>
-                    <div
-                      aria-label="Pусский (Beta)"
-                      class="MenuOption TextOption menu-option"
-                      role="button"
-                    >
-                      <div
-                        class="noicon"
-                      />
-                      <div
-                        class="menu-name"
+                        aria-label="Nederlands"
+                        class="MenuOption TextOption menu-option"
+                        role="button"
                       >
-                        Pусский (Beta)
+                        <div
+                          class="noicon"
+                        />
+                        <div
+                          class="menu-name"
+                        >
+                          Nederlands
+                        </div>
+                        <div
+                          class="noicon"
+                        />
                       </div>
                       <div
-                        class="noicon"
-                      />
-                    </div>
-                    <div
-                      aria-label="中文 (繁體)"
-                      class="MenuOption TextOption menu-option"
-                      role="button"
-                    >
-                      <div
-                        class="noicon"
-                      />
-                      <div
-                        class="menu-name"
+                        aria-label="Pусский (Beta)"
+                        class="MenuOption TextOption menu-option"
+                        role="button"
                       >
-                        中文 (繁體)
+                        <div
+                          class="noicon"
+                        />
+                        <div
+                          class="menu-name"
+                        >
+                          Pусский (Beta)
+                        </div>
+                        <div
+                          class="noicon"
+                        />
                       </div>
                       <div
-                        class="noicon"
-                      />
-                    </div>
-                    <div
-                      aria-label="中文 (简体)"
-                      class="MenuOption TextOption menu-option"
-                      role="button"
-                    >
-                      <div
-                        class="noicon"
-                      />
-                      <div
-                        class="menu-name"
+                        aria-label="中文 (繁體)"
+                        class="MenuOption TextOption menu-option"
+                        role="button"
                       >
-                        中文 (简体)
+                        <div
+                          class="noicon"
+                        />
+                        <div
+                          class="menu-name"
+                        >
+                          中文 (繁體)
+                        </div>
+                        <div
+                          class="noicon"
+                        />
                       </div>
                       <div
-                        class="noicon"
-                      />
-                    </div>
-                    <div
-                      aria-label="Türkçe"
-                      class="MenuOption TextOption menu-option"
-                      role="button"
-                    >
-                      <div
-                        class="noicon"
-                      />
-                      <div
-                        class="menu-name"
+                        aria-label="中文 (简体)"
+                        class="MenuOption TextOption menu-option"
+                        role="button"
                       >
-                        Türkçe
+                        <div
+                          class="noicon"
+                        />
+                        <div
+                          class="menu-name"
+                        >
+                          中文 (简体)
+                        </div>
+                        <div
+                          class="noicon"
+                        />
                       </div>
                       <div
-                        class="noicon"
-                      />
-                    </div>
-                    <div
-                      aria-label="Occitan"
-                      class="MenuOption TextOption menu-option"
-                      role="button"
-                    >
-                      <div
-                        class="noicon"
-                      />
-                      <div
-                        class="menu-name"
+                        aria-label="Türkçe"
+                        class="MenuOption TextOption menu-option"
+                        role="button"
                       >
-                        Occitan
+                        <div
+                          class="noicon"
+                        />
+                        <div
+                          class="menu-name"
+                        >
+                          Türkçe
+                        </div>
+                        <div
+                          class="noicon"
+                        />
                       </div>
                       <div
-                        class="noicon"
-                      />
-                    </div>
-                    <div
-                      aria-label="Português (Brasil) (Beta)"
-                      class="MenuOption TextOption menu-option"
-                      role="button"
-                    >
-                      <div
-                        class="noicon"
-                      />
-                      <div
-                        class="menu-name"
+                        aria-label="Occitan"
+                        class="MenuOption TextOption menu-option"
+                        role="button"
                       >
-                        Português (Brasil) (Beta)
+                        <div
+                          class="noicon"
+                        />
+                        <div
+                          class="menu-name"
+                        >
+                          Occitan
+                        </div>
+                        <div
+                          class="noicon"
+                        />
                       </div>
                       <div
-                        class="noicon"
-                      />
-                    </div>
-                    <div
-                      aria-label="Català (Beta)"
-                      class="MenuOption TextOption menu-option"
-                      role="button"
-                    >
-                      <div
-                        class="noicon"
-                      />
-                      <div
-                        class="menu-name"
+                        aria-label="Português (Brasil) (Beta)"
+                        class="MenuOption TextOption menu-option"
+                        role="button"
                       >
-                        Català (Beta)
+                        <div
+                          class="noicon"
+                        />
+                        <div
+                          class="menu-name"
+                        >
+                          Português (Brasil) (Beta)
+                        </div>
+                        <div
+                          class="noicon"
+                        />
                       </div>
                       <div
-                        class="noicon"
-                      />
-                    </div>
-                    <div
-                      aria-label="Ελληνικά (Alpha)"
-                      class="MenuOption TextOption menu-option"
-                      role="button"
-                    >
-                      <div
-                        class="noicon"
-                      />
-                      <div
-                        class="menu-name"
+                        aria-label="Català (Beta)"
+                        class="MenuOption TextOption menu-option"
+                        role="button"
                       >
-                        Ελληνικά (Alpha)
+                        <div
+                          class="noicon"
+                        />
+                        <div
+                          class="menu-name"
+                        >
+                          Català (Beta)
+                        </div>
+                        <div
+                          class="noicon"
+                        />
                       </div>
                       <div
-                        class="noicon"
-                      />
-                    </div>
-                    <div
-                      aria-label="bahasa Indonesia (Alpha)"
-                      class="MenuOption TextOption menu-option"
-                      role="button"
-                    >
-                      <div
-                        class="noicon"
-                      />
-                      <div
-                        class="menu-name"
+                        aria-label="Ελληνικά (Alpha)"
+                        class="MenuOption TextOption menu-option"
+                        role="button"
                       >
-                        bahasa Indonesia (Alpha)
+                        <div
+                          class="noicon"
+                        />
+                        <div
+                          class="menu-name"
+                        >
+                          Ελληνικά (Alpha)
+                        </div>
+                        <div
+                          class="noicon"
+                        />
                       </div>
                       <div
-                        class="noicon"
-                      />
-                    </div>
-                    <div
-                      aria-label="Italiano (Beta)"
-                      class="MenuOption TextOption menu-option"
-                      role="button"
-                    >
-                      <div
-                        class="noicon"
-                      />
-                      <div
-                        class="menu-name"
+                        aria-label="bahasa Indonesia (Alpha)"
+                        class="MenuOption TextOption menu-option"
+                        role="button"
                       >
-                        Italiano (Beta)
+                        <div
+                          class="noicon"
+                        />
+                        <div
+                          class="menu-name"
+                        >
+                          bahasa Indonesia (Alpha)
+                        </div>
+                        <div
+                          class="noicon"
+                        />
                       </div>
                       <div
-                        class="noicon"
-                      />
-                    </div>
-                    <div
-                      aria-label="Svenska (Beta)"
-                      class="MenuOption TextOption menu-option"
-                      role="button"
-                    >
-                      <div
-                        class="noicon"
-                      />
-                      <div
-                        class="menu-name"
+                        aria-label="Italiano (Beta)"
+                        class="MenuOption TextOption menu-option"
+                        role="button"
                       >
-                        Svenska (Beta)
+                        <div
+                          class="noicon"
+                        />
+                        <div
+                          class="menu-name"
+                        >
+                          Italiano (Beta)
+                        </div>
+                        <div
+                          class="noicon"
+                        />
                       </div>
                       <div
-                        class="noicon"
-                      />
+                        aria-label="Svenska (Beta)"
+                        class="MenuOption TextOption menu-option"
+                        role="button"
+                      >
+                        <div
+                          class="noicon"
+                        />
+                        <div
+                          class="menu-name"
+                        >
+                          Svenska (Beta)
+                        </div>
+                        <div
+                          class="noicon"
+                        />
+                      </div>
                     </div>
-                  </div>
-                  <div
-                    class="menu-spacer hideOnWidescreen"
-                  />
-                  <div
-                    class="menu-options hideOnWidescreen"
-                  >
                     <div
-                      aria-label="Cancel"
-                      class="MenuOption TextOption menu-option menu-cancel"
-                      role="button"
+                      class="menu-spacer hideOnWidescreen"
+                    />
+                    <div
+                      class="menu-options hideOnWidescreen"
                     >
                       <div
-                        class="noicon"
-                      />
-                      <div
-                        class="menu-name"
+                        aria-label="Cancel"
+                        class="MenuOption TextOption menu-option menu-cancel"
+                        role="button"
                       >
-                        Cancel
+                        <div
+                          class="noicon"
+                        />
+                        <div
+                          class="menu-name"
+                        >
+                          Cancel
+                        </div>
+                        <div
+                          class="noicon"
+                        />
                       </div>
-                      <div
-                        class="noicon"
-                      />
                     </div>
                   </div>
                 </div>
               </div>
             </div>
-            <div
-              class="MenuOption SwitchOption menu-option"
-            >
+            <div>
               <div
-                class="noicon"
-              />
-              <div
-                class="menu-name"
-              >
-                Random icons
-              </div>
-              <div
-                class="Switch on"
+                class="MenuOption SwitchOption menu-option"
               >
                 <div
-                  class="octo-switch-inner"
+                  class="noicon"
                 />
+                <div
+                  class="menu-name"
+                >
+                  Random icons
+                </div>
+                <div
+                  class="Switch on"
+                >
+                  <div
+                    class="octo-switch-inner"
+                  />
+                </div>
               </div>
             </div>
           </div>
@@ -512,79 +520,87 @@ exports[`components/sidebar/GlobalHeaderSettingsMenu settings menu open should m
           <div
             class="menu-options"
           >
-            <div
-              aria-label="Import archive"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
+            <div>
               <div
-                class="noicon"
-              />
-              <div
-                class="menu-name"
-              >
-                Import archive
-              </div>
-              <div
-                class="noicon"
-              />
-            </div>
-            <div
-              aria-label="Export archive"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
-              <div
-                class="noicon"
-              />
-              <div
-                class="menu-name"
-              >
-                Export archive
-              </div>
-              <div
-                class="noicon"
-              />
-            </div>
-            <div
-              class="MenuOption SubMenuOption menu-option open-left"
-              id="lang"
-            >
-              <svg
-                class="SubmenuTriangleIcon Icon"
-                viewBox="0 0 100 100"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <polygon
-                  points="50,35 75,50 50,65"
-                />
-              </svg>
-              <div
-                class="noicon"
-              />
-              <div
-                class="menu-name"
-              >
-                Set language
-              </div>
-            </div>
-            <div
-              class="MenuOption SwitchOption menu-option"
-            >
-              <div
-                class="noicon"
-              />
-              <div
-                class="menu-name"
-              >
-                Random icons
-              </div>
-              <div
-                class="Switch on"
+                aria-label="Import archive"
+                class="MenuOption TextOption menu-option"
+                role="button"
               >
                 <div
-                  class="octo-switch-inner"
+                  class="noicon"
                 />
+                <div
+                  class="menu-name"
+                >
+                  Import archive
+                </div>
+                <div
+                  class="noicon"
+                />
+              </div>
+            </div>
+            <div>
+              <div
+                aria-label="Export archive"
+                class="MenuOption TextOption menu-option"
+                role="button"
+              >
+                <div
+                  class="noicon"
+                />
+                <div
+                  class="menu-name"
+                >
+                  Export archive
+                </div>
+                <div
+                  class="noicon"
+                />
+              </div>
+            </div>
+            <div>
+              <div
+                class="MenuOption SubMenuOption menu-option open-left "
+                id="lang"
+              >
+                <svg
+                  class="SubmenuTriangleIcon Icon"
+                  viewBox="0 0 100 100"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <polygon
+                    points="50,35 75,50 50,65"
+                  />
+                </svg>
+                <div
+                  class="noicon"
+                />
+                <div
+                  class="menu-name"
+                >
+                  Set language
+                </div>
+              </div>
+            </div>
+            <div>
+              <div
+                class="MenuOption SwitchOption menu-option"
+              >
+                <div
+                  class="noicon"
+                />
+                <div
+                  class="menu-name"
+                >
+                  Random icons
+                </div>
+                <div
+                  class="Switch on"
+                >
+                  <div
+                    class="octo-switch-inner"
+                  />
+                </div>
               </div>
             </div>
           </div>

--- a/webapp/src/components/kanban/__snapshots__/kanbanCard.test.tsx.snap
+++ b/webapp/src/components/kanban/__snapshots__/kanbanCard.test.tsx.snap
@@ -29,68 +29,74 @@ exports[`src/components/kanban/kanbanCard return kanbanCard and click on copy li
           <div
             class="menu-options"
           >
-            <div
-              aria-label="Delete"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
-              <svg
-                class="DeleteIcon Icon"
-                viewBox="0 0 448 512"
-                xmlns="http://www.w3.org/2000/svg"
+            <div>
+              <div
+                aria-label="Delete"
+                class="MenuOption TextOption menu-option"
+                role="button"
               >
-                <path
-                  d="M268 416h24a12 12 0 0 0 12-12V188a12 12 0 0 0-12-12h-24a12 12 0 0 0-12 12v216a12 12 0 0 0 12 12zM432 80h-82.41l-34-56.7A48 48 0 0 0 274.41 0H173.59a48 48 0 0 0-41.16 23.3L98.41 80H16A16 16 0 0 0 0 96v16a16 16 0 0 0 16 16h16v336a48 48 0 0 0 48 48h288a48 48 0 0 0 48-48V128h16a16 16 0 0 0 16-16V96a16 16 0 0 0-16-16zM171.84 50.91A6 6 0 0 1 177 48h94a6 6 0 0 1 5.15 2.91L293.61 80H154.39zM368 464H80V128h288zm-212-48h24a12 12 0 0 0 12-12V188a12 12 0 0 0-12-12h-24a12 12 0 0 0-12 12v216a12 12 0 0 0 12 12z"
+                <svg
+                  class="DeleteIcon Icon"
+                  viewBox="0 0 448 512"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M268 416h24a12 12 0 0 0 12-12V188a12 12 0 0 0-12-12h-24a12 12 0 0 0-12 12v216a12 12 0 0 0 12 12zM432 80h-82.41l-34-56.7A48 48 0 0 0 274.41 0H173.59a48 48 0 0 0-41.16 23.3L98.41 80H16A16 16 0 0 0 0 96v16a16 16 0 0 0 16 16h16v336a48 48 0 0 0 48 48h288a48 48 0 0 0 48-48V128h16a16 16 0 0 0 16-16V96a16 16 0 0 0-16-16zM171.84 50.91A6 6 0 0 1 177 48h94a6 6 0 0 1 5.15 2.91L293.61 80H154.39zM368 464H80V128h288zm-212-48h24a12 12 0 0 0 12-12V188a12 12 0 0 0-12-12h-24a12 12 0 0 0-12 12v216a12 12 0 0 0 12 12z"
+                  />
+                </svg>
+                <div
+                  class="menu-name"
+                >
+                  Delete
+                </div>
+                <div
+                  class="noicon"
                 />
-              </svg>
-              <div
-                class="menu-name"
-              >
-                Delete
               </div>
-              <div
-                class="noicon"
-              />
             </div>
-            <div
-              aria-label="Duplicate"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
-              <svg
-                class="DuplicateIcon Icon"
-                viewBox="0 0 512 512"
-                xmlns="http://www.w3.org/2000/svg"
+            <div>
+              <div
+                aria-label="Duplicate"
+                class="MenuOption TextOption menu-option"
+                role="button"
               >
-                <path
-                  d="M464 0H144c-26.51 0-48 21.49-48 48v48H48c-26.51 0-48 21.49-48 48v320c0 26.51 21.49 48 48 48h320c26.51 0 48-21.49 48-48v-48h48c26.51 0 48-21.49 48-48V48c0-26.51-21.49-48-48-48zM362 464H54a6 6 0 0 1-6-6V150a6 6 0 0 1 6-6h42v224c0 26.51 21.49 48 48 48h224v42a6 6 0 0 1-6 6zm96-96H150a6 6 0 0 1-6-6V54a6 6 0 0 1 6-6h308a6 6 0 0 1 6 6v308a6 6 0 0 1-6 6z"
+                <svg
+                  class="DuplicateIcon Icon"
+                  viewBox="0 0 512 512"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M464 0H144c-26.51 0-48 21.49-48 48v48H48c-26.51 0-48 21.49-48 48v320c0 26.51 21.49 48 48 48h320c26.51 0 48-21.49 48-48v-48h48c26.51 0 48-21.49 48-48V48c0-26.51-21.49-48-48-48zM362 464H54a6 6 0 0 1-6-6V150a6 6 0 0 1 6-6h42v224c0 26.51 21.49 48 48 48h224v42a6 6 0 0 1-6 6zm96-96H150a6 6 0 0 1-6-6V54a6 6 0 0 1 6-6h308a6 6 0 0 1 6 6v308a6 6 0 0 1-6 6z"
+                  />
+                </svg>
+                <div
+                  class="menu-name"
+                >
+                  Duplicate
+                </div>
+                <div
+                  class="noicon"
                 />
-              </svg>
-              <div
-                class="menu-name"
-              >
-                Duplicate
               </div>
-              <div
-                class="noicon"
-              />
             </div>
-            <div
-              aria-label="Copy link"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
-              <i
-                class="CompassIcon icon-link-variant LinkIcon"
-              />
+            <div>
               <div
-                class="menu-name"
+                aria-label="Copy link"
+                class="MenuOption TextOption menu-option"
+                role="button"
               >
-                Copy link
+                <i
+                  class="CompassIcon icon-link-variant LinkIcon"
+                />
+                <div
+                  class="menu-name"
+                >
+                  Copy link
+                </div>
+                <div
+                  class="noicon"
+                />
               </div>
-              <div
-                class="noicon"
-              />
             </div>
           </div>
           <div
@@ -173,68 +179,74 @@ exports[`src/components/kanban/kanbanCard return kanbanCard and click on delete 
           <div
             class="menu-options"
           >
-            <div
-              aria-label="Delete"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
-              <svg
-                class="DeleteIcon Icon"
-                viewBox="0 0 448 512"
-                xmlns="http://www.w3.org/2000/svg"
+            <div>
+              <div
+                aria-label="Delete"
+                class="MenuOption TextOption menu-option"
+                role="button"
               >
-                <path
-                  d="M268 416h24a12 12 0 0 0 12-12V188a12 12 0 0 0-12-12h-24a12 12 0 0 0-12 12v216a12 12 0 0 0 12 12zM432 80h-82.41l-34-56.7A48 48 0 0 0 274.41 0H173.59a48 48 0 0 0-41.16 23.3L98.41 80H16A16 16 0 0 0 0 96v16a16 16 0 0 0 16 16h16v336a48 48 0 0 0 48 48h288a48 48 0 0 0 48-48V128h16a16 16 0 0 0 16-16V96a16 16 0 0 0-16-16zM171.84 50.91A6 6 0 0 1 177 48h94a6 6 0 0 1 5.15 2.91L293.61 80H154.39zM368 464H80V128h288zm-212-48h24a12 12 0 0 0 12-12V188a12 12 0 0 0-12-12h-24a12 12 0 0 0-12 12v216a12 12 0 0 0 12 12z"
+                <svg
+                  class="DeleteIcon Icon"
+                  viewBox="0 0 448 512"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M268 416h24a12 12 0 0 0 12-12V188a12 12 0 0 0-12-12h-24a12 12 0 0 0-12 12v216a12 12 0 0 0 12 12zM432 80h-82.41l-34-56.7A48 48 0 0 0 274.41 0H173.59a48 48 0 0 0-41.16 23.3L98.41 80H16A16 16 0 0 0 0 96v16a16 16 0 0 0 16 16h16v336a48 48 0 0 0 48 48h288a48 48 0 0 0 48-48V128h16a16 16 0 0 0 16-16V96a16 16 0 0 0-16-16zM171.84 50.91A6 6 0 0 1 177 48h94a6 6 0 0 1 5.15 2.91L293.61 80H154.39zM368 464H80V128h288zm-212-48h24a12 12 0 0 0 12-12V188a12 12 0 0 0-12-12h-24a12 12 0 0 0-12 12v216a12 12 0 0 0 12 12z"
+                  />
+                </svg>
+                <div
+                  class="menu-name"
+                >
+                  Delete
+                </div>
+                <div
+                  class="noicon"
                 />
-              </svg>
-              <div
-                class="menu-name"
-              >
-                Delete
               </div>
-              <div
-                class="noicon"
-              />
             </div>
-            <div
-              aria-label="Duplicate"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
-              <svg
-                class="DuplicateIcon Icon"
-                viewBox="0 0 512 512"
-                xmlns="http://www.w3.org/2000/svg"
+            <div>
+              <div
+                aria-label="Duplicate"
+                class="MenuOption TextOption menu-option"
+                role="button"
               >
-                <path
-                  d="M464 0H144c-26.51 0-48 21.49-48 48v48H48c-26.51 0-48 21.49-48 48v320c0 26.51 21.49 48 48 48h320c26.51 0 48-21.49 48-48v-48h48c26.51 0 48-21.49 48-48V48c0-26.51-21.49-48-48-48zM362 464H54a6 6 0 0 1-6-6V150a6 6 0 0 1 6-6h42v224c0 26.51 21.49 48 48 48h224v42a6 6 0 0 1-6 6zm96-96H150a6 6 0 0 1-6-6V54a6 6 0 0 1 6-6h308a6 6 0 0 1 6 6v308a6 6 0 0 1-6 6z"
+                <svg
+                  class="DuplicateIcon Icon"
+                  viewBox="0 0 512 512"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M464 0H144c-26.51 0-48 21.49-48 48v48H48c-26.51 0-48 21.49-48 48v320c0 26.51 21.49 48 48 48h320c26.51 0 48-21.49 48-48v-48h48c26.51 0 48-21.49 48-48V48c0-26.51-21.49-48-48-48zM362 464H54a6 6 0 0 1-6-6V150a6 6 0 0 1 6-6h42v224c0 26.51 21.49 48 48 48h224v42a6 6 0 0 1-6 6zm96-96H150a6 6 0 0 1-6-6V54a6 6 0 0 1 6-6h308a6 6 0 0 1 6 6v308a6 6 0 0 1-6 6z"
+                  />
+                </svg>
+                <div
+                  class="menu-name"
+                >
+                  Duplicate
+                </div>
+                <div
+                  class="noicon"
                 />
-              </svg>
-              <div
-                class="menu-name"
-              >
-                Duplicate
               </div>
-              <div
-                class="noicon"
-              />
             </div>
-            <div
-              aria-label="Copy link"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
-              <i
-                class="CompassIcon icon-link-variant LinkIcon"
-              />
+            <div>
               <div
-                class="menu-name"
+                aria-label="Copy link"
+                class="MenuOption TextOption menu-option"
+                role="button"
               >
-                Copy link
+                <i
+                  class="CompassIcon icon-link-variant LinkIcon"
+                />
+                <div
+                  class="menu-name"
+                >
+                  Copy link
+                </div>
+                <div
+                  class="noicon"
+                />
               </div>
-              <div
-                class="noicon"
-              />
             </div>
           </div>
           <div
@@ -317,68 +329,74 @@ exports[`src/components/kanban/kanbanCard return kanbanCard and click on duplica
           <div
             class="menu-options"
           >
-            <div
-              aria-label="Delete"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
-              <svg
-                class="DeleteIcon Icon"
-                viewBox="0 0 448 512"
-                xmlns="http://www.w3.org/2000/svg"
+            <div>
+              <div
+                aria-label="Delete"
+                class="MenuOption TextOption menu-option"
+                role="button"
               >
-                <path
-                  d="M268 416h24a12 12 0 0 0 12-12V188a12 12 0 0 0-12-12h-24a12 12 0 0 0-12 12v216a12 12 0 0 0 12 12zM432 80h-82.41l-34-56.7A48 48 0 0 0 274.41 0H173.59a48 48 0 0 0-41.16 23.3L98.41 80H16A16 16 0 0 0 0 96v16a16 16 0 0 0 16 16h16v336a48 48 0 0 0 48 48h288a48 48 0 0 0 48-48V128h16a16 16 0 0 0 16-16V96a16 16 0 0 0-16-16zM171.84 50.91A6 6 0 0 1 177 48h94a6 6 0 0 1 5.15 2.91L293.61 80H154.39zM368 464H80V128h288zm-212-48h24a12 12 0 0 0 12-12V188a12 12 0 0 0-12-12h-24a12 12 0 0 0-12 12v216a12 12 0 0 0 12 12z"
+                <svg
+                  class="DeleteIcon Icon"
+                  viewBox="0 0 448 512"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M268 416h24a12 12 0 0 0 12-12V188a12 12 0 0 0-12-12h-24a12 12 0 0 0-12 12v216a12 12 0 0 0 12 12zM432 80h-82.41l-34-56.7A48 48 0 0 0 274.41 0H173.59a48 48 0 0 0-41.16 23.3L98.41 80H16A16 16 0 0 0 0 96v16a16 16 0 0 0 16 16h16v336a48 48 0 0 0 48 48h288a48 48 0 0 0 48-48V128h16a16 16 0 0 0 16-16V96a16 16 0 0 0-16-16zM171.84 50.91A6 6 0 0 1 177 48h94a6 6 0 0 1 5.15 2.91L293.61 80H154.39zM368 464H80V128h288zm-212-48h24a12 12 0 0 0 12-12V188a12 12 0 0 0-12-12h-24a12 12 0 0 0-12 12v216a12 12 0 0 0 12 12z"
+                  />
+                </svg>
+                <div
+                  class="menu-name"
+                >
+                  Delete
+                </div>
+                <div
+                  class="noicon"
                 />
-              </svg>
-              <div
-                class="menu-name"
-              >
-                Delete
               </div>
-              <div
-                class="noicon"
-              />
             </div>
-            <div
-              aria-label="Duplicate"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
-              <svg
-                class="DuplicateIcon Icon"
-                viewBox="0 0 512 512"
-                xmlns="http://www.w3.org/2000/svg"
+            <div>
+              <div
+                aria-label="Duplicate"
+                class="MenuOption TextOption menu-option"
+                role="button"
               >
-                <path
-                  d="M464 0H144c-26.51 0-48 21.49-48 48v48H48c-26.51 0-48 21.49-48 48v320c0 26.51 21.49 48 48 48h320c26.51 0 48-21.49 48-48v-48h48c26.51 0 48-21.49 48-48V48c0-26.51-21.49-48-48-48zM362 464H54a6 6 0 0 1-6-6V150a6 6 0 0 1 6-6h42v224c0 26.51 21.49 48 48 48h224v42a6 6 0 0 1-6 6zm96-96H150a6 6 0 0 1-6-6V54a6 6 0 0 1 6-6h308a6 6 0 0 1 6 6v308a6 6 0 0 1-6 6z"
+                <svg
+                  class="DuplicateIcon Icon"
+                  viewBox="0 0 512 512"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M464 0H144c-26.51 0-48 21.49-48 48v48H48c-26.51 0-48 21.49-48 48v320c0 26.51 21.49 48 48 48h320c26.51 0 48-21.49 48-48v-48h48c26.51 0 48-21.49 48-48V48c0-26.51-21.49-48-48-48zM362 464H54a6 6 0 0 1-6-6V150a6 6 0 0 1 6-6h42v224c0 26.51 21.49 48 48 48h224v42a6 6 0 0 1-6 6zm96-96H150a6 6 0 0 1-6-6V54a6 6 0 0 1 6-6h308a6 6 0 0 1 6 6v308a6 6 0 0 1-6 6z"
+                  />
+                </svg>
+                <div
+                  class="menu-name"
+                >
+                  Duplicate
+                </div>
+                <div
+                  class="noicon"
                 />
-              </svg>
-              <div
-                class="menu-name"
-              >
-                Duplicate
               </div>
-              <div
-                class="noicon"
-              />
             </div>
-            <div
-              aria-label="Copy link"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
-              <i
-                class="CompassIcon icon-link-variant LinkIcon"
-              />
+            <div>
               <div
-                class="menu-name"
+                aria-label="Copy link"
+                class="MenuOption TextOption menu-option"
+                role="button"
               >
-                Copy link
+                <i
+                  class="CompassIcon icon-link-variant LinkIcon"
+                />
+                <div
+                  class="menu-name"
+                >
+                  Copy link
+                </div>
+                <div
+                  class="noicon"
+                />
               </div>
-              <div
-                class="noicon"
-              />
             </div>
           </div>
           <div

--- a/webapp/src/components/kanban/__snapshots__/kanbanHiddenColumnItem.test.tsx.snap
+++ b/webapp/src/components/kanban/__snapshots__/kanbanHiddenColumnItem.test.tsx.snap
@@ -24,28 +24,30 @@ exports[`src/components/kanban/kanbanHiddenColumnItem return kanbanHiddenColumnI
           <div
             class="menu-options"
           >
-            <div
-              aria-label="Show"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
-              <svg
-                class="ShowIcon Icon"
-                viewBox="0 0 576 512"
-                xmlns="http://www.w3.org/2000/svg"
+            <div>
+              <div
+                aria-label="Show"
+                class="MenuOption TextOption menu-option"
+                role="button"
               >
-                <path
-                  d="M288 144a110.94 110.94 0 0 0-31.24 5 55.4 55.4 0 0 1 7.24 27 56 56 0 0 1-56 56 55.4 55.4 0 0 1-27-7.24A111.71 111.71 0 1 0 288 144zm284.52 97.4C518.29 135.59 410.93 64 288 64S57.68 135.64 3.48 241.41a32.35 32.35 0 0 0 0 29.19C57.71 376.41 165.07 448 288 448s230.32-71.64 284.52-177.41a32.35 32.35 0 0 0 0-29.19zM288 400c-98.65 0-189.09-55-237.93-144C98.91 167 189.34 112 288 112s189.09 55 237.93 144C477.1 345 386.66 400 288 400z"
+                <svg
+                  class="ShowIcon Icon"
+                  viewBox="0 0 576 512"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M288 144a110.94 110.94 0 0 0-31.24 5 55.4 55.4 0 0 1 7.24 27 56 56 0 0 1-56 56 55.4 55.4 0 0 1-27-7.24A111.71 111.71 0 1 0 288 144zm284.52 97.4C518.29 135.59 410.93 64 288 64S57.68 135.64 3.48 241.41a32.35 32.35 0 0 0 0 29.19C57.71 376.41 165.07 448 288 448s230.32-71.64 284.52-177.41a32.35 32.35 0 0 0 0-29.19zM288 400c-98.65 0-189.09-55-237.93-144C98.91 167 189.34 112 288 112s189.09 55 237.93 144C477.1 345 386.66 400 288 400z"
+                  />
+                </svg>
+                <div
+                  class="menu-name"
+                >
+                  Show
+                </div>
+                <div
+                  class="noicon"
                 />
-              </svg>
-              <div
-                class="menu-name"
-              >
-                Show
               </div>
-              <div
-                class="noicon"
-              />
             </div>
           </div>
           <div
@@ -111,28 +113,30 @@ exports[`src/components/kanban/kanbanHiddenColumnItem return kanbanHiddenColumnI
           <div
             class="menu-options"
           >
-            <div
-              aria-label="Show"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
-              <svg
-                class="ShowIcon Icon"
-                viewBox="0 0 576 512"
-                xmlns="http://www.w3.org/2000/svg"
+            <div>
+              <div
+                aria-label="Show"
+                class="MenuOption TextOption menu-option"
+                role="button"
               >
-                <path
-                  d="M288 144a110.94 110.94 0 0 0-31.24 5 55.4 55.4 0 0 1 7.24 27 56 56 0 0 1-56 56 55.4 55.4 0 0 1-27-7.24A111.71 111.71 0 1 0 288 144zm284.52 97.4C518.29 135.59 410.93 64 288 64S57.68 135.64 3.48 241.41a32.35 32.35 0 0 0 0 29.19C57.71 376.41 165.07 448 288 448s230.32-71.64 284.52-177.41a32.35 32.35 0 0 0 0-29.19zM288 400c-98.65 0-189.09-55-237.93-144C98.91 167 189.34 112 288 112s189.09 55 237.93 144C477.1 345 386.66 400 288 400z"
+                <svg
+                  class="ShowIcon Icon"
+                  viewBox="0 0 576 512"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M288 144a110.94 110.94 0 0 0-31.24 5 55.4 55.4 0 0 1 7.24 27 56 56 0 0 1-56 56 55.4 55.4 0 0 1-27-7.24A111.71 111.71 0 1 0 288 144zm284.52 97.4C518.29 135.59 410.93 64 288 64S57.68 135.64 3.48 241.41a32.35 32.35 0 0 0 0 29.19C57.71 376.41 165.07 448 288 448s230.32-71.64 284.52-177.41a32.35 32.35 0 0 0 0-29.19zM288 400c-98.65 0-189.09-55-237.93-144C98.91 167 189.34 112 288 112s189.09 55 237.93 144C477.1 345 386.66 400 288 400z"
+                  />
+                </svg>
+                <div
+                  class="menu-name"
+                >
+                  Show
+                </div>
+                <div
+                  class="noicon"
                 />
-              </svg>
-              <div
-                class="menu-name"
-              >
-                Show
               </div>
-              <div
-                class="noicon"
-              />
             </div>
           </div>
           <div

--- a/webapp/src/components/sidebar/__snapshots__/sidebarSettingsMenu.test.tsx.snap
+++ b/webapp/src/components/sidebar/__snapshots__/sidebarSettingsMenu.test.tsx.snap
@@ -24,432 +24,442 @@ exports[`components/sidebar/SidebarSettingsMenu languages menu open should match
           <div
             class="menu-options"
           >
-            <div
-              aria-label="Import archive"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
+            <div>
               <div
-                class="noicon"
-              />
-              <div
-                class="menu-name"
-              >
-                Import archive
-              </div>
-              <div
-                class="noicon"
-              />
-            </div>
-            <div
-              aria-label="Export archive"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
-              <div
-                class="noicon"
-              />
-              <div
-                class="menu-name"
-              >
-                Export archive
-              </div>
-              <div
-                class="noicon"
-              />
-            </div>
-            <div
-              class="MenuOption SubMenuOption menu-option"
-              id="lang"
-            >
-              <div
-                class="noicon"
-              />
-              <div
-                class="menu-name"
-              >
-                Set language
-              </div>
-              <svg
-                class="SubmenuTriangleIcon Icon"
-                viewBox="0 0 100 100"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <polygon
-                  points="50,35 75,50 50,65"
-                />
-              </svg>
-              <div
-                class="SubMenu Menu noselect top"
+                aria-label="Import archive"
+                class="MenuOption TextOption menu-option"
+                role="button"
               >
                 <div
-                  class="menu-contents"
+                  class="noicon"
+                />
+                <div
+                  class="menu-name"
+                >
+                  Import archive
+                </div>
+                <div
+                  class="noicon"
+                />
+              </div>
+            </div>
+            <div>
+              <div
+                aria-label="Export archive"
+                class="MenuOption TextOption menu-option"
+                role="button"
+              >
+                <div
+                  class="noicon"
+                />
+                <div
+                  class="menu-name"
+                >
+                  Export archive
+                </div>
+                <div
+                  class="noicon"
+                />
+              </div>
+            </div>
+            <div>
+              <div
+                class="MenuOption SubMenuOption menu-option menu-option-active"
+                id="lang"
+              >
+                <div
+                  class="noicon"
+                />
+                <div
+                  class="menu-name"
+                >
+                  Set language
+                </div>
+                <svg
+                  class="SubmenuTriangleIcon Icon"
+                  viewBox="0 0 100 100"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <polygon
+                    points="50,35 75,50 50,65"
+                  />
+                </svg>
+                <div
+                  class="SubMenu Menu noselect top"
                 >
                   <div
-                    class="menu-options"
+                    class="menu-contents"
                   >
                     <div
-                      aria-label="English"
-                      class="MenuOption TextOption menu-option"
-                      role="button"
+                      class="menu-options"
                     >
                       <div
-                        class="noicon"
-                      />
-                      <div
-                        class="menu-name"
+                        aria-label="English"
+                        class="MenuOption TextOption menu-option"
+                        role="button"
                       >
-                        English
-                      </div>
-                      <svg
-                        class="CheckIcon Icon"
-                        viewBox="0 0 100 100"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <polyline
-                          points="20,60 40,80 80,40"
+                        <div
+                          class="noicon"
                         />
-                      </svg>
-                    </div>
-                    <div
-                      aria-label="Español (Alpha)"
-                      class="MenuOption TextOption menu-option"
-                      role="button"
-                    >
-                      <div
-                        class="noicon"
-                      />
-                      <div
-                        class="menu-name"
-                      >
-                        Español (Alpha)
+                        <div
+                          class="menu-name"
+                        >
+                          English
+                        </div>
+                        <svg
+                          class="CheckIcon Icon"
+                          viewBox="0 0 100 100"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <polyline
+                            points="20,60 40,80 80,40"
+                          />
+                        </svg>
                       </div>
                       <div
-                        class="noicon"
-                      />
-                    </div>
-                    <div
-                      aria-label="Deutsch"
-                      class="MenuOption TextOption menu-option"
-                      role="button"
-                    >
-                      <div
-                        class="noicon"
-                      />
-                      <div
-                        class="menu-name"
+                        aria-label="Español (Alpha)"
+                        class="MenuOption TextOption menu-option"
+                        role="button"
                       >
-                        Deutsch
+                        <div
+                          class="noicon"
+                        />
+                        <div
+                          class="menu-name"
+                        >
+                          Español (Alpha)
+                        </div>
+                        <div
+                          class="noicon"
+                        />
                       </div>
                       <div
-                        class="noicon"
-                      />
-                    </div>
-                    <div
-                      aria-label="日本語"
-                      class="MenuOption TextOption menu-option"
-                      role="button"
-                    >
-                      <div
-                        class="noicon"
-                      />
-                      <div
-                        class="menu-name"
+                        aria-label="Deutsch"
+                        class="MenuOption TextOption menu-option"
+                        role="button"
                       >
-                        日本語
+                        <div
+                          class="noicon"
+                        />
+                        <div
+                          class="menu-name"
+                        >
+                          Deutsch
+                        </div>
+                        <div
+                          class="noicon"
+                        />
                       </div>
                       <div
-                        class="noicon"
-                      />
-                    </div>
-                    <div
-                      aria-label="Français (Beta)"
-                      class="MenuOption TextOption menu-option"
-                      role="button"
-                    >
-                      <div
-                        class="noicon"
-                      />
-                      <div
-                        class="menu-name"
+                        aria-label="日本語"
+                        class="MenuOption TextOption menu-option"
+                        role="button"
                       >
-                        Français (Beta)
+                        <div
+                          class="noicon"
+                        />
+                        <div
+                          class="menu-name"
+                        >
+                          日本語
+                        </div>
+                        <div
+                          class="noicon"
+                        />
                       </div>
                       <div
-                        class="noicon"
-                      />
-                    </div>
-                    <div
-                      aria-label="Nederlands"
-                      class="MenuOption TextOption menu-option"
-                      role="button"
-                    >
-                      <div
-                        class="noicon"
-                      />
-                      <div
-                        class="menu-name"
+                        aria-label="Français (Beta)"
+                        class="MenuOption TextOption menu-option"
+                        role="button"
                       >
-                        Nederlands
+                        <div
+                          class="noicon"
+                        />
+                        <div
+                          class="menu-name"
+                        >
+                          Français (Beta)
+                        </div>
+                        <div
+                          class="noicon"
+                        />
                       </div>
                       <div
-                        class="noicon"
-                      />
-                    </div>
-                    <div
-                      aria-label="Pусский (Beta)"
-                      class="MenuOption TextOption menu-option"
-                      role="button"
-                    >
-                      <div
-                        class="noicon"
-                      />
-                      <div
-                        class="menu-name"
+                        aria-label="Nederlands"
+                        class="MenuOption TextOption menu-option"
+                        role="button"
                       >
-                        Pусский (Beta)
+                        <div
+                          class="noicon"
+                        />
+                        <div
+                          class="menu-name"
+                        >
+                          Nederlands
+                        </div>
+                        <div
+                          class="noicon"
+                        />
                       </div>
                       <div
-                        class="noicon"
-                      />
-                    </div>
-                    <div
-                      aria-label="中文 (繁體)"
-                      class="MenuOption TextOption menu-option"
-                      role="button"
-                    >
-                      <div
-                        class="noicon"
-                      />
-                      <div
-                        class="menu-name"
+                        aria-label="Pусский (Beta)"
+                        class="MenuOption TextOption menu-option"
+                        role="button"
                       >
-                        中文 (繁體)
+                        <div
+                          class="noicon"
+                        />
+                        <div
+                          class="menu-name"
+                        >
+                          Pусский (Beta)
+                        </div>
+                        <div
+                          class="noicon"
+                        />
                       </div>
                       <div
-                        class="noicon"
-                      />
-                    </div>
-                    <div
-                      aria-label="中文 (简体)"
-                      class="MenuOption TextOption menu-option"
-                      role="button"
-                    >
-                      <div
-                        class="noicon"
-                      />
-                      <div
-                        class="menu-name"
+                        aria-label="中文 (繁體)"
+                        class="MenuOption TextOption menu-option"
+                        role="button"
                       >
-                        中文 (简体)
+                        <div
+                          class="noicon"
+                        />
+                        <div
+                          class="menu-name"
+                        >
+                          中文 (繁體)
+                        </div>
+                        <div
+                          class="noicon"
+                        />
                       </div>
                       <div
-                        class="noicon"
-                      />
-                    </div>
-                    <div
-                      aria-label="Türkçe"
-                      class="MenuOption TextOption menu-option"
-                      role="button"
-                    >
-                      <div
-                        class="noicon"
-                      />
-                      <div
-                        class="menu-name"
+                        aria-label="中文 (简体)"
+                        class="MenuOption TextOption menu-option"
+                        role="button"
                       >
-                        Türkçe
+                        <div
+                          class="noicon"
+                        />
+                        <div
+                          class="menu-name"
+                        >
+                          中文 (简体)
+                        </div>
+                        <div
+                          class="noicon"
+                        />
                       </div>
                       <div
-                        class="noicon"
-                      />
-                    </div>
-                    <div
-                      aria-label="Occitan"
-                      class="MenuOption TextOption menu-option"
-                      role="button"
-                    >
-                      <div
-                        class="noicon"
-                      />
-                      <div
-                        class="menu-name"
+                        aria-label="Türkçe"
+                        class="MenuOption TextOption menu-option"
+                        role="button"
                       >
-                        Occitan
+                        <div
+                          class="noicon"
+                        />
+                        <div
+                          class="menu-name"
+                        >
+                          Türkçe
+                        </div>
+                        <div
+                          class="noicon"
+                        />
                       </div>
                       <div
-                        class="noicon"
-                      />
-                    </div>
-                    <div
-                      aria-label="Português (Brasil) (Beta)"
-                      class="MenuOption TextOption menu-option"
-                      role="button"
-                    >
-                      <div
-                        class="noicon"
-                      />
-                      <div
-                        class="menu-name"
+                        aria-label="Occitan"
+                        class="MenuOption TextOption menu-option"
+                        role="button"
                       >
-                        Português (Brasil) (Beta)
+                        <div
+                          class="noicon"
+                        />
+                        <div
+                          class="menu-name"
+                        >
+                          Occitan
+                        </div>
+                        <div
+                          class="noicon"
+                        />
                       </div>
                       <div
-                        class="noicon"
-                      />
-                    </div>
-                    <div
-                      aria-label="Català (Beta)"
-                      class="MenuOption TextOption menu-option"
-                      role="button"
-                    >
-                      <div
-                        class="noicon"
-                      />
-                      <div
-                        class="menu-name"
+                        aria-label="Português (Brasil) (Beta)"
+                        class="MenuOption TextOption menu-option"
+                        role="button"
                       >
-                        Català (Beta)
+                        <div
+                          class="noicon"
+                        />
+                        <div
+                          class="menu-name"
+                        >
+                          Português (Brasil) (Beta)
+                        </div>
+                        <div
+                          class="noicon"
+                        />
                       </div>
                       <div
-                        class="noicon"
-                      />
-                    </div>
-                    <div
-                      aria-label="Ελληνικά (Alpha)"
-                      class="MenuOption TextOption menu-option"
-                      role="button"
-                    >
-                      <div
-                        class="noicon"
-                      />
-                      <div
-                        class="menu-name"
+                        aria-label="Català (Beta)"
+                        class="MenuOption TextOption menu-option"
+                        role="button"
                       >
-                        Ελληνικά (Alpha)
+                        <div
+                          class="noicon"
+                        />
+                        <div
+                          class="menu-name"
+                        >
+                          Català (Beta)
+                        </div>
+                        <div
+                          class="noicon"
+                        />
                       </div>
                       <div
-                        class="noicon"
-                      />
-                    </div>
-                    <div
-                      aria-label="bahasa Indonesia (Alpha)"
-                      class="MenuOption TextOption menu-option"
-                      role="button"
-                    >
-                      <div
-                        class="noicon"
-                      />
-                      <div
-                        class="menu-name"
+                        aria-label="Ελληνικά (Alpha)"
+                        class="MenuOption TextOption menu-option"
+                        role="button"
                       >
-                        bahasa Indonesia (Alpha)
+                        <div
+                          class="noicon"
+                        />
+                        <div
+                          class="menu-name"
+                        >
+                          Ελληνικά (Alpha)
+                        </div>
+                        <div
+                          class="noicon"
+                        />
                       </div>
                       <div
-                        class="noicon"
-                      />
-                    </div>
-                    <div
-                      aria-label="Italiano (Beta)"
-                      class="MenuOption TextOption menu-option"
-                      role="button"
-                    >
-                      <div
-                        class="noicon"
-                      />
-                      <div
-                        class="menu-name"
+                        aria-label="bahasa Indonesia (Alpha)"
+                        class="MenuOption TextOption menu-option"
+                        role="button"
                       >
-                        Italiano (Beta)
+                        <div
+                          class="noicon"
+                        />
+                        <div
+                          class="menu-name"
+                        >
+                          bahasa Indonesia (Alpha)
+                        </div>
+                        <div
+                          class="noicon"
+                        />
                       </div>
                       <div
-                        class="noicon"
-                      />
-                    </div>
-                    <div
-                      aria-label="Svenska (Beta)"
-                      class="MenuOption TextOption menu-option"
-                      role="button"
-                    >
-                      <div
-                        class="noicon"
-                      />
-                      <div
-                        class="menu-name"
+                        aria-label="Italiano (Beta)"
+                        class="MenuOption TextOption menu-option"
+                        role="button"
                       >
-                        Svenska (Beta)
+                        <div
+                          class="noicon"
+                        />
+                        <div
+                          class="menu-name"
+                        >
+                          Italiano (Beta)
+                        </div>
+                        <div
+                          class="noicon"
+                        />
                       </div>
                       <div
-                        class="noicon"
-                      />
+                        aria-label="Svenska (Beta)"
+                        class="MenuOption TextOption menu-option"
+                        role="button"
+                      >
+                        <div
+                          class="noicon"
+                        />
+                        <div
+                          class="menu-name"
+                        >
+                          Svenska (Beta)
+                        </div>
+                        <div
+                          class="noicon"
+                        />
+                      </div>
                     </div>
-                  </div>
-                  <div
-                    class="menu-spacer hideOnWidescreen"
-                  />
-                  <div
-                    class="menu-options hideOnWidescreen"
-                  >
                     <div
-                      aria-label="Cancel"
-                      class="MenuOption TextOption menu-option menu-cancel"
-                      role="button"
+                      class="menu-spacer hideOnWidescreen"
+                    />
+                    <div
+                      class="menu-options hideOnWidescreen"
                     >
                       <div
-                        class="noicon"
-                      />
-                      <div
-                        class="menu-name"
+                        aria-label="Cancel"
+                        class="MenuOption TextOption menu-option menu-cancel"
+                        role="button"
                       >
-                        Cancel
+                        <div
+                          class="noicon"
+                        />
+                        <div
+                          class="menu-name"
+                        >
+                          Cancel
+                        </div>
+                        <div
+                          class="noicon"
+                        />
                       </div>
-                      <div
-                        class="noicon"
-                      />
                     </div>
                   </div>
                 </div>
               </div>
             </div>
-            <div
-              class="MenuOption SubMenuOption menu-option"
-              id="theme"
-            >
+            <div>
               <div
-                class="noicon"
-              />
-              <div
-                class="menu-name"
-              >
-                Set theme
-              </div>
-              <svg
-                class="SubmenuTriangleIcon Icon"
-                viewBox="0 0 100 100"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <polygon
-                  points="50,35 75,50 50,65"
-                />
-              </svg>
-            </div>
-            <div
-              class="MenuOption SwitchOption menu-option"
-            >
-              <div
-                class="noicon"
-              />
-              <div
-                class="menu-name"
-              >
-                Random icons
-              </div>
-              <div
-                class="Switch on"
+                class="MenuOption SubMenuOption menu-option "
+                id="theme"
               >
                 <div
-                  class="octo-switch-inner"
+                  class="noicon"
                 />
+                <div
+                  class="menu-name"
+                >
+                  Set theme
+                </div>
+                <svg
+                  class="SubmenuTriangleIcon Icon"
+                  viewBox="0 0 100 100"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <polygon
+                    points="50,35 75,50 50,65"
+                  />
+                </svg>
+              </div>
+            </div>
+            <div>
+              <div
+                class="MenuOption SwitchOption menu-option"
+              >
+                <div
+                  class="noicon"
+                />
+                <div
+                  class="menu-name"
+                >
+                  Random icons
+                </div>
+                <div
+                  class="Switch on"
+                >
+                  <div
+                    class="octo-switch-inner"
+                  />
+                </div>
               </div>
             </div>
           </div>
@@ -528,101 +538,111 @@ exports[`components/sidebar/SidebarSettingsMenu settings menu open should match 
           <div
             class="menu-options"
           >
-            <div
-              aria-label="Import archive"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
+            <div>
               <div
-                class="noicon"
-              />
-              <div
-                class="menu-name"
-              >
-                Import archive
-              </div>
-              <div
-                class="noicon"
-              />
-            </div>
-            <div
-              aria-label="Export archive"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
-              <div
-                class="noicon"
-              />
-              <div
-                class="menu-name"
-              >
-                Export archive
-              </div>
-              <div
-                class="noicon"
-              />
-            </div>
-            <div
-              class="MenuOption SubMenuOption menu-option"
-              id="lang"
-            >
-              <div
-                class="noicon"
-              />
-              <div
-                class="menu-name"
-              >
-                Set language
-              </div>
-              <svg
-                class="SubmenuTriangleIcon Icon"
-                viewBox="0 0 100 100"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <polygon
-                  points="50,35 75,50 50,65"
-                />
-              </svg>
-            </div>
-            <div
-              class="MenuOption SubMenuOption menu-option"
-              id="theme"
-            >
-              <div
-                class="noicon"
-              />
-              <div
-                class="menu-name"
-              >
-                Set theme
-              </div>
-              <svg
-                class="SubmenuTriangleIcon Icon"
-                viewBox="0 0 100 100"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <polygon
-                  points="50,35 75,50 50,65"
-                />
-              </svg>
-            </div>
-            <div
-              class="MenuOption SwitchOption menu-option"
-            >
-              <div
-                class="noicon"
-              />
-              <div
-                class="menu-name"
-              >
-                Random icons
-              </div>
-              <div
-                class="Switch on"
+                aria-label="Import archive"
+                class="MenuOption TextOption menu-option"
+                role="button"
               >
                 <div
-                  class="octo-switch-inner"
+                  class="noicon"
                 />
+                <div
+                  class="menu-name"
+                >
+                  Import archive
+                </div>
+                <div
+                  class="noicon"
+                />
+              </div>
+            </div>
+            <div>
+              <div
+                aria-label="Export archive"
+                class="MenuOption TextOption menu-option"
+                role="button"
+              >
+                <div
+                  class="noicon"
+                />
+                <div
+                  class="menu-name"
+                >
+                  Export archive
+                </div>
+                <div
+                  class="noicon"
+                />
+              </div>
+            </div>
+            <div>
+              <div
+                class="MenuOption SubMenuOption menu-option "
+                id="lang"
+              >
+                <div
+                  class="noicon"
+                />
+                <div
+                  class="menu-name"
+                >
+                  Set language
+                </div>
+                <svg
+                  class="SubmenuTriangleIcon Icon"
+                  viewBox="0 0 100 100"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <polygon
+                    points="50,35 75,50 50,65"
+                  />
+                </svg>
+              </div>
+            </div>
+            <div>
+              <div
+                class="MenuOption SubMenuOption menu-option "
+                id="theme"
+              >
+                <div
+                  class="noicon"
+                />
+                <div
+                  class="menu-name"
+                >
+                  Set theme
+                </div>
+                <svg
+                  class="SubmenuTriangleIcon Icon"
+                  viewBox="0 0 100 100"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <polygon
+                    points="50,35 75,50 50,65"
+                  />
+                </svg>
+              </div>
+            </div>
+            <div>
+              <div
+                class="MenuOption SwitchOption menu-option"
+              >
+                <div
+                  class="noicon"
+                />
+                <div
+                  class="menu-name"
+                >
+                  Random icons
+                </div>
+                <div
+                  class="Switch on"
+                >
+                  <div
+                    class="octo-switch-inner"
+                  />
+                </div>
               </div>
             </div>
           </div>
@@ -681,211 +701,221 @@ exports[`components/sidebar/SidebarSettingsMenu theme menu open should match sna
           <div
             class="menu-options"
           >
-            <div
-              aria-label="Import archive"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
+            <div>
               <div
-                class="noicon"
-              />
-              <div
-                class="menu-name"
-              >
-                Import archive
-              </div>
-              <div
-                class="noicon"
-              />
-            </div>
-            <div
-              aria-label="Export archive"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
-              <div
-                class="noicon"
-              />
-              <div
-                class="menu-name"
-              >
-                Export archive
-              </div>
-              <div
-                class="noicon"
-              />
-            </div>
-            <div
-              class="MenuOption SubMenuOption menu-option"
-              id="lang"
-            >
-              <div
-                class="noicon"
-              />
-              <div
-                class="menu-name"
-              >
-                Set language
-              </div>
-              <svg
-                class="SubmenuTriangleIcon Icon"
-                viewBox="0 0 100 100"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <polygon
-                  points="50,35 75,50 50,65"
-                />
-              </svg>
-            </div>
-            <div
-              class="MenuOption SubMenuOption menu-option"
-              id="theme"
-            >
-              <div
-                class="noicon"
-              />
-              <div
-                class="menu-name"
-              >
-                Set theme
-              </div>
-              <svg
-                class="SubmenuTriangleIcon Icon"
-                viewBox="0 0 100 100"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <polygon
-                  points="50,35 75,50 50,65"
-                />
-              </svg>
-              <div
-                class="SubMenu Menu noselect top"
+                aria-label="Import archive"
+                class="MenuOption TextOption menu-option"
+                role="button"
               >
                 <div
-                  class="menu-contents"
+                  class="noicon"
+                />
+                <div
+                  class="menu-name"
+                >
+                  Import archive
+                </div>
+                <div
+                  class="noicon"
+                />
+              </div>
+            </div>
+            <div>
+              <div
+                aria-label="Export archive"
+                class="MenuOption TextOption menu-option"
+                role="button"
+              >
+                <div
+                  class="noicon"
+                />
+                <div
+                  class="menu-name"
+                >
+                  Export archive
+                </div>
+                <div
+                  class="noicon"
+                />
+              </div>
+            </div>
+            <div>
+              <div
+                class="MenuOption SubMenuOption menu-option "
+                id="lang"
+              >
+                <div
+                  class="noicon"
+                />
+                <div
+                  class="menu-name"
+                >
+                  Set language
+                </div>
+                <svg
+                  class="SubmenuTriangleIcon Icon"
+                  viewBox="0 0 100 100"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <polygon
+                    points="50,35 75,50 50,65"
+                  />
+                </svg>
+              </div>
+            </div>
+            <div>
+              <div
+                class="MenuOption SubMenuOption menu-option menu-option-active"
+                id="theme"
+              >
+                <div
+                  class="noicon"
+                />
+                <div
+                  class="menu-name"
+                >
+                  Set theme
+                </div>
+                <svg
+                  class="SubmenuTriangleIcon Icon"
+                  viewBox="0 0 100 100"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <polygon
+                    points="50,35 75,50 50,65"
+                  />
+                </svg>
+                <div
+                  class="SubMenu Menu noselect top"
                 >
                   <div
-                    class="menu-options"
+                    class="menu-contents"
                   >
                     <div
-                      aria-label="Default theme"
-                      class="MenuOption TextOption menu-option"
-                      role="button"
+                      class="menu-options"
                     >
                       <div
-                        class="noicon"
-                      />
-                      <div
-                        class="menu-name"
+                        aria-label="Default theme"
+                        class="MenuOption TextOption menu-option"
+                        role="button"
                       >
-                        Default theme
-                      </div>
-                      <svg
-                        class="CheckIcon Icon"
-                        viewBox="0 0 100 100"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <polyline
-                          points="20,60 40,80 80,40"
+                        <div
+                          class="noicon"
                         />
-                      </svg>
-                    </div>
-                    <div
-                      aria-label="Dark theme"
-                      class="MenuOption TextOption menu-option"
-                      role="button"
-                    >
-                      <div
-                        class="noicon"
-                      />
-                      <div
-                        class="menu-name"
-                      >
-                        Dark theme
+                        <div
+                          class="menu-name"
+                        >
+                          Default theme
+                        </div>
+                        <svg
+                          class="CheckIcon Icon"
+                          viewBox="0 0 100 100"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <polyline
+                            points="20,60 40,80 80,40"
+                          />
+                        </svg>
                       </div>
                       <div
-                        class="noicon"
-                      />
-                    </div>
-                    <div
-                      aria-label="Light theme"
-                      class="MenuOption TextOption menu-option"
-                      role="button"
-                    >
-                      <div
-                        class="noicon"
-                      />
-                      <div
-                        class="menu-name"
+                        aria-label="Dark theme"
+                        class="MenuOption TextOption menu-option"
+                        role="button"
                       >
-                        Light theme
+                        <div
+                          class="noicon"
+                        />
+                        <div
+                          class="menu-name"
+                        >
+                          Dark theme
+                        </div>
+                        <div
+                          class="noicon"
+                        />
                       </div>
                       <div
-                        class="noicon"
-                      />
-                    </div>
-                    <div
-                      aria-label="System theme"
-                      class="MenuOption TextOption menu-option"
-                      role="button"
-                    >
-                      <div
-                        class="noicon"
-                      />
-                      <div
-                        class="menu-name"
+                        aria-label="Light theme"
+                        class="MenuOption TextOption menu-option"
+                        role="button"
                       >
-                        System theme
+                        <div
+                          class="noicon"
+                        />
+                        <div
+                          class="menu-name"
+                        >
+                          Light theme
+                        </div>
+                        <div
+                          class="noicon"
+                        />
                       </div>
                       <div
-                        class="noicon"
-                      />
+                        aria-label="System theme"
+                        class="MenuOption TextOption menu-option"
+                        role="button"
+                      >
+                        <div
+                          class="noicon"
+                        />
+                        <div
+                          class="menu-name"
+                        >
+                          System theme
+                        </div>
+                        <div
+                          class="noicon"
+                        />
+                      </div>
                     </div>
-                  </div>
-                  <div
-                    class="menu-spacer hideOnWidescreen"
-                  />
-                  <div
-                    class="menu-options hideOnWidescreen"
-                  >
                     <div
-                      aria-label="Cancel"
-                      class="MenuOption TextOption menu-option menu-cancel"
-                      role="button"
+                      class="menu-spacer hideOnWidescreen"
+                    />
+                    <div
+                      class="menu-options hideOnWidescreen"
                     >
                       <div
-                        class="noicon"
-                      />
-                      <div
-                        class="menu-name"
+                        aria-label="Cancel"
+                        class="MenuOption TextOption menu-option menu-cancel"
+                        role="button"
                       >
-                        Cancel
+                        <div
+                          class="noicon"
+                        />
+                        <div
+                          class="menu-name"
+                        >
+                          Cancel
+                        </div>
+                        <div
+                          class="noicon"
+                        />
                       </div>
-                      <div
-                        class="noicon"
-                      />
                     </div>
                   </div>
                 </div>
               </div>
             </div>
-            <div
-              class="MenuOption SwitchOption menu-option"
-            >
+            <div>
               <div
-                class="noicon"
-              />
-              <div
-                class="menu-name"
-              >
-                Random icons
-              </div>
-              <div
-                class="Switch on"
+                class="MenuOption SwitchOption menu-option"
               >
                 <div
-                  class="octo-switch-inner"
+                  class="noicon"
                 />
+                <div
+                  class="menu-name"
+                >
+                  Random icons
+                </div>
+                <div
+                  class="Switch on"
+                >
+                  <div
+                    class="octo-switch-inner"
+                  />
+                </div>
               </div>
             </div>
           </div>

--- a/webapp/src/components/sidebar/__snapshots__/sidebarSettingsMenu.test.tsx.snap
+++ b/webapp/src/components/sidebar/__snapshots__/sidebarSettingsMenu.test.tsx.snap
@@ -419,7 +419,7 @@ exports[`components/sidebar/SidebarSettingsMenu languages menu open should match
             </div>
             <div>
               <div
-                class="MenuOption SubMenuOption menu-option "
+                class="MenuOption SubMenuOption menu-option"
                 id="theme"
               >
                 <div
@@ -578,7 +578,7 @@ exports[`components/sidebar/SidebarSettingsMenu settings menu open should match 
             </div>
             <div>
               <div
-                class="MenuOption SubMenuOption menu-option "
+                class="MenuOption SubMenuOption menu-option"
                 id="lang"
               >
                 <div
@@ -602,7 +602,7 @@ exports[`components/sidebar/SidebarSettingsMenu settings menu open should match 
             </div>
             <div>
               <div
-                class="MenuOption SubMenuOption menu-option "
+                class="MenuOption SubMenuOption menu-option"
                 id="theme"
               >
                 <div
@@ -741,7 +741,7 @@ exports[`components/sidebar/SidebarSettingsMenu theme menu open should match sna
             </div>
             <div>
               <div
-                class="MenuOption SubMenuOption menu-option "
+                class="MenuOption SubMenuOption menu-option"
                 id="lang"
               >
                 <div

--- a/webapp/src/components/sidebar/sidebarSettingsMenu.tsx
+++ b/webapp/src/components/sidebar/sidebarSettingsMenu.tsx
@@ -95,6 +95,7 @@ const SidebarSettingsMenu = React.memo((props: Props) => {
                         id='lang'
                         name={intl.formatMessage({id: 'Sidebar.set-language', defaultMessage: 'Set language'})}
                         position='top'
+                        closeOnLeave={true}
                     >
                         {
                             Constants.languages.map((language) => (
@@ -112,6 +113,7 @@ const SidebarSettingsMenu = React.memo((props: Props) => {
                         id='theme'
                         name={intl.formatMessage({id: 'Sidebar.set-theme', defaultMessage: 'Set theme'})}
                         position='top'
+                        closeOnLeave={true}
                     >
                         {
                             themes.map((theme) =>

--- a/webapp/src/components/sidebar/sidebarSettingsMenu.tsx
+++ b/webapp/src/components/sidebar/sidebarSettingsMenu.tsx
@@ -95,7 +95,6 @@ const SidebarSettingsMenu = React.memo((props: Props) => {
                         id='lang'
                         name={intl.formatMessage({id: 'Sidebar.set-language', defaultMessage: 'Set language'})}
                         position='top'
-                        closeOnLeave={true}
                     >
                         {
                             Constants.languages.map((language) => (
@@ -113,7 +112,6 @@ const SidebarSettingsMenu = React.memo((props: Props) => {
                         id='theme'
                         name={intl.formatMessage({id: 'Sidebar.set-theme', defaultMessage: 'Set theme'})}
                         position='top'
-                        closeOnLeave={true}
                     >
                         {
                             themes.map((theme) =>

--- a/webapp/src/components/table/__snapshots__/tableHeaderMenu.test.tsx.snap
+++ b/webapp/src/components/table/__snapshots__/tableHeaderMenu.test.tsx.snap
@@ -11,124 +11,134 @@ exports[`components/table/TableHeaderMenu should match snapshot, other column 1`
       <div
         class="menu-options"
       >
-        <div
-          aria-label="Sort ascending"
-          class="MenuOption TextOption menu-option"
-          role="button"
-        >
+        <div>
           <div
-            class="noicon"
-          />
-          <div
-            class="menu-name"
+            aria-label="Sort ascending"
+            class="MenuOption TextOption menu-option"
+            role="button"
           >
-            Sort ascending
+            <div
+              class="noicon"
+            />
+            <div
+              class="menu-name"
+            >
+              Sort ascending
+            </div>
+            <div
+              class="noicon"
+            />
           </div>
-          <div
-            class="noicon"
-          />
         </div>
-        <div
-          aria-label="Sort descending"
-          class="MenuOption TextOption menu-option"
-          role="button"
-        >
+        <div>
           <div
-            class="noicon"
-          />
-          <div
-            class="menu-name"
+            aria-label="Sort descending"
+            class="MenuOption TextOption menu-option"
+            role="button"
           >
-            Sort descending
+            <div
+              class="noicon"
+            />
+            <div
+              class="menu-name"
+            >
+              Sort descending
+            </div>
+            <div
+              class="noicon"
+            />
           </div>
-          <div
-            class="noicon"
-          />
         </div>
-        <div
-          aria-label="Insert left"
-          class="MenuOption TextOption menu-option"
-          role="button"
-        >
+        <div>
           <div
-            class="noicon"
-          />
-          <div
-            class="menu-name"
+            aria-label="Insert left"
+            class="MenuOption TextOption menu-option"
+            role="button"
           >
-            Insert left
+            <div
+              class="noicon"
+            />
+            <div
+              class="menu-name"
+            >
+              Insert left
+            </div>
+            <div
+              class="noicon"
+            />
           </div>
-          <div
-            class="noicon"
-          />
         </div>
-        <div
-          aria-label="Insert right"
-          class="MenuOption TextOption menu-option"
-          role="button"
-        >
+        <div>
           <div
-            class="noicon"
-          />
-          <div
-            class="menu-name"
+            aria-label="Insert right"
+            class="MenuOption TextOption menu-option"
+            role="button"
           >
-            Insert right
+            <div
+              class="noicon"
+            />
+            <div
+              class="menu-name"
+            >
+              Insert right
+            </div>
+            <div
+              class="noicon"
+            />
           </div>
-          <div
-            class="noicon"
-          />
         </div>
-        <div
-          aria-label="Hide"
-          class="MenuOption TextOption menu-option"
-          role="button"
-        >
+        <div>
           <div
-            class="noicon"
-          />
-          <div
-            class="menu-name"
+            aria-label="Hide"
+            class="MenuOption TextOption menu-option"
+            role="button"
           >
-            Hide
+            <div
+              class="noicon"
+            />
+            <div
+              class="menu-name"
+            >
+              Hide
+            </div>
+            <div
+              class="noicon"
+            />
           </div>
           <div
-            class="noicon"
-          />
-        </div>
-        <div
-          aria-label="Duplicate"
-          class="MenuOption TextOption menu-option"
-          role="button"
-        >
-          <div
-            class="noicon"
-          />
-          <div
-            class="menu-name"
+            aria-label="Duplicate"
+            class="MenuOption TextOption menu-option"
+            role="button"
           >
-            Duplicate
+            <div
+              class="noicon"
+            />
+            <div
+              class="menu-name"
+            >
+              Duplicate
+            </div>
+            <div
+              class="noicon"
+            />
           </div>
           <div
-            class="noicon"
-          />
-        </div>
-        <div
-          aria-label="Delete"
-          class="MenuOption TextOption menu-option"
-          role="button"
-        >
-          <div
-            class="noicon"
-          />
-          <div
-            class="menu-name"
+            aria-label="Delete"
+            class="MenuOption TextOption menu-option"
+            role="button"
           >
-            Delete
+            <div
+              class="noicon"
+            />
+            <div
+              class="menu-name"
+            >
+              Delete
+            </div>
+            <div
+              class="noicon"
+            />
           </div>
-          <div
-            class="noicon"
-          />
         </div>
       </div>
       <div
@@ -171,73 +181,81 @@ exports[`components/table/TableHeaderMenu should match snapshot, title column 1`
       <div
         class="menu-options"
       >
-        <div
-          aria-label="Sort ascending"
-          class="MenuOption TextOption menu-option"
-          role="button"
-        >
+        <div>
           <div
-            class="noicon"
-          />
-          <div
-            class="menu-name"
+            aria-label="Sort ascending"
+            class="MenuOption TextOption menu-option"
+            role="button"
           >
-            Sort ascending
+            <div
+              class="noicon"
+            />
+            <div
+              class="menu-name"
+            >
+              Sort ascending
+            </div>
+            <div
+              class="noicon"
+            />
           </div>
-          <div
-            class="noicon"
-          />
         </div>
-        <div
-          aria-label="Sort descending"
-          class="MenuOption TextOption menu-option"
-          role="button"
-        >
+        <div>
           <div
-            class="noicon"
-          />
-          <div
-            class="menu-name"
+            aria-label="Sort descending"
+            class="MenuOption TextOption menu-option"
+            role="button"
           >
-            Sort descending
+            <div
+              class="noicon"
+            />
+            <div
+              class="menu-name"
+            >
+              Sort descending
+            </div>
+            <div
+              class="noicon"
+            />
           </div>
-          <div
-            class="noicon"
-          />
         </div>
-        <div
-          aria-label="Insert left"
-          class="MenuOption TextOption menu-option"
-          role="button"
-        >
+        <div>
           <div
-            class="noicon"
-          />
-          <div
-            class="menu-name"
+            aria-label="Insert left"
+            class="MenuOption TextOption menu-option"
+            role="button"
           >
-            Insert left
+            <div
+              class="noicon"
+            />
+            <div
+              class="menu-name"
+            >
+              Insert left
+            </div>
+            <div
+              class="noicon"
+            />
           </div>
-          <div
-            class="noicon"
-          />
         </div>
-        <div
-          aria-label="Insert right"
-          class="MenuOption TextOption menu-option"
-          role="button"
-        >
+        <div>
           <div
-            class="noicon"
-          />
-          <div
-            class="menu-name"
+            aria-label="Insert right"
+            class="MenuOption TextOption menu-option"
+            role="button"
           >
-            Insert right
+            <div
+              class="noicon"
+            />
+            <div
+              class="menu-name"
+            >
+              Insert right
+            </div>
+            <div
+              class="noicon"
+            />
           </div>
-          <div
-            class="noicon"
-          />
         </div>
       </div>
       <div

--- a/webapp/src/components/viewHeader/__snapshots__/emptyCardButton.test.tsx.snap
+++ b/webapp/src/components/viewHeader/__snapshots__/emptyCardButton.test.tsx.snap
@@ -92,28 +92,30 @@ exports[`components/viewHeader/emptyCardButton return EmptyCardButton and Set Te
           <div
             class="menu-options"
           >
-            <div
-              aria-label="Set as default"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
-              <svg
-                class="CheckIcon Icon"
-                viewBox="0 0 100 100"
-                xmlns="http://www.w3.org/2000/svg"
+            <div>
+              <div
+                aria-label="Set as default"
+                class="MenuOption TextOption menu-option"
+                role="button"
               >
-                <polyline
-                  points="20,60 40,80 80,40"
+                <svg
+                  class="CheckIcon Icon"
+                  viewBox="0 0 100 100"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <polyline
+                    points="20,60 40,80 80,40"
+                  />
+                </svg>
+                <div
+                  class="menu-name"
+                >
+                  Set as default
+                </div>
+                <div
+                  class="noicon"
                 />
-              </svg>
-              <div
-                class="menu-name"
-              >
-                Set as default
               </div>
-              <div
-                class="noicon"
-              />
             </div>
           </div>
           <div

--- a/webapp/src/components/viewHeader/__snapshots__/filterComponent.test.tsx.snap
+++ b/webapp/src/components/viewHeader/__snapshots__/filterComponent.test.tsx.snap
@@ -47,73 +47,81 @@ exports[`components/viewHeader/filterComponent return filterComponent 1`] = `
               <div
                 class="menu-options"
               >
-                <div
-                  aria-label="Status"
-                  class="MenuOption TextOption menu-option"
-                  role="button"
-                >
+                <div>
                   <div
-                    class="noicon"
-                  />
-                  <div
-                    class="menu-name"
+                    aria-label="Status"
+                    class="MenuOption TextOption menu-option"
+                    role="button"
                   >
-                    Status
+                    <div
+                      class="noicon"
+                    />
+                    <div
+                      class="menu-name"
+                    >
+                      Status
+                    </div>
+                    <div
+                      class="noicon"
+                    />
                   </div>
-                  <div
-                    class="noicon"
-                  />
                 </div>
-                <div
-                  aria-label="Property 1"
-                  class="MenuOption TextOption menu-option"
-                  role="button"
-                >
+                <div>
                   <div
-                    class="noicon"
-                  />
-                  <div
-                    class="menu-name"
+                    aria-label="Property 1"
+                    class="MenuOption TextOption menu-option"
+                    role="button"
                   >
-                    Property 1
+                    <div
+                      class="noicon"
+                    />
+                    <div
+                      class="menu-name"
+                    >
+                      Property 1
+                    </div>
+                    <div
+                      class="noicon"
+                    />
                   </div>
-                  <div
-                    class="noicon"
-                  />
                 </div>
-                <div
-                  aria-label="Property 2"
-                  class="MenuOption TextOption menu-option"
-                  role="button"
-                >
+                <div>
                   <div
-                    class="noicon"
-                  />
-                  <div
-                    class="menu-name"
+                    aria-label="Property 2"
+                    class="MenuOption TextOption menu-option"
+                    role="button"
                   >
-                    Property 2
+                    <div
+                      class="noicon"
+                    />
+                    <div
+                      class="menu-name"
+                    >
+                      Property 2
+                    </div>
+                    <div
+                      class="noicon"
+                    />
                   </div>
-                  <div
-                    class="noicon"
-                  />
                 </div>
-                <div
-                  aria-label="Property 3"
-                  class="MenuOption TextOption menu-option"
-                  role="button"
-                >
+                <div>
                   <div
-                    class="noicon"
-                  />
-                  <div
-                    class="menu-name"
+                    aria-label="Property 3"
+                    class="MenuOption TextOption menu-option"
+                    role="button"
                   >
-                    Property 3
+                    <div
+                      class="noicon"
+                    />
+                    <div
+                      class="menu-name"
+                    >
+                      Property 3
+                    </div>
+                    <div
+                      class="noicon"
+                    />
                   </div>
-                  <div
-                    class="noicon"
-                  />
                 </div>
               </div>
               <div
@@ -230,73 +238,81 @@ exports[`components/viewHeader/filterComponent return filterComponent and add Fi
               <div
                 class="menu-options"
               >
-                <div
-                  aria-label="Status"
-                  class="MenuOption TextOption menu-option"
-                  role="button"
-                >
+                <div>
                   <div
-                    class="noicon"
-                  />
-                  <div
-                    class="menu-name"
+                    aria-label="Status"
+                    class="MenuOption TextOption menu-option"
+                    role="button"
                   >
-                    Status
+                    <div
+                      class="noicon"
+                    />
+                    <div
+                      class="menu-name"
+                    >
+                      Status
+                    </div>
+                    <div
+                      class="noicon"
+                    />
                   </div>
-                  <div
-                    class="noicon"
-                  />
                 </div>
-                <div
-                  aria-label="Property 1"
-                  class="MenuOption TextOption menu-option"
-                  role="button"
-                >
+                <div>
                   <div
-                    class="noicon"
-                  />
-                  <div
-                    class="menu-name"
+                    aria-label="Property 1"
+                    class="MenuOption TextOption menu-option"
+                    role="button"
                   >
-                    Property 1
+                    <div
+                      class="noicon"
+                    />
+                    <div
+                      class="menu-name"
+                    >
+                      Property 1
+                    </div>
+                    <div
+                      class="noicon"
+                    />
                   </div>
-                  <div
-                    class="noicon"
-                  />
                 </div>
-                <div
-                  aria-label="Property 2"
-                  class="MenuOption TextOption menu-option"
-                  role="button"
-                >
+                <div>
                   <div
-                    class="noicon"
-                  />
-                  <div
-                    class="menu-name"
+                    aria-label="Property 2"
+                    class="MenuOption TextOption menu-option"
+                    role="button"
                   >
-                    Property 2
+                    <div
+                      class="noicon"
+                    />
+                    <div
+                      class="menu-name"
+                    >
+                      Property 2
+                    </div>
+                    <div
+                      class="noicon"
+                    />
                   </div>
-                  <div
-                    class="noicon"
-                  />
                 </div>
-                <div
-                  aria-label="Property 3"
-                  class="MenuOption TextOption menu-option"
-                  role="button"
-                >
+                <div>
                   <div
-                    class="noicon"
-                  />
-                  <div
-                    class="menu-name"
+                    aria-label="Property 3"
+                    class="MenuOption TextOption menu-option"
+                    role="button"
                   >
-                    Property 3
+                    <div
+                      class="noicon"
+                    />
+                    <div
+                      class="menu-name"
+                    >
+                      Property 3
+                    </div>
+                    <div
+                      class="noicon"
+                    />
                   </div>
-                  <div
-                    class="noicon"
-                  />
                 </div>
               </div>
               <div
@@ -427,73 +443,81 @@ exports[`components/viewHeader/filterComponent return filterComponent and click 
               <div
                 class="menu-options"
               >
-                <div
-                  aria-label="includes"
-                  class="MenuOption TextOption menu-option"
-                  role="button"
-                >
+                <div>
                   <div
-                    class="noicon"
-                  />
-                  <div
-                    class="menu-name"
+                    aria-label="includes"
+                    class="MenuOption TextOption menu-option"
+                    role="button"
                   >
-                    includes
+                    <div
+                      class="noicon"
+                    />
+                    <div
+                      class="menu-name"
+                    >
+                      includes
+                    </div>
+                    <div
+                      class="noicon"
+                    />
                   </div>
-                  <div
-                    class="noicon"
-                  />
                 </div>
-                <div
-                  aria-label="doesn't include"
-                  class="MenuOption TextOption menu-option"
-                  role="button"
-                >
+                <div>
                   <div
-                    class="noicon"
-                  />
-                  <div
-                    class="menu-name"
+                    aria-label="doesn't include"
+                    class="MenuOption TextOption menu-option"
+                    role="button"
                   >
-                    doesn't include
+                    <div
+                      class="noicon"
+                    />
+                    <div
+                      class="menu-name"
+                    >
+                      doesn't include
+                    </div>
+                    <div
+                      class="noicon"
+                    />
                   </div>
-                  <div
-                    class="noicon"
-                  />
                 </div>
-                <div
-                  aria-label="is empty"
-                  class="MenuOption TextOption menu-option"
-                  role="button"
-                >
+                <div>
                   <div
-                    class="noicon"
-                  />
-                  <div
-                    class="menu-name"
+                    aria-label="is empty"
+                    class="MenuOption TextOption menu-option"
+                    role="button"
                   >
-                    is empty
+                    <div
+                      class="noicon"
+                    />
+                    <div
+                      class="menu-name"
+                    >
+                      is empty
+                    </div>
+                    <div
+                      class="noicon"
+                    />
                   </div>
-                  <div
-                    class="noicon"
-                  />
                 </div>
-                <div
-                  aria-label="is not empty"
-                  class="MenuOption TextOption menu-option"
-                  role="button"
-                >
+                <div>
                   <div
-                    class="noicon"
-                  />
-                  <div
-                    class="menu-name"
+                    aria-label="is not empty"
+                    class="MenuOption TextOption menu-option"
+                    role="button"
                   >
-                    is not empty
+                    <div
+                      class="noicon"
+                    />
+                    <div
+                      class="menu-name"
+                    >
+                      is not empty
+                    </div>
+                    <div
+                      class="noicon"
+                    />
                   </div>
-                  <div
-                    class="noicon"
-                  />
                 </div>
               </div>
               <div
@@ -596,73 +620,81 @@ exports[`components/viewHeader/filterComponent return filterComponent and filter
               <div
                 class="menu-options"
               >
-                <div
-                  aria-label="Status"
-                  class="MenuOption TextOption menu-option"
-                  role="button"
-                >
+                <div>
                   <div
-                    class="noicon"
-                  />
-                  <div
-                    class="menu-name"
+                    aria-label="Status"
+                    class="MenuOption TextOption menu-option"
+                    role="button"
                   >
-                    Status
+                    <div
+                      class="noicon"
+                    />
+                    <div
+                      class="menu-name"
+                    >
+                      Status
+                    </div>
+                    <div
+                      class="noicon"
+                    />
                   </div>
-                  <div
-                    class="noicon"
-                  />
                 </div>
-                <div
-                  aria-label="Property 1"
-                  class="MenuOption TextOption menu-option"
-                  role="button"
-                >
+                <div>
                   <div
-                    class="noicon"
-                  />
-                  <div
-                    class="menu-name"
+                    aria-label="Property 1"
+                    class="MenuOption TextOption menu-option"
+                    role="button"
                   >
-                    Property 1
+                    <div
+                      class="noicon"
+                    />
+                    <div
+                      class="menu-name"
+                    >
+                      Property 1
+                    </div>
+                    <div
+                      class="noicon"
+                    />
                   </div>
-                  <div
-                    class="noicon"
-                  />
                 </div>
-                <div
-                  aria-label="Property 2"
-                  class="MenuOption TextOption menu-option"
-                  role="button"
-                >
+                <div>
                   <div
-                    class="noicon"
-                  />
-                  <div
-                    class="menu-name"
+                    aria-label="Property 2"
+                    class="MenuOption TextOption menu-option"
+                    role="button"
                   >
-                    Property 2
+                    <div
+                      class="noicon"
+                    />
+                    <div
+                      class="menu-name"
+                    >
+                      Property 2
+                    </div>
+                    <div
+                      class="noicon"
+                    />
                   </div>
-                  <div
-                    class="noicon"
-                  />
                 </div>
-                <div
-                  aria-label="Property 3"
-                  class="MenuOption TextOption menu-option"
-                  role="button"
-                >
+                <div>
                   <div
-                    class="noicon"
-                  />
-                  <div
-                    class="menu-name"
+                    aria-label="Property 3"
+                    class="MenuOption TextOption menu-option"
+                    role="button"
                   >
-                    Property 3
+                    <div
+                      class="noicon"
+                    />
+                    <div
+                      class="menu-name"
+                    >
+                      Property 3
+                    </div>
+                    <div
+                      class="noicon"
+                    />
                   </div>
-                  <div
-                    class="noicon"
-                  />
                 </div>
               </div>
               <div

--- a/webapp/src/components/viewHeader/__snapshots__/filterEntry.test.tsx.snap
+++ b/webapp/src/components/viewHeader/__snapshots__/filterEntry.test.tsx.snap
@@ -27,73 +27,81 @@ exports[`components/viewHeader/filterEntry return filterEntry 1`] = `
           <div
             class="menu-options"
           >
-            <div
-              aria-label="Status"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
+            <div>
               <div
-                class="noicon"
-              />
-              <div
-                class="menu-name"
+                aria-label="Status"
+                class="MenuOption TextOption menu-option"
+                role="button"
               >
-                Status
+                <div
+                  class="noicon"
+                />
+                <div
+                  class="menu-name"
+                >
+                  Status
+                </div>
+                <div
+                  class="noicon"
+                />
               </div>
-              <div
-                class="noicon"
-              />
             </div>
-            <div
-              aria-label="Property 1"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
+            <div>
               <div
-                class="noicon"
-              />
-              <div
-                class="menu-name"
+                aria-label="Property 1"
+                class="MenuOption TextOption menu-option"
+                role="button"
               >
-                Property 1
+                <div
+                  class="noicon"
+                />
+                <div
+                  class="menu-name"
+                >
+                  Property 1
+                </div>
+                <div
+                  class="noicon"
+                />
               </div>
-              <div
-                class="noicon"
-              />
             </div>
-            <div
-              aria-label="Property 2"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
+            <div>
               <div
-                class="noicon"
-              />
-              <div
-                class="menu-name"
+                aria-label="Property 2"
+                class="MenuOption TextOption menu-option"
+                role="button"
               >
-                Property 2
+                <div
+                  class="noicon"
+                />
+                <div
+                  class="menu-name"
+                >
+                  Property 2
+                </div>
+                <div
+                  class="noicon"
+                />
               </div>
-              <div
-                class="noicon"
-              />
             </div>
-            <div
-              aria-label="Property 3"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
+            <div>
               <div
-                class="noicon"
-              />
-              <div
-                class="menu-name"
+                aria-label="Property 3"
+                class="MenuOption TextOption menu-option"
+                role="button"
               >
-                Property 3
+                <div
+                  class="noicon"
+                />
+                <div
+                  class="menu-name"
+                >
+                  Property 3
+                </div>
+                <div
+                  class="noicon"
+                />
               </div>
-              <div
-                class="noicon"
-              />
             </div>
           </div>
           <div
@@ -193,73 +201,81 @@ exports[`components/viewHeader/filterEntry return filterEntry and click on delet
           <div
             class="menu-options"
           >
-            <div
-              aria-label="includes"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
+            <div>
               <div
-                class="noicon"
-              />
-              <div
-                class="menu-name"
+                aria-label="includes"
+                class="MenuOption TextOption menu-option"
+                role="button"
               >
-                includes
+                <div
+                  class="noicon"
+                />
+                <div
+                  class="menu-name"
+                >
+                  includes
+                </div>
+                <div
+                  class="noicon"
+                />
               </div>
-              <div
-                class="noicon"
-              />
             </div>
-            <div
-              aria-label="doesn't include"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
+            <div>
               <div
-                class="noicon"
-              />
-              <div
-                class="menu-name"
+                aria-label="doesn't include"
+                class="MenuOption TextOption menu-option"
+                role="button"
               >
-                doesn't include
+                <div
+                  class="noicon"
+                />
+                <div
+                  class="menu-name"
+                >
+                  doesn't include
+                </div>
+                <div
+                  class="noicon"
+                />
               </div>
-              <div
-                class="noicon"
-              />
             </div>
-            <div
-              aria-label="is empty"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
+            <div>
               <div
-                class="noicon"
-              />
-              <div
-                class="menu-name"
+                aria-label="is empty"
+                class="MenuOption TextOption menu-option"
+                role="button"
               >
-                is empty
+                <div
+                  class="noicon"
+                />
+                <div
+                  class="menu-name"
+                >
+                  is empty
+                </div>
+                <div
+                  class="noicon"
+                />
               </div>
-              <div
-                class="noicon"
-              />
             </div>
-            <div
-              aria-label="is not empty"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
+            <div>
               <div
-                class="noicon"
-              />
-              <div
-                class="menu-name"
+                aria-label="is not empty"
+                class="MenuOption TextOption menu-option"
+                role="button"
               >
-                is not empty
+                <div
+                  class="noicon"
+                />
+                <div
+                  class="menu-name"
+                >
+                  is not empty
+                </div>
+                <div
+                  class="noicon"
+                />
               </div>
-              <div
-                class="noicon"
-              />
             </div>
           </div>
           <div
@@ -345,73 +361,81 @@ exports[`components/viewHeader/filterEntry return filterEntry and click on doesn
           <div
             class="menu-options"
           >
-            <div
-              aria-label="includes"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
+            <div>
               <div
-                class="noicon"
-              />
-              <div
-                class="menu-name"
+                aria-label="includes"
+                class="MenuOption TextOption menu-option"
+                role="button"
               >
-                includes
+                <div
+                  class="noicon"
+                />
+                <div
+                  class="menu-name"
+                >
+                  includes
+                </div>
+                <div
+                  class="noicon"
+                />
               </div>
-              <div
-                class="noicon"
-              />
             </div>
-            <div
-              aria-label="doesn't include"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
+            <div>
               <div
-                class="noicon"
-              />
-              <div
-                class="menu-name"
+                aria-label="doesn't include"
+                class="MenuOption TextOption menu-option"
+                role="button"
               >
-                doesn't include
+                <div
+                  class="noicon"
+                />
+                <div
+                  class="menu-name"
+                >
+                  doesn't include
+                </div>
+                <div
+                  class="noicon"
+                />
               </div>
-              <div
-                class="noicon"
-              />
             </div>
-            <div
-              aria-label="is empty"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
+            <div>
               <div
-                class="noicon"
-              />
-              <div
-                class="menu-name"
+                aria-label="is empty"
+                class="MenuOption TextOption menu-option"
+                role="button"
               >
-                is empty
+                <div
+                  class="noicon"
+                />
+                <div
+                  class="menu-name"
+                >
+                  is empty
+                </div>
+                <div
+                  class="noicon"
+                />
               </div>
-              <div
-                class="noicon"
-              />
             </div>
-            <div
-              aria-label="is not empty"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
+            <div>
               <div
-                class="noicon"
-              />
-              <div
-                class="menu-name"
+                aria-label="is not empty"
+                class="MenuOption TextOption menu-option"
+                role="button"
               >
-                is not empty
+                <div
+                  class="noicon"
+                />
+                <div
+                  class="menu-name"
+                >
+                  is not empty
+                </div>
+                <div
+                  class="noicon"
+                />
               </div>
-              <div
-                class="noicon"
-              />
             </div>
           </div>
           <div
@@ -497,73 +521,81 @@ exports[`components/viewHeader/filterEntry return filterEntry and click on inclu
           <div
             class="menu-options"
           >
-            <div
-              aria-label="includes"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
+            <div>
               <div
-                class="noicon"
-              />
-              <div
-                class="menu-name"
+                aria-label="includes"
+                class="MenuOption TextOption menu-option"
+                role="button"
               >
-                includes
+                <div
+                  class="noicon"
+                />
+                <div
+                  class="menu-name"
+                >
+                  includes
+                </div>
+                <div
+                  class="noicon"
+                />
               </div>
-              <div
-                class="noicon"
-              />
             </div>
-            <div
-              aria-label="doesn't include"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
+            <div>
               <div
-                class="noicon"
-              />
-              <div
-                class="menu-name"
+                aria-label="doesn't include"
+                class="MenuOption TextOption menu-option"
+                role="button"
               >
-                doesn't include
+                <div
+                  class="noicon"
+                />
+                <div
+                  class="menu-name"
+                >
+                  doesn't include
+                </div>
+                <div
+                  class="noicon"
+                />
               </div>
-              <div
-                class="noicon"
-              />
             </div>
-            <div
-              aria-label="is empty"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
+            <div>
               <div
-                class="noicon"
-              />
-              <div
-                class="menu-name"
+                aria-label="is empty"
+                class="MenuOption TextOption menu-option"
+                role="button"
               >
-                is empty
+                <div
+                  class="noicon"
+                />
+                <div
+                  class="menu-name"
+                >
+                  is empty
+                </div>
+                <div
+                  class="noicon"
+                />
               </div>
-              <div
-                class="noicon"
-              />
             </div>
-            <div
-              aria-label="is not empty"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
+            <div>
               <div
-                class="noicon"
-              />
-              <div
-                class="menu-name"
+                aria-label="is not empty"
+                class="MenuOption TextOption menu-option"
+                role="button"
               >
-                is not empty
+                <div
+                  class="noicon"
+                />
+                <div
+                  class="menu-name"
+                >
+                  is not empty
+                </div>
+                <div
+                  class="noicon"
+                />
               </div>
-              <div
-                class="noicon"
-              />
             </div>
           </div>
           <div
@@ -649,73 +681,81 @@ exports[`components/viewHeader/filterEntry return filterEntry and click on is em
           <div
             class="menu-options"
           >
-            <div
-              aria-label="includes"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
+            <div>
               <div
-                class="noicon"
-              />
-              <div
-                class="menu-name"
+                aria-label="includes"
+                class="MenuOption TextOption menu-option"
+                role="button"
               >
-                includes
+                <div
+                  class="noicon"
+                />
+                <div
+                  class="menu-name"
+                >
+                  includes
+                </div>
+                <div
+                  class="noicon"
+                />
               </div>
-              <div
-                class="noicon"
-              />
             </div>
-            <div
-              aria-label="doesn't include"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
+            <div>
               <div
-                class="noicon"
-              />
-              <div
-                class="menu-name"
+                aria-label="doesn't include"
+                class="MenuOption TextOption menu-option"
+                role="button"
               >
-                doesn't include
+                <div
+                  class="noicon"
+                />
+                <div
+                  class="menu-name"
+                >
+                  doesn't include
+                </div>
+                <div
+                  class="noicon"
+                />
               </div>
-              <div
-                class="noicon"
-              />
             </div>
-            <div
-              aria-label="is empty"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
+            <div>
               <div
-                class="noicon"
-              />
-              <div
-                class="menu-name"
+                aria-label="is empty"
+                class="MenuOption TextOption menu-option"
+                role="button"
               >
-                is empty
+                <div
+                  class="noicon"
+                />
+                <div
+                  class="menu-name"
+                >
+                  is empty
+                </div>
+                <div
+                  class="noicon"
+                />
               </div>
-              <div
-                class="noicon"
-              />
             </div>
-            <div
-              aria-label="is not empty"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
+            <div>
               <div
-                class="noicon"
-              />
-              <div
-                class="menu-name"
+                aria-label="is not empty"
+                class="MenuOption TextOption menu-option"
+                role="button"
               >
-                is not empty
+                <div
+                  class="noicon"
+                />
+                <div
+                  class="menu-name"
+                >
+                  is not empty
+                </div>
+                <div
+                  class="noicon"
+                />
               </div>
-              <div
-                class="noicon"
-              />
             </div>
           </div>
           <div
@@ -801,73 +841,81 @@ exports[`components/viewHeader/filterEntry return filterEntry and click on is no
           <div
             class="menu-options"
           >
-            <div
-              aria-label="includes"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
+            <div>
               <div
-                class="noicon"
-              />
-              <div
-                class="menu-name"
+                aria-label="includes"
+                class="MenuOption TextOption menu-option"
+                role="button"
               >
-                includes
+                <div
+                  class="noicon"
+                />
+                <div
+                  class="menu-name"
+                >
+                  includes
+                </div>
+                <div
+                  class="noicon"
+                />
               </div>
-              <div
-                class="noicon"
-              />
             </div>
-            <div
-              aria-label="doesn't include"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
+            <div>
               <div
-                class="noicon"
-              />
-              <div
-                class="menu-name"
+                aria-label="doesn't include"
+                class="MenuOption TextOption menu-option"
+                role="button"
               >
-                doesn't include
+                <div
+                  class="noicon"
+                />
+                <div
+                  class="menu-name"
+                >
+                  doesn't include
+                </div>
+                <div
+                  class="noicon"
+                />
               </div>
-              <div
-                class="noicon"
-              />
             </div>
-            <div
-              aria-label="is empty"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
+            <div>
               <div
-                class="noicon"
-              />
-              <div
-                class="menu-name"
+                aria-label="is empty"
+                class="MenuOption TextOption menu-option"
+                role="button"
               >
-                is empty
+                <div
+                  class="noicon"
+                />
+                <div
+                  class="menu-name"
+                >
+                  is empty
+                </div>
+                <div
+                  class="noicon"
+                />
               </div>
-              <div
-                class="noicon"
-              />
             </div>
-            <div
-              aria-label="is not empty"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
+            <div>
               <div
-                class="noicon"
-              />
-              <div
-                class="menu-name"
+                aria-label="is not empty"
+                class="MenuOption TextOption menu-option"
+                role="button"
               >
-                is not empty
+                <div
+                  class="noicon"
+                />
+                <div
+                  class="menu-name"
+                >
+                  is not empty
+                </div>
+                <div
+                  class="noicon"
+                />
               </div>
-              <div
-                class="noicon"
-              />
             </div>
           </div>
           <div
@@ -939,73 +987,81 @@ exports[`components/viewHeader/filterEntry return filterEntry and click on statu
           <div
             class="menu-options"
           >
-            <div
-              aria-label="Status"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
+            <div>
               <div
-                class="noicon"
-              />
-              <div
-                class="menu-name"
+                aria-label="Status"
+                class="MenuOption TextOption menu-option"
+                role="button"
               >
-                Status
+                <div
+                  class="noicon"
+                />
+                <div
+                  class="menu-name"
+                >
+                  Status
+                </div>
+                <div
+                  class="noicon"
+                />
               </div>
-              <div
-                class="noicon"
-              />
             </div>
-            <div
-              aria-label="Property 1"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
+            <div>
               <div
-                class="noicon"
-              />
-              <div
-                class="menu-name"
+                aria-label="Property 1"
+                class="MenuOption TextOption menu-option"
+                role="button"
               >
-                Property 1
+                <div
+                  class="noicon"
+                />
+                <div
+                  class="menu-name"
+                >
+                  Property 1
+                </div>
+                <div
+                  class="noicon"
+                />
               </div>
-              <div
-                class="noicon"
-              />
             </div>
-            <div
-              aria-label="Property 2"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
+            <div>
               <div
-                class="noicon"
-              />
-              <div
-                class="menu-name"
+                aria-label="Property 2"
+                class="MenuOption TextOption menu-option"
+                role="button"
               >
-                Property 2
+                <div
+                  class="noicon"
+                />
+                <div
+                  class="menu-name"
+                >
+                  Property 2
+                </div>
+                <div
+                  class="noicon"
+                />
               </div>
-              <div
-                class="noicon"
-              />
             </div>
-            <div
-              aria-label="Property 3"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
+            <div>
               <div
-                class="noicon"
-              />
-              <div
-                class="menu-name"
+                aria-label="Property 3"
+                class="MenuOption TextOption menu-option"
+                role="button"
               >
-                Property 3
+                <div
+                  class="noicon"
+                />
+                <div
+                  class="menu-name"
+                >
+                  Property 3
+                </div>
+                <div
+                  class="noicon"
+                />
               </div>
-              <div
-                class="noicon"
-              />
             </div>
           </div>
           <div

--- a/webapp/src/components/viewHeader/__snapshots__/filterValue.test.tsx.snap
+++ b/webapp/src/components/viewHeader/__snapshots__/filterValue.test.tsx.snap
@@ -24,23 +24,25 @@ exports[`components/viewHeader/filterValue return filterValue 1`] = `
         <div
           class="menu-options"
         >
-          <div
-            class="MenuOption SwitchOption menu-option"
-          >
+          <div>
             <div
-              class="noicon"
-            />
-            <div
-              class="menu-name"
-            >
-              Status
-            </div>
-            <div
-              class="Switch on"
+              class="MenuOption SwitchOption menu-option"
             >
               <div
-                class="octo-switch-inner"
+                class="noicon"
               />
+              <div
+                class="menu-name"
+              >
+                Status
+              </div>
+              <div
+                class="Switch on"
+              >
+                <div
+                  class="octo-switch-inner"
+                />
+              </div>
             </div>
           </div>
         </div>

--- a/webapp/src/components/viewHeader/__snapshots__/newCardButton.test.tsx.snap
+++ b/webapp/src/components/viewHeader/__snapshots__/newCardButton.test.tsx.snap
@@ -31,61 +31,65 @@ exports[`components/viewHeader/newCardButton return NewCardButton 1`] = `
           <div
             class="menu-options"
           >
-            <div
-              aria-label="Empty card"
-              class="MenuOption TextOption menu-option bold-menu-text"
-              role="button"
-            >
-              <svg
-                class="CardIcon Icon"
-                viewBox="0 0 100 100"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <rect
-                  height="40"
-                  rx="3"
-                  ry="3"
-                  width="60"
-                  x="20"
-                  y="30"
-                />
-              </svg>
+            <div>
               <div
-                class="menu-name"
-              >
-                Empty card
-              </div>
-              <div
-                aria-label="menuwrapper"
-                class="MenuWrapper"
+                aria-label="Empty card"
+                class="MenuOption TextOption menu-option bold-menu-text"
                 role="button"
               >
-                <button
-                  class="Button IconButton"
-                  type="button"
+                <svg
+                  class="CardIcon Icon"
+                  viewBox="0 0 100 100"
+                  xmlns="http://www.w3.org/2000/svg"
                 >
-                  <i
-                    class="CompassIcon icon-dots-horizontal OptionsIcon"
+                  <rect
+                    height="40"
+                    rx="3"
+                    ry="3"
+                    width="60"
+                    x="20"
+                    y="30"
                   />
-                </button>
+                </svg>
+                <div
+                  class="menu-name"
+                >
+                  Empty card
+                </div>
+                <div
+                  aria-label="menuwrapper"
+                  class="MenuWrapper"
+                  role="button"
+                >
+                  <button
+                    class="Button IconButton"
+                    role="button"
+                  >
+                    <i
+                      class="CompassIcon icon-dots-horizontal OptionsIcon"
+                    />
+                  </button>
+                </div>
               </div>
             </div>
-            <div
-              aria-label="New template"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
-              <i
-                class="CompassIcon icon-plus AddIcon"
-              />
+            <div>
               <div
-                class="menu-name"
+                aria-label="New template"
+                class="MenuOption TextOption menu-option"
+                role="button"
               >
-                New template
+                <i
+                  class="CompassIcon icon-plus AddIcon"
+                />
+                <div
+                  class="menu-name"
+                >
+                  New template
+                </div>
+                <div
+                  class="noicon"
+                />
               </div>
-              <div
-                class="noicon"
-              />
             </div>
           </div>
           <div
@@ -150,35 +154,13 @@ exports[`components/viewHeader/newCardButton return NewCardButton and addCard 1`
           <div
             class="menu-options"
           >
-            <div
-              aria-label="Empty card"
-              class="MenuOption TextOption menu-option bold-menu-text"
-              role="button"
-            >
-              <svg
-                class="CardIcon Icon"
-                viewBox="0 0 100 100"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <rect
-                  height="40"
-                  rx="3"
-                  ry="3"
-                  width="60"
-                  x="20"
-                  y="30"
-                />
-              </svg>
+            <div>
               <div
-                class="menu-name"
-              >
-                Empty card
-              </div>
-              <div
-                aria-label="menuwrapper"
-                class="MenuWrapper"
+                aria-label="Empty card"
+                class="MenuOption TextOption menu-option bold-menu-text"
                 role="button"
               >
+<<<<<<< HEAD
                 <button
                   class="Button IconButton"
                   type="button"
@@ -187,24 +169,61 @@ exports[`components/viewHeader/newCardButton return NewCardButton and addCard 1`
                     class="CompassIcon icon-dots-horizontal OptionsIcon"
                   />
                 </button>
+=======
+                <svg
+                  class="CardIcon Icon"
+                  viewBox="0 0 100 100"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <rect
+                    height="40"
+                    rx="3"
+                    ry="3"
+                    width="60"
+                    x="20"
+                    y="30"
+                  />
+                </svg>
+                <div
+                  class="menu-name"
+                >
+                  Empty card
+                </div>
+                <div
+                  aria-label="menuwrapper"
+                  class="MenuWrapper"
+                  role="button"
+                >
+                  <div
+                    class="Button IconButton"
+                    role="button"
+                  >
+                    <i
+                      class="CompassIcon icon-dots-horizontal OptionsIcon"
+                    />
+                  </div>
+                </div>
+>>>>>>> 4fa2517b (update snapshots)
               </div>
             </div>
-            <div
-              aria-label="New template"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
-              <i
-                class="CompassIcon icon-plus AddIcon"
-              />
+            <div>
               <div
-                class="menu-name"
+                aria-label="New template"
+                class="MenuOption TextOption menu-option"
+                role="button"
               >
-                New template
+                <i
+                  class="CompassIcon icon-plus AddIcon"
+                />
+                <div
+                  class="menu-name"
+                >
+                  New template
+                </div>
+                <div
+                  class="noicon"
+                />
               </div>
-              <div
-                class="noicon"
-              />
             </div>
           </div>
           <div
@@ -269,35 +288,13 @@ exports[`components/viewHeader/newCardButton return NewCardButton and addCardTem
           <div
             class="menu-options"
           >
-            <div
-              aria-label="Empty card"
-              class="MenuOption TextOption menu-option bold-menu-text"
-              role="button"
-            >
-              <svg
-                class="CardIcon Icon"
-                viewBox="0 0 100 100"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <rect
-                  height="40"
-                  rx="3"
-                  ry="3"
-                  width="60"
-                  x="20"
-                  y="30"
-                />
-              </svg>
+            <div>
               <div
-                class="menu-name"
-              >
-                Empty card
-              </div>
-              <div
-                aria-label="menuwrapper"
-                class="MenuWrapper"
+                aria-label="Empty card"
+                class="MenuOption TextOption menu-option bold-menu-text"
                 role="button"
               >
+<<<<<<< HEAD
                 <button
                   class="Button IconButton"
                   type="button"
@@ -306,24 +303,61 @@ exports[`components/viewHeader/newCardButton return NewCardButton and addCardTem
                     class="CompassIcon icon-dots-horizontal OptionsIcon"
                   />
                 </button>
+=======
+                <svg
+                  class="CardIcon Icon"
+                  viewBox="0 0 100 100"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <rect
+                    height="40"
+                    rx="3"
+                    ry="3"
+                    width="60"
+                    x="20"
+                    y="30"
+                  />
+                </svg>
+                <div
+                  class="menu-name"
+                >
+                  Empty card
+                </div>
+                <div
+                  aria-label="menuwrapper"
+                  class="MenuWrapper"
+                  role="button"
+                >
+                  <div
+                    class="Button IconButton"
+                    role="button"
+                  >
+                    <i
+                      class="CompassIcon icon-dots-horizontal OptionsIcon"
+                    />
+                  </div>
+                </div>
+>>>>>>> 4fa2517b (update snapshots)
               </div>
             </div>
-            <div
-              aria-label="New template"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
-              <i
-                class="CompassIcon icon-plus AddIcon"
-              />
+            <div>
               <div
-                class="menu-name"
+                aria-label="New template"
+                class="MenuOption TextOption menu-option"
+                role="button"
               >
-                New template
+                <i
+                  class="CompassIcon icon-plus AddIcon"
+                />
+                <div
+                  class="menu-name"
+                >
+                  New template
+                </div>
+                <div
+                  class="noicon"
+                />
               </div>
-              <div
-                class="noicon"
-              />
             </div>
           </div>
           <div

--- a/webapp/src/components/viewHeader/__snapshots__/newCardButton.test.tsx.snap
+++ b/webapp/src/components/viewHeader/__snapshots__/newCardButton.test.tsx.snap
@@ -63,7 +63,7 @@ exports[`components/viewHeader/newCardButton return NewCardButton 1`] = `
                 >
                   <button
                     class="Button IconButton"
-                    role="button"
+                    type="button"
                   >
                     <i
                       class="CompassIcon icon-dots-horizontal OptionsIcon"
@@ -160,16 +160,6 @@ exports[`components/viewHeader/newCardButton return NewCardButton and addCard 1`
                 class="MenuOption TextOption menu-option bold-menu-text"
                 role="button"
               >
-<<<<<<< HEAD
-                <button
-                  class="Button IconButton"
-                  type="button"
-                >
-                  <i
-                    class="CompassIcon icon-dots-horizontal OptionsIcon"
-                  />
-                </button>
-=======
                 <svg
                   class="CardIcon Icon"
                   viewBox="0 0 100 100"
@@ -194,16 +184,15 @@ exports[`components/viewHeader/newCardButton return NewCardButton and addCard 1`
                   class="MenuWrapper"
                   role="button"
                 >
-                  <div
+                  <button
                     class="Button IconButton"
-                    role="button"
+                    type="button"
                   >
                     <i
                       class="CompassIcon icon-dots-horizontal OptionsIcon"
                     />
-                  </div>
+                  </button>
                 </div>
->>>>>>> 4fa2517b (update snapshots)
               </div>
             </div>
             <div>
@@ -294,16 +283,6 @@ exports[`components/viewHeader/newCardButton return NewCardButton and addCardTem
                 class="MenuOption TextOption menu-option bold-menu-text"
                 role="button"
               >
-<<<<<<< HEAD
-                <button
-                  class="Button IconButton"
-                  type="button"
-                >
-                  <i
-                    class="CompassIcon icon-dots-horizontal OptionsIcon"
-                  />
-                </button>
-=======
                 <svg
                   class="CardIcon Icon"
                   viewBox="0 0 100 100"
@@ -328,16 +307,15 @@ exports[`components/viewHeader/newCardButton return NewCardButton and addCardTem
                   class="MenuWrapper"
                   role="button"
                 >
-                  <div
+                  <button
                     class="Button IconButton"
-                    role="button"
+                    type="button"
                   >
                     <i
                       class="CompassIcon icon-dots-horizontal OptionsIcon"
                     />
-                  </div>
+                  </button>
                 </div>
->>>>>>> 4fa2517b (update snapshots)
               </div>
             </div>
             <div>

--- a/webapp/src/components/viewHeader/__snapshots__/newCardButtonTemplateItem.test.tsx.snap
+++ b/webapp/src/components/viewHeader/__snapshots__/newCardButtonTemplateItem.test.tsx.snap
@@ -39,82 +39,88 @@ exports[`components/viewHeader/newCardButtonTemplateItem return NewCardButtonTem
           <div
             class="menu-options"
           >
-            <div
-              aria-label="Set as default"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
-              <svg
-                class="CheckIcon Icon"
-                viewBox="0 0 100 100"
-                xmlns="http://www.w3.org/2000/svg"
+            <div>
+              <div
+                aria-label="Set as default"
+                class="MenuOption TextOption menu-option"
+                role="button"
               >
-                <polyline
-                  points="20,60 40,80 80,40"
+                <svg
+                  class="CheckIcon Icon"
+                  viewBox="0 0 100 100"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <polyline
+                    points="20,60 40,80 80,40"
+                  />
+                </svg>
+                <div
+                  class="menu-name"
+                >
+                  Set as default
+                </div>
+                <div
+                  class="noicon"
                 />
-              </svg>
-              <div
-                class="menu-name"
-              >
-                Set as default
               </div>
-              <div
-                class="noicon"
-              />
             </div>
-            <div
-              aria-label="Edit"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
-              <svg
-                class="EditIcon Icon"
-                viewBox="0 0 100 100"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <g>
-                  <path
-                    d="M35.2,48.7l-2,14.1c-0.1,0.9,0.2,1.9,0.8,2.5c0.6,0.6,1.3,0.9,2.1,0.9c0.1,0,0.3,0,0.4,0l14.1-2c1.7-0.2,3.4-1.1,4.6-2.3   l28.2-28.2l4.6-4.5c1.8-1.8,2.7-4.1,2.7-6.6c0-2.5-1-4.9-2.7-6.6l-4.5-4.5c-3.7-3.7-9.6-3.7-13.3,0l-4.5,4.6L37.5,44.1   C36.2,45.3,35.4,47,35.2,48.7z M74.5,15.6c1.3-1.3,3.5-1.3,4.8,0l4.5,4.5c0.6,0.6,1,1.5,1,2.4c0,0.9-0.4,1.8-1,2.4c0,0,0,0,0,0   l-2.4,2.4L72.1,18L74.5,15.6z M41.1,49.5c0.1-0.4,0.3-0.9,0.6-1.2l26.1-26.1l4.7,4.7l4.7,4.7L51,57.7c-0.3,0.3-0.7,0.5-1.2,0.6   l-10.2,1.4L41.1,49.5z"
-                  />
-                  <path
-                    d="M88.3,35.8c-1.7,0-3,1.3-3,3v42.7c0,3.6-2.9,6.5-6.5,6.5H21.2c-3.6,0-6.5-2.9-6.5-6.5v-61c0-3.6,2.9-6.5,6.5-6.5h39.2   c1.7,0,3-1.3,3-3s-1.3-3-3-3H21.2C14.3,8,8.7,13.6,8.7,20.5v61c0,6.9,5.6,12.5,12.5,12.5h57.5c6.9,0,12.5-5.6,12.5-12.5V38.8   C91.3,37.2,89.9,35.8,88.3,35.8z"
-                  />
-                  <path
-                    d="M24.4,72c-1.7,0-3,1.3-3,3s1.3,3,3,3h28.8c1.7,0,3-1.3,3-3s-1.3-3-3-3H24.4z"
-                  />
-                </g>
-              </svg>
+            <div>
               <div
-                class="menu-name"
+                aria-label="Edit"
+                class="MenuOption TextOption menu-option"
+                role="button"
               >
-                Edit
-              </div>
-              <div
-                class="noicon"
-              />
-            </div>
-            <div
-              aria-label="Delete"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
-              <svg
-                class="DeleteIcon Icon"
-                viewBox="0 0 448 512"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M268 416h24a12 12 0 0 0 12-12V188a12 12 0 0 0-12-12h-24a12 12 0 0 0-12 12v216a12 12 0 0 0 12 12zM432 80h-82.41l-34-56.7A48 48 0 0 0 274.41 0H173.59a48 48 0 0 0-41.16 23.3L98.41 80H16A16 16 0 0 0 0 96v16a16 16 0 0 0 16 16h16v336a48 48 0 0 0 48 48h288a48 48 0 0 0 48-48V128h16a16 16 0 0 0 16-16V96a16 16 0 0 0-16-16zM171.84 50.91A6 6 0 0 1 177 48h94a6 6 0 0 1 5.15 2.91L293.61 80H154.39zM368 464H80V128h288zm-212-48h24a12 12 0 0 0 12-12V188a12 12 0 0 0-12-12h-24a12 12 0 0 0-12 12v216a12 12 0 0 0 12 12z"
+                <svg
+                  class="EditIcon Icon"
+                  viewBox="0 0 100 100"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <g>
+                    <path
+                      d="M35.2,48.7l-2,14.1c-0.1,0.9,0.2,1.9,0.8,2.5c0.6,0.6,1.3,0.9,2.1,0.9c0.1,0,0.3,0,0.4,0l14.1-2c1.7-0.2,3.4-1.1,4.6-2.3   l28.2-28.2l4.6-4.5c1.8-1.8,2.7-4.1,2.7-6.6c0-2.5-1-4.9-2.7-6.6l-4.5-4.5c-3.7-3.7-9.6-3.7-13.3,0l-4.5,4.6L37.5,44.1   C36.2,45.3,35.4,47,35.2,48.7z M74.5,15.6c1.3-1.3,3.5-1.3,4.8,0l4.5,4.5c0.6,0.6,1,1.5,1,2.4c0,0.9-0.4,1.8-1,2.4c0,0,0,0,0,0   l-2.4,2.4L72.1,18L74.5,15.6z M41.1,49.5c0.1-0.4,0.3-0.9,0.6-1.2l26.1-26.1l4.7,4.7l4.7,4.7L51,57.7c-0.3,0.3-0.7,0.5-1.2,0.6   l-10.2,1.4L41.1,49.5z"
+                    />
+                    <path
+                      d="M88.3,35.8c-1.7,0-3,1.3-3,3v42.7c0,3.6-2.9,6.5-6.5,6.5H21.2c-3.6,0-6.5-2.9-6.5-6.5v-61c0-3.6,2.9-6.5,6.5-6.5h39.2   c1.7,0,3-1.3,3-3s-1.3-3-3-3H21.2C14.3,8,8.7,13.6,8.7,20.5v61c0,6.9,5.6,12.5,12.5,12.5h57.5c6.9,0,12.5-5.6,12.5-12.5V38.8   C91.3,37.2,89.9,35.8,88.3,35.8z"
+                    />
+                    <path
+                      d="M24.4,72c-1.7,0-3,1.3-3,3s1.3,3,3,3h28.8c1.7,0,3-1.3,3-3s-1.3-3-3-3H24.4z"
+                    />
+                  </g>
+                </svg>
+                <div
+                  class="menu-name"
+                >
+                  Edit
+                </div>
+                <div
+                  class="noicon"
                 />
-              </svg>
-              <div
-                class="menu-name"
-              >
-                Delete
               </div>
+            </div>
+            <div>
               <div
-                class="noicon"
-              />
+                aria-label="Delete"
+                class="MenuOption TextOption menu-option"
+                role="button"
+              >
+                <svg
+                  class="DeleteIcon Icon"
+                  viewBox="0 0 448 512"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M268 416h24a12 12 0 0 0 12-12V188a12 12 0 0 0-12-12h-24a12 12 0 0 0-12 12v216a12 12 0 0 0 12 12zM432 80h-82.41l-34-56.7A48 48 0 0 0 274.41 0H173.59a48 48 0 0 0-41.16 23.3L98.41 80H16A16 16 0 0 0 0 96v16a16 16 0 0 0 16 16h16v336a48 48 0 0 0 48 48h288a48 48 0 0 0 48-48V128h16a16 16 0 0 0 16-16V96a16 16 0 0 0-16-16zM171.84 50.91A6 6 0 0 1 177 48h94a6 6 0 0 1 5.15 2.91L293.61 80H154.39zM368 464H80V128h288zm-212-48h24a12 12 0 0 0 12-12V188a12 12 0 0 0-12-12h-24a12 12 0 0 0-12 12v216a12 12 0 0 0 12 12z"
+                  />
+                </svg>
+                <div
+                  class="menu-name"
+                >
+                  Delete
+                </div>
+                <div
+                  class="noicon"
+                />
+              </div>
             </div>
           </div>
           <div
@@ -187,82 +193,88 @@ exports[`components/viewHeader/newCardButtonTemplateItem return NewCardButtonTem
           <div
             class="menu-options"
           >
-            <div
-              aria-label="Set as default"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
-              <svg
-                class="CheckIcon Icon"
-                viewBox="0 0 100 100"
-                xmlns="http://www.w3.org/2000/svg"
+            <div>
+              <div
+                aria-label="Set as default"
+                class="MenuOption TextOption menu-option"
+                role="button"
               >
-                <polyline
-                  points="20,60 40,80 80,40"
+                <svg
+                  class="CheckIcon Icon"
+                  viewBox="0 0 100 100"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <polyline
+                    points="20,60 40,80 80,40"
+                  />
+                </svg>
+                <div
+                  class="menu-name"
+                >
+                  Set as default
+                </div>
+                <div
+                  class="noicon"
                 />
-              </svg>
-              <div
-                class="menu-name"
-              >
-                Set as default
               </div>
-              <div
-                class="noicon"
-              />
             </div>
-            <div
-              aria-label="Edit"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
-              <svg
-                class="EditIcon Icon"
-                viewBox="0 0 100 100"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <g>
-                  <path
-                    d="M35.2,48.7l-2,14.1c-0.1,0.9,0.2,1.9,0.8,2.5c0.6,0.6,1.3,0.9,2.1,0.9c0.1,0,0.3,0,0.4,0l14.1-2c1.7-0.2,3.4-1.1,4.6-2.3   l28.2-28.2l4.6-4.5c1.8-1.8,2.7-4.1,2.7-6.6c0-2.5-1-4.9-2.7-6.6l-4.5-4.5c-3.7-3.7-9.6-3.7-13.3,0l-4.5,4.6L37.5,44.1   C36.2,45.3,35.4,47,35.2,48.7z M74.5,15.6c1.3-1.3,3.5-1.3,4.8,0l4.5,4.5c0.6,0.6,1,1.5,1,2.4c0,0.9-0.4,1.8-1,2.4c0,0,0,0,0,0   l-2.4,2.4L72.1,18L74.5,15.6z M41.1,49.5c0.1-0.4,0.3-0.9,0.6-1.2l26.1-26.1l4.7,4.7l4.7,4.7L51,57.7c-0.3,0.3-0.7,0.5-1.2,0.6   l-10.2,1.4L41.1,49.5z"
-                  />
-                  <path
-                    d="M88.3,35.8c-1.7,0-3,1.3-3,3v42.7c0,3.6-2.9,6.5-6.5,6.5H21.2c-3.6,0-6.5-2.9-6.5-6.5v-61c0-3.6,2.9-6.5,6.5-6.5h39.2   c1.7,0,3-1.3,3-3s-1.3-3-3-3H21.2C14.3,8,8.7,13.6,8.7,20.5v61c0,6.9,5.6,12.5,12.5,12.5h57.5c6.9,0,12.5-5.6,12.5-12.5V38.8   C91.3,37.2,89.9,35.8,88.3,35.8z"
-                  />
-                  <path
-                    d="M24.4,72c-1.7,0-3,1.3-3,3s1.3,3,3,3h28.8c1.7,0,3-1.3,3-3s-1.3-3-3-3H24.4z"
-                  />
-                </g>
-              </svg>
+            <div>
               <div
-                class="menu-name"
+                aria-label="Edit"
+                class="MenuOption TextOption menu-option"
+                role="button"
               >
-                Edit
-              </div>
-              <div
-                class="noicon"
-              />
-            </div>
-            <div
-              aria-label="Delete"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
-              <svg
-                class="DeleteIcon Icon"
-                viewBox="0 0 448 512"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M268 416h24a12 12 0 0 0 12-12V188a12 12 0 0 0-12-12h-24a12 12 0 0 0-12 12v216a12 12 0 0 0 12 12zM432 80h-82.41l-34-56.7A48 48 0 0 0 274.41 0H173.59a48 48 0 0 0-41.16 23.3L98.41 80H16A16 16 0 0 0 0 96v16a16 16 0 0 0 16 16h16v336a48 48 0 0 0 48 48h288a48 48 0 0 0 48-48V128h16a16 16 0 0 0 16-16V96a16 16 0 0 0-16-16zM171.84 50.91A6 6 0 0 1 177 48h94a6 6 0 0 1 5.15 2.91L293.61 80H154.39zM368 464H80V128h288zm-212-48h24a12 12 0 0 0 12-12V188a12 12 0 0 0-12-12h-24a12 12 0 0 0-12 12v216a12 12 0 0 0 12 12z"
+                <svg
+                  class="EditIcon Icon"
+                  viewBox="0 0 100 100"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <g>
+                    <path
+                      d="M35.2,48.7l-2,14.1c-0.1,0.9,0.2,1.9,0.8,2.5c0.6,0.6,1.3,0.9,2.1,0.9c0.1,0,0.3,0,0.4,0l14.1-2c1.7-0.2,3.4-1.1,4.6-2.3   l28.2-28.2l4.6-4.5c1.8-1.8,2.7-4.1,2.7-6.6c0-2.5-1-4.9-2.7-6.6l-4.5-4.5c-3.7-3.7-9.6-3.7-13.3,0l-4.5,4.6L37.5,44.1   C36.2,45.3,35.4,47,35.2,48.7z M74.5,15.6c1.3-1.3,3.5-1.3,4.8,0l4.5,4.5c0.6,0.6,1,1.5,1,2.4c0,0.9-0.4,1.8-1,2.4c0,0,0,0,0,0   l-2.4,2.4L72.1,18L74.5,15.6z M41.1,49.5c0.1-0.4,0.3-0.9,0.6-1.2l26.1-26.1l4.7,4.7l4.7,4.7L51,57.7c-0.3,0.3-0.7,0.5-1.2,0.6   l-10.2,1.4L41.1,49.5z"
+                    />
+                    <path
+                      d="M88.3,35.8c-1.7,0-3,1.3-3,3v42.7c0,3.6-2.9,6.5-6.5,6.5H21.2c-3.6,0-6.5-2.9-6.5-6.5v-61c0-3.6,2.9-6.5,6.5-6.5h39.2   c1.7,0,3-1.3,3-3s-1.3-3-3-3H21.2C14.3,8,8.7,13.6,8.7,20.5v61c0,6.9,5.6,12.5,12.5,12.5h57.5c6.9,0,12.5-5.6,12.5-12.5V38.8   C91.3,37.2,89.9,35.8,88.3,35.8z"
+                    />
+                    <path
+                      d="M24.4,72c-1.7,0-3,1.3-3,3s1.3,3,3,3h28.8c1.7,0,3-1.3,3-3s-1.3-3-3-3H24.4z"
+                    />
+                  </g>
+                </svg>
+                <div
+                  class="menu-name"
+                >
+                  Edit
+                </div>
+                <div
+                  class="noicon"
                 />
-              </svg>
-              <div
-                class="menu-name"
-              >
-                Delete
               </div>
+            </div>
+            <div>
               <div
-                class="noicon"
-              />
+                aria-label="Delete"
+                class="MenuOption TextOption menu-option"
+                role="button"
+              >
+                <svg
+                  class="DeleteIcon Icon"
+                  viewBox="0 0 448 512"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M268 416h24a12 12 0 0 0 12-12V188a12 12 0 0 0-12-12h-24a12 12 0 0 0-12 12v216a12 12 0 0 0 12 12zM432 80h-82.41l-34-56.7A48 48 0 0 0 274.41 0H173.59a48 48 0 0 0-41.16 23.3L98.41 80H16A16 16 0 0 0 0 96v16a16 16 0 0 0 16 16h16v336a48 48 0 0 0 48 48h288a48 48 0 0 0 48-48V128h16a16 16 0 0 0 16-16V96a16 16 0 0 0-16-16zM171.84 50.91A6 6 0 0 1 177 48h94a6 6 0 0 1 5.15 2.91L293.61 80H154.39zM368 464H80V128h288zm-212-48h24a12 12 0 0 0 12-12V188a12 12 0 0 0-12-12h-24a12 12 0 0 0-12 12v216a12 12 0 0 0 12 12z"
+                  />
+                </svg>
+                <div
+                  class="menu-name"
+                >
+                  Delete
+                </div>
+                <div
+                  class="noicon"
+                />
+              </div>
             </div>
           </div>
           <div
@@ -370,82 +382,88 @@ exports[`components/viewHeader/newCardButtonTemplateItem return NewCardButtonTem
           <div
             class="menu-options"
           >
-            <div
-              aria-label="Set as default"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
-              <svg
-                class="CheckIcon Icon"
-                viewBox="0 0 100 100"
-                xmlns="http://www.w3.org/2000/svg"
+            <div>
+              <div
+                aria-label="Set as default"
+                class="MenuOption TextOption menu-option"
+                role="button"
               >
-                <polyline
-                  points="20,60 40,80 80,40"
+                <svg
+                  class="CheckIcon Icon"
+                  viewBox="0 0 100 100"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <polyline
+                    points="20,60 40,80 80,40"
+                  />
+                </svg>
+                <div
+                  class="menu-name"
+                >
+                  Set as default
+                </div>
+                <div
+                  class="noicon"
                 />
-              </svg>
-              <div
-                class="menu-name"
-              >
-                Set as default
               </div>
-              <div
-                class="noicon"
-              />
             </div>
-            <div
-              aria-label="Edit"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
-              <svg
-                class="EditIcon Icon"
-                viewBox="0 0 100 100"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <g>
-                  <path
-                    d="M35.2,48.7l-2,14.1c-0.1,0.9,0.2,1.9,0.8,2.5c0.6,0.6,1.3,0.9,2.1,0.9c0.1,0,0.3,0,0.4,0l14.1-2c1.7-0.2,3.4-1.1,4.6-2.3   l28.2-28.2l4.6-4.5c1.8-1.8,2.7-4.1,2.7-6.6c0-2.5-1-4.9-2.7-6.6l-4.5-4.5c-3.7-3.7-9.6-3.7-13.3,0l-4.5,4.6L37.5,44.1   C36.2,45.3,35.4,47,35.2,48.7z M74.5,15.6c1.3-1.3,3.5-1.3,4.8,0l4.5,4.5c0.6,0.6,1,1.5,1,2.4c0,0.9-0.4,1.8-1,2.4c0,0,0,0,0,0   l-2.4,2.4L72.1,18L74.5,15.6z M41.1,49.5c0.1-0.4,0.3-0.9,0.6-1.2l26.1-26.1l4.7,4.7l4.7,4.7L51,57.7c-0.3,0.3-0.7,0.5-1.2,0.6   l-10.2,1.4L41.1,49.5z"
-                  />
-                  <path
-                    d="M88.3,35.8c-1.7,0-3,1.3-3,3v42.7c0,3.6-2.9,6.5-6.5,6.5H21.2c-3.6,0-6.5-2.9-6.5-6.5v-61c0-3.6,2.9-6.5,6.5-6.5h39.2   c1.7,0,3-1.3,3-3s-1.3-3-3-3H21.2C14.3,8,8.7,13.6,8.7,20.5v61c0,6.9,5.6,12.5,12.5,12.5h57.5c6.9,0,12.5-5.6,12.5-12.5V38.8   C91.3,37.2,89.9,35.8,88.3,35.8z"
-                  />
-                  <path
-                    d="M24.4,72c-1.7,0-3,1.3-3,3s1.3,3,3,3h28.8c1.7,0,3-1.3,3-3s-1.3-3-3-3H24.4z"
-                  />
-                </g>
-              </svg>
+            <div>
               <div
-                class="menu-name"
+                aria-label="Edit"
+                class="MenuOption TextOption menu-option"
+                role="button"
               >
-                Edit
-              </div>
-              <div
-                class="noicon"
-              />
-            </div>
-            <div
-              aria-label="Delete"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
-              <svg
-                class="DeleteIcon Icon"
-                viewBox="0 0 448 512"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M268 416h24a12 12 0 0 0 12-12V188a12 12 0 0 0-12-12h-24a12 12 0 0 0-12 12v216a12 12 0 0 0 12 12zM432 80h-82.41l-34-56.7A48 48 0 0 0 274.41 0H173.59a48 48 0 0 0-41.16 23.3L98.41 80H16A16 16 0 0 0 0 96v16a16 16 0 0 0 16 16h16v336a48 48 0 0 0 48 48h288a48 48 0 0 0 48-48V128h16a16 16 0 0 0 16-16V96a16 16 0 0 0-16-16zM171.84 50.91A6 6 0 0 1 177 48h94a6 6 0 0 1 5.15 2.91L293.61 80H154.39zM368 464H80V128h288zm-212-48h24a12 12 0 0 0 12-12V188a12 12 0 0 0-12-12h-24a12 12 0 0 0-12 12v216a12 12 0 0 0 12 12z"
+                <svg
+                  class="EditIcon Icon"
+                  viewBox="0 0 100 100"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <g>
+                    <path
+                      d="M35.2,48.7l-2,14.1c-0.1,0.9,0.2,1.9,0.8,2.5c0.6,0.6,1.3,0.9,2.1,0.9c0.1,0,0.3,0,0.4,0l14.1-2c1.7-0.2,3.4-1.1,4.6-2.3   l28.2-28.2l4.6-4.5c1.8-1.8,2.7-4.1,2.7-6.6c0-2.5-1-4.9-2.7-6.6l-4.5-4.5c-3.7-3.7-9.6-3.7-13.3,0l-4.5,4.6L37.5,44.1   C36.2,45.3,35.4,47,35.2,48.7z M74.5,15.6c1.3-1.3,3.5-1.3,4.8,0l4.5,4.5c0.6,0.6,1,1.5,1,2.4c0,0.9-0.4,1.8-1,2.4c0,0,0,0,0,0   l-2.4,2.4L72.1,18L74.5,15.6z M41.1,49.5c0.1-0.4,0.3-0.9,0.6-1.2l26.1-26.1l4.7,4.7l4.7,4.7L51,57.7c-0.3,0.3-0.7,0.5-1.2,0.6   l-10.2,1.4L41.1,49.5z"
+                    />
+                    <path
+                      d="M88.3,35.8c-1.7,0-3,1.3-3,3v42.7c0,3.6-2.9,6.5-6.5,6.5H21.2c-3.6,0-6.5-2.9-6.5-6.5v-61c0-3.6,2.9-6.5,6.5-6.5h39.2   c1.7,0,3-1.3,3-3s-1.3-3-3-3H21.2C14.3,8,8.7,13.6,8.7,20.5v61c0,6.9,5.6,12.5,12.5,12.5h57.5c6.9,0,12.5-5.6,12.5-12.5V38.8   C91.3,37.2,89.9,35.8,88.3,35.8z"
+                    />
+                    <path
+                      d="M24.4,72c-1.7,0-3,1.3-3,3s1.3,3,3,3h28.8c1.7,0,3-1.3,3-3s-1.3-3-3-3H24.4z"
+                    />
+                  </g>
+                </svg>
+                <div
+                  class="menu-name"
+                >
+                  Edit
+                </div>
+                <div
+                  class="noicon"
                 />
-              </svg>
-              <div
-                class="menu-name"
-              >
-                Delete
               </div>
+            </div>
+            <div>
               <div
-                class="noicon"
-              />
+                aria-label="Delete"
+                class="MenuOption TextOption menu-option"
+                role="button"
+              >
+                <svg
+                  class="DeleteIcon Icon"
+                  viewBox="0 0 448 512"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M268 416h24a12 12 0 0 0 12-12V188a12 12 0 0 0-12-12h-24a12 12 0 0 0-12 12v216a12 12 0 0 0 12 12zM432 80h-82.41l-34-56.7A48 48 0 0 0 274.41 0H173.59a48 48 0 0 0-41.16 23.3L98.41 80H16A16 16 0 0 0 0 96v16a16 16 0 0 0 16 16h16v336a48 48 0 0 0 48 48h288a48 48 0 0 0 48-48V128h16a16 16 0 0 0 16-16V96a16 16 0 0 0-16-16zM171.84 50.91A6 6 0 0 1 177 48h94a6 6 0 0 1 5.15 2.91L293.61 80H154.39zM368 464H80V128h288zm-212-48h24a12 12 0 0 0 12-12V188a12 12 0 0 0-12-12h-24a12 12 0 0 0-12 12v216a12 12 0 0 0 12 12z"
+                  />
+                </svg>
+                <div
+                  class="menu-name"
+                >
+                  Delete
+                </div>
+                <div
+                  class="noicon"
+                />
+              </div>
             </div>
           </div>
           <div
@@ -518,82 +536,88 @@ exports[`components/viewHeader/newCardButtonTemplateItem return NewCardButtonTem
           <div
             class="menu-options"
           >
-            <div
-              aria-label="Set as default"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
-              <svg
-                class="CheckIcon Icon"
-                viewBox="0 0 100 100"
-                xmlns="http://www.w3.org/2000/svg"
+            <div>
+              <div
+                aria-label="Set as default"
+                class="MenuOption TextOption menu-option"
+                role="button"
               >
-                <polyline
-                  points="20,60 40,80 80,40"
+                <svg
+                  class="CheckIcon Icon"
+                  viewBox="0 0 100 100"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <polyline
+                    points="20,60 40,80 80,40"
+                  />
+                </svg>
+                <div
+                  class="menu-name"
+                >
+                  Set as default
+                </div>
+                <div
+                  class="noicon"
                 />
-              </svg>
-              <div
-                class="menu-name"
-              >
-                Set as default
               </div>
-              <div
-                class="noicon"
-              />
             </div>
-            <div
-              aria-label="Edit"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
-              <svg
-                class="EditIcon Icon"
-                viewBox="0 0 100 100"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <g>
-                  <path
-                    d="M35.2,48.7l-2,14.1c-0.1,0.9,0.2,1.9,0.8,2.5c0.6,0.6,1.3,0.9,2.1,0.9c0.1,0,0.3,0,0.4,0l14.1-2c1.7-0.2,3.4-1.1,4.6-2.3   l28.2-28.2l4.6-4.5c1.8-1.8,2.7-4.1,2.7-6.6c0-2.5-1-4.9-2.7-6.6l-4.5-4.5c-3.7-3.7-9.6-3.7-13.3,0l-4.5,4.6L37.5,44.1   C36.2,45.3,35.4,47,35.2,48.7z M74.5,15.6c1.3-1.3,3.5-1.3,4.8,0l4.5,4.5c0.6,0.6,1,1.5,1,2.4c0,0.9-0.4,1.8-1,2.4c0,0,0,0,0,0   l-2.4,2.4L72.1,18L74.5,15.6z M41.1,49.5c0.1-0.4,0.3-0.9,0.6-1.2l26.1-26.1l4.7,4.7l4.7,4.7L51,57.7c-0.3,0.3-0.7,0.5-1.2,0.6   l-10.2,1.4L41.1,49.5z"
-                  />
-                  <path
-                    d="M88.3,35.8c-1.7,0-3,1.3-3,3v42.7c0,3.6-2.9,6.5-6.5,6.5H21.2c-3.6,0-6.5-2.9-6.5-6.5v-61c0-3.6,2.9-6.5,6.5-6.5h39.2   c1.7,0,3-1.3,3-3s-1.3-3-3-3H21.2C14.3,8,8.7,13.6,8.7,20.5v61c0,6.9,5.6,12.5,12.5,12.5h57.5c6.9,0,12.5-5.6,12.5-12.5V38.8   C91.3,37.2,89.9,35.8,88.3,35.8z"
-                  />
-                  <path
-                    d="M24.4,72c-1.7,0-3,1.3-3,3s1.3,3,3,3h28.8c1.7,0,3-1.3,3-3s-1.3-3-3-3H24.4z"
-                  />
-                </g>
-              </svg>
+            <div>
               <div
-                class="menu-name"
+                aria-label="Edit"
+                class="MenuOption TextOption menu-option"
+                role="button"
               >
-                Edit
-              </div>
-              <div
-                class="noicon"
-              />
-            </div>
-            <div
-              aria-label="Delete"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
-              <svg
-                class="DeleteIcon Icon"
-                viewBox="0 0 448 512"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M268 416h24a12 12 0 0 0 12-12V188a12 12 0 0 0-12-12h-24a12 12 0 0 0-12 12v216a12 12 0 0 0 12 12zM432 80h-82.41l-34-56.7A48 48 0 0 0 274.41 0H173.59a48 48 0 0 0-41.16 23.3L98.41 80H16A16 16 0 0 0 0 96v16a16 16 0 0 0 16 16h16v336a48 48 0 0 0 48 48h288a48 48 0 0 0 48-48V128h16a16 16 0 0 0 16-16V96a16 16 0 0 0-16-16zM171.84 50.91A6 6 0 0 1 177 48h94a6 6 0 0 1 5.15 2.91L293.61 80H154.39zM368 464H80V128h288zm-212-48h24a12 12 0 0 0 12-12V188a12 12 0 0 0-12-12h-24a12 12 0 0 0-12 12v216a12 12 0 0 0 12 12z"
+                <svg
+                  class="EditIcon Icon"
+                  viewBox="0 0 100 100"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <g>
+                    <path
+                      d="M35.2,48.7l-2,14.1c-0.1,0.9,0.2,1.9,0.8,2.5c0.6,0.6,1.3,0.9,2.1,0.9c0.1,0,0.3,0,0.4,0l14.1-2c1.7-0.2,3.4-1.1,4.6-2.3   l28.2-28.2l4.6-4.5c1.8-1.8,2.7-4.1,2.7-6.6c0-2.5-1-4.9-2.7-6.6l-4.5-4.5c-3.7-3.7-9.6-3.7-13.3,0l-4.5,4.6L37.5,44.1   C36.2,45.3,35.4,47,35.2,48.7z M74.5,15.6c1.3-1.3,3.5-1.3,4.8,0l4.5,4.5c0.6,0.6,1,1.5,1,2.4c0,0.9-0.4,1.8-1,2.4c0,0,0,0,0,0   l-2.4,2.4L72.1,18L74.5,15.6z M41.1,49.5c0.1-0.4,0.3-0.9,0.6-1.2l26.1-26.1l4.7,4.7l4.7,4.7L51,57.7c-0.3,0.3-0.7,0.5-1.2,0.6   l-10.2,1.4L41.1,49.5z"
+                    />
+                    <path
+                      d="M88.3,35.8c-1.7,0-3,1.3-3,3v42.7c0,3.6-2.9,6.5-6.5,6.5H21.2c-3.6,0-6.5-2.9-6.5-6.5v-61c0-3.6,2.9-6.5,6.5-6.5h39.2   c1.7,0,3-1.3,3-3s-1.3-3-3-3H21.2C14.3,8,8.7,13.6,8.7,20.5v61c0,6.9,5.6,12.5,12.5,12.5h57.5c6.9,0,12.5-5.6,12.5-12.5V38.8   C91.3,37.2,89.9,35.8,88.3,35.8z"
+                    />
+                    <path
+                      d="M24.4,72c-1.7,0-3,1.3-3,3s1.3,3,3,3h28.8c1.7,0,3-1.3,3-3s-1.3-3-3-3H24.4z"
+                    />
+                  </g>
+                </svg>
+                <div
+                  class="menu-name"
+                >
+                  Edit
+                </div>
+                <div
+                  class="noicon"
                 />
-              </svg>
-              <div
-                class="menu-name"
-              >
-                Delete
               </div>
+            </div>
+            <div>
               <div
-                class="noicon"
-              />
+                aria-label="Delete"
+                class="MenuOption TextOption menu-option"
+                role="button"
+              >
+                <svg
+                  class="DeleteIcon Icon"
+                  viewBox="0 0 448 512"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M268 416h24a12 12 0 0 0 12-12V188a12 12 0 0 0-12-12h-24a12 12 0 0 0-12 12v216a12 12 0 0 0 12 12zM432 80h-82.41l-34-56.7A48 48 0 0 0 274.41 0H173.59a48 48 0 0 0-41.16 23.3L98.41 80H16A16 16 0 0 0 0 96v16a16 16 0 0 0 16 16h16v336a48 48 0 0 0 48 48h288a48 48 0 0 0 48-48V128h16a16 16 0 0 0 16-16V96a16 16 0 0 0-16-16zM171.84 50.91A6 6 0 0 1 177 48h94a6 6 0 0 1 5.15 2.91L293.61 80H154.39zM368 464H80V128h288zm-212-48h24a12 12 0 0 0 12-12V188a12 12 0 0 0-12-12h-24a12 12 0 0 0-12 12v216a12 12 0 0 0 12 12z"
+                  />
+                </svg>
+                <div
+                  class="menu-name"
+                >
+                  Delete
+                </div>
+                <div
+                  class="noicon"
+                />
+              </div>
             </div>
           </div>
           <div

--- a/webapp/src/components/viewHeader/__snapshots__/viewHeaderActionsMenu.test.tsx.snap
+++ b/webapp/src/components/viewHeader/__snapshots__/viewHeaderActionsMenu.test.tsx.snap
@@ -27,56 +27,62 @@ exports[`components/viewHeader/viewHeaderActionsMenu return menu and verify call
           <div
             class="menu-options"
           >
-            <div
-              aria-label="Export to CSV"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
+            <div>
               <div
-                class="noicon"
-              />
-              <div
-                class="menu-name"
+                aria-label="Export to CSV"
+                class="MenuOption TextOption menu-option"
+                role="button"
               >
-                Export to CSV
+                <div
+                  class="noicon"
+                />
+                <div
+                  class="menu-name"
+                >
+                  Export to CSV
+                </div>
+                <div
+                  class="noicon"
+                />
               </div>
-              <div
-                class="noicon"
-              />
             </div>
-            <div
-              aria-label="Export board archive"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
+            <div>
               <div
-                class="noicon"
-              />
-              <div
-                class="menu-name"
+                aria-label="Export board archive"
+                class="MenuOption TextOption menu-option"
+                role="button"
               >
-                Export board archive
+                <div
+                  class="noicon"
+                />
+                <div
+                  class="menu-name"
+                >
+                  Export board archive
+                </div>
+                <div
+                  class="noicon"
+                />
               </div>
-              <div
-                class="noicon"
-              />
             </div>
-            <div
-              aria-label="Share board"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
+            <div>
               <div
-                class="noicon"
-              />
-              <div
-                class="menu-name"
+                aria-label="Share board"
+                class="MenuOption TextOption menu-option"
+                role="button"
               >
-                Share board
+                <div
+                  class="noicon"
+                />
+                <div
+                  class="menu-name"
+                >
+                  Share board
+                </div>
+                <div
+                  class="noicon"
+                />
               </div>
-              <div
-                class="noicon"
-              />
             </div>
           </div>
           <div
@@ -137,56 +143,62 @@ exports[`components/viewHeader/viewHeaderActionsMenu return menu and verify call
           <div
             class="menu-options"
           >
-            <div
-              aria-label="Export to CSV"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
+            <div>
               <div
-                class="noicon"
-              />
-              <div
-                class="menu-name"
+                aria-label="Export to CSV"
+                class="MenuOption TextOption menu-option"
+                role="button"
               >
-                Export to CSV
+                <div
+                  class="noicon"
+                />
+                <div
+                  class="menu-name"
+                >
+                  Export to CSV
+                </div>
+                <div
+                  class="noicon"
+                />
               </div>
-              <div
-                class="noicon"
-              />
             </div>
-            <div
-              aria-label="Export board archive"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
+            <div>
               <div
-                class="noicon"
-              />
-              <div
-                class="menu-name"
+                aria-label="Export board archive"
+                class="MenuOption TextOption menu-option"
+                role="button"
               >
-                Export board archive
+                <div
+                  class="noicon"
+                />
+                <div
+                  class="menu-name"
+                >
+                  Export board archive
+                </div>
+                <div
+                  class="noicon"
+                />
               </div>
-              <div
-                class="noicon"
-              />
             </div>
-            <div
-              aria-label="Share board"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
+            <div>
               <div
-                class="noicon"
-              />
-              <div
-                class="menu-name"
+                aria-label="Share board"
+                class="MenuOption TextOption menu-option"
+                role="button"
               >
-                Share board
+                <div
+                  class="noicon"
+                />
+                <div
+                  class="menu-name"
+                >
+                  Share board
+                </div>
+                <div
+                  class="noicon"
+                />
               </div>
-              <div
-                class="noicon"
-              />
             </div>
           </div>
           <div
@@ -247,56 +259,62 @@ exports[`components/viewHeader/viewHeaderActionsMenu return menu with Share Boar
           <div
             class="menu-options"
           >
-            <div
-              aria-label="Export to CSV"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
+            <div>
               <div
-                class="noicon"
-              />
-              <div
-                class="menu-name"
+                aria-label="Export to CSV"
+                class="MenuOption TextOption menu-option"
+                role="button"
               >
-                Export to CSV
+                <div
+                  class="noicon"
+                />
+                <div
+                  class="menu-name"
+                >
+                  Export to CSV
+                </div>
+                <div
+                  class="noicon"
+                />
               </div>
-              <div
-                class="noicon"
-              />
             </div>
-            <div
-              aria-label="Export board archive"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
+            <div>
               <div
-                class="noicon"
-              />
-              <div
-                class="menu-name"
+                aria-label="Export board archive"
+                class="MenuOption TextOption menu-option"
+                role="button"
               >
-                Export board archive
+                <div
+                  class="noicon"
+                />
+                <div
+                  class="menu-name"
+                >
+                  Export board archive
+                </div>
+                <div
+                  class="noicon"
+                />
               </div>
-              <div
-                class="noicon"
-              />
             </div>
-            <div
-              aria-label="Share board"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
+            <div>
               <div
-                class="noicon"
-              />
-              <div
-                class="menu-name"
+                aria-label="Share board"
+                class="MenuOption TextOption menu-option"
+                role="button"
               >
-                Share board
+                <div
+                  class="noicon"
+                />
+                <div
+                  class="menu-name"
+                >
+                  Share board
+                </div>
+                <div
+                  class="noicon"
+                />
               </div>
-              <div
-                class="noicon"
-              />
             </div>
           </div>
           <div
@@ -357,39 +375,43 @@ exports[`components/viewHeader/viewHeaderActionsMenu return menu without Share B
           <div
             class="menu-options"
           >
-            <div
-              aria-label="Export to CSV"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
+            <div>
               <div
-                class="noicon"
-              />
-              <div
-                class="menu-name"
+                aria-label="Export to CSV"
+                class="MenuOption TextOption menu-option"
+                role="button"
               >
-                Export to CSV
+                <div
+                  class="noicon"
+                />
+                <div
+                  class="menu-name"
+                >
+                  Export to CSV
+                </div>
+                <div
+                  class="noicon"
+                />
               </div>
-              <div
-                class="noicon"
-              />
             </div>
-            <div
-              aria-label="Export board archive"
-              class="MenuOption TextOption menu-option"
-              role="button"
-            >
+            <div>
               <div
-                class="noicon"
-              />
-              <div
-                class="menu-name"
+                aria-label="Export board archive"
+                class="MenuOption TextOption menu-option"
+                role="button"
               >
-                Export board archive
+                <div
+                  class="noicon"
+                />
+                <div
+                  class="menu-name"
+                >
+                  Export board archive
+                </div>
+                <div
+                  class="noicon"
+                />
               </div>
-              <div
-                class="noicon"
-              />
             </div>
           </div>
           <div

--- a/webapp/src/components/viewHeader/__snapshots__/viewHeaderGroupByMenu.test.tsx.snap
+++ b/webapp/src/components/viewHeader/__snapshots__/viewHeaderGroupByMenu.test.tsx.snap
@@ -29,79 +29,87 @@ exports[`components/viewHeader/viewHeaderGroupByMenu return groupBy menu 1`] = `
         <div
           class="menu-options"
         >
-          <div
-            aria-label="Status"
-            class="MenuOption TextOption menu-option"
-            role="button"
-          >
+          <div>
             <div
-              class="noicon"
-            />
-            <div
-              class="menu-name"
+              aria-label="Status"
+              class="MenuOption TextOption menu-option"
+              role="button"
             >
-              Status
-            </div>
-            <div
-              class="noicon"
-            />
-          </div>
-          <div
-            aria-label="Property 1"
-            class="MenuOption TextOption menu-option"
-            role="button"
-          >
-            <div
-              class="noicon"
-            />
-            <div
-              class="menu-name"
-            >
-              Property 1
-            </div>
-            <svg
-              class="CheckIcon Icon"
-              viewBox="0 0 100 100"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <polyline
-                points="20,60 40,80 80,40"
+              <div
+                class="noicon"
               />
-            </svg>
-          </div>
-          <div
-            aria-label="Property 2"
-            class="MenuOption TextOption menu-option"
-            role="button"
-          >
-            <div
-              class="noicon"
-            />
-            <div
-              class="menu-name"
-            >
-              Property 2
+              <div
+                class="menu-name"
+              >
+                Status
+              </div>
+              <div
+                class="noicon"
+              />
             </div>
-            <div
-              class="noicon"
-            />
           </div>
-          <div
-            aria-label="Property 3"
-            class="MenuOption TextOption menu-option"
-            role="button"
-          >
+          <div>
             <div
-              class="noicon"
-            />
-            <div
-              class="menu-name"
+              aria-label="Property 1"
+              class="MenuOption TextOption menu-option"
+              role="button"
             >
-              Property 3
+              <div
+                class="noicon"
+              />
+              <div
+                class="menu-name"
+              >
+                Property 1
+              </div>
+              <svg
+                class="CheckIcon Icon"
+                viewBox="0 0 100 100"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <polyline
+                  points="20,60 40,80 80,40"
+                />
+              </svg>
             </div>
+          </div>
+          <div>
             <div
-              class="noicon"
-            />
+              aria-label="Property 2"
+              class="MenuOption TextOption menu-option"
+              role="button"
+            >
+              <div
+                class="noicon"
+              />
+              <div
+                class="menu-name"
+              >
+                Property 2
+              </div>
+              <div
+                class="noicon"
+              />
+            </div>
+          </div>
+          <div>
+            <div
+              aria-label="Property 3"
+              class="MenuOption TextOption menu-option"
+              role="button"
+            >
+              <div
+                class="noicon"
+              />
+              <div
+                class="menu-name"
+              >
+                Property 3
+              </div>
+              <div
+                class="noicon"
+              />
+            </div>
           </div>
         </div>
         <div
@@ -187,99 +195,109 @@ exports[`components/viewHeader/viewHeaderGroupByMenu return groupBy menu and ung
         <div
           class="menu-options"
         >
-          <div
-            aria-label="Ungroup"
-            class="MenuOption TextOption menu-option"
-            role="button"
-          >
+          <div>
             <div
-              class="noicon"
-            />
-            <div
-              class="menu-name"
+              aria-label="Ungroup"
+              class="MenuOption TextOption menu-option"
+              role="button"
             >
-              Ungroup
-            </div>
-            <div
-              class="noicon"
-            />
-          </div>
-          <div
-            class="MenuOption MenuSeparator menu-separator"
-          />
-          <div
-            aria-label="Status"
-            class="MenuOption TextOption menu-option"
-            role="button"
-          >
-            <div
-              class="noicon"
-            />
-            <div
-              class="menu-name"
-            >
-              Status
-            </div>
-            <div
-              class="noicon"
-            />
-          </div>
-          <div
-            aria-label="Property 1"
-            class="MenuOption TextOption menu-option"
-            role="button"
-          >
-            <div
-              class="noicon"
-            />
-            <div
-              class="menu-name"
-            >
-              Property 1
-            </div>
-            <svg
-              class="CheckIcon Icon"
-              viewBox="0 0 100 100"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <polyline
-                points="20,60 40,80 80,40"
+              <div
+                class="noicon"
               />
-            </svg>
-          </div>
-          <div
-            aria-label="Property 2"
-            class="MenuOption TextOption menu-option"
-            role="button"
-          >
-            <div
-              class="noicon"
-            />
-            <div
-              class="menu-name"
-            >
-              Property 2
+              <div
+                class="menu-name"
+              >
+                Ungroup
+              </div>
+              <div
+                class="noicon"
+              />
             </div>
             <div
-              class="noicon"
+              class="MenuOption MenuSeparator menu-separator"
             />
           </div>
-          <div
-            aria-label="Property 3"
-            class="MenuOption TextOption menu-option"
-            role="button"
-          >
+          <div>
             <div
-              class="noicon"
-            />
-            <div
-              class="menu-name"
+              aria-label="Status"
+              class="MenuOption TextOption menu-option"
+              role="button"
             >
-              Property 3
+              <div
+                class="noicon"
+              />
+              <div
+                class="menu-name"
+              >
+                Status
+              </div>
+              <div
+                class="noicon"
+              />
             </div>
+          </div>
+          <div>
             <div
-              class="noicon"
-            />
+              aria-label="Property 1"
+              class="MenuOption TextOption menu-option"
+              role="button"
+            >
+              <div
+                class="noicon"
+              />
+              <div
+                class="menu-name"
+              >
+                Property 1
+              </div>
+              <svg
+                class="CheckIcon Icon"
+                viewBox="0 0 100 100"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <polyline
+                  points="20,60 40,80 80,40"
+                />
+              </svg>
+            </div>
+          </div>
+          <div>
+            <div
+              aria-label="Property 2"
+              class="MenuOption TextOption menu-option"
+              role="button"
+            >
+              <div
+                class="noicon"
+              />
+              <div
+                class="menu-name"
+              >
+                Property 2
+              </div>
+              <div
+                class="noicon"
+              />
+            </div>
+          </div>
+          <div>
+            <div
+              aria-label="Property 3"
+              class="MenuOption TextOption menu-option"
+              role="button"
+            >
+              <div
+                class="noicon"
+              />
+              <div
+                class="menu-name"
+              >
+                Property 3
+              </div>
+              <div
+                class="noicon"
+              />
+            </div>
           </div>
         </div>
         <div

--- a/webapp/src/components/viewHeader/__snapshots__/viewHeaderPropertiesMenu.test.tsx.snap
+++ b/webapp/src/components/viewHeader/__snapshots__/viewHeaderPropertiesMenu.test.tsx.snap
@@ -24,80 +24,88 @@ exports[`components/viewHeader/viewHeaderPropertiesMenu return properties menu 1
         <div
           class="menu-options"
         >
-          <div
-            class="MenuOption SwitchOption menu-option"
-          >
+          <div>
             <div
-              class="noicon"
-            />
-            <div
-              class="menu-name"
-            >
-              Status
-            </div>
-            <div
-              class="Switch"
+              class="MenuOption SwitchOption menu-option"
             >
               <div
-                class="octo-switch-inner"
+                class="noicon"
               />
+              <div
+                class="menu-name"
+              >
+                Status
+              </div>
+              <div
+                class="Switch"
+              >
+                <div
+                  class="octo-switch-inner"
+                />
+              </div>
             </div>
           </div>
-          <div
-            class="MenuOption SwitchOption menu-option"
-          >
+          <div>
             <div
-              class="noicon"
-            />
-            <div
-              class="menu-name"
-            >
-              Property 1
-            </div>
-            <div
-              class="Switch"
+              class="MenuOption SwitchOption menu-option"
             >
               <div
-                class="octo-switch-inner"
+                class="noicon"
               />
+              <div
+                class="menu-name"
+              >
+                Property 1
+              </div>
+              <div
+                class="Switch"
+              >
+                <div
+                  class="octo-switch-inner"
+                />
+              </div>
             </div>
           </div>
-          <div
-            class="MenuOption SwitchOption menu-option"
-          >
+          <div>
             <div
-              class="noicon"
-            />
-            <div
-              class="menu-name"
-            >
-              Property 2
-            </div>
-            <div
-              class="Switch"
+              class="MenuOption SwitchOption menu-option"
             >
               <div
-                class="octo-switch-inner"
+                class="noicon"
               />
+              <div
+                class="menu-name"
+              >
+                Property 2
+              </div>
+              <div
+                class="Switch"
+              >
+                <div
+                  class="octo-switch-inner"
+                />
+              </div>
             </div>
           </div>
-          <div
-            class="MenuOption SwitchOption menu-option"
-          >
+          <div>
             <div
-              class="noicon"
-            />
-            <div
-              class="menu-name"
-            >
-              Property 3
-            </div>
-            <div
-              class="Switch"
+              class="MenuOption SwitchOption menu-option"
             >
               <div
-                class="octo-switch-inner"
+                class="noicon"
               />
+              <div
+                class="menu-name"
+              >
+                Property 3
+              </div>
+              <div
+                class="Switch"
+              >
+                <div
+                  class="octo-switch-inner"
+                />
+              </div>
             </div>
           </div>
         </div>
@@ -155,99 +163,109 @@ exports[`components/viewHeader/viewHeaderPropertiesMenu return properties menu w
         <div
           class="menu-options"
         >
-          <div
-            class="MenuOption SwitchOption menu-option"
-          >
+          <div>
             <div
-              class="noicon"
-            />
-            <div
-              class="menu-name"
-            >
-              Title
-            </div>
-            <div
-              class="Switch"
+              class="MenuOption SwitchOption menu-option"
             >
               <div
-                class="octo-switch-inner"
+                class="noicon"
               />
+              <div
+                class="menu-name"
+              >
+                Title
+              </div>
+              <div
+                class="Switch"
+              >
+                <div
+                  class="octo-switch-inner"
+                />
+              </div>
             </div>
           </div>
-          <div
-            class="MenuOption SwitchOption menu-option"
-          >
+          <div>
             <div
-              class="noicon"
-            />
-            <div
-              class="menu-name"
-            >
-              Status
-            </div>
-            <div
-              class="Switch"
+              class="MenuOption SwitchOption menu-option"
             >
               <div
-                class="octo-switch-inner"
+                class="noicon"
               />
+              <div
+                class="menu-name"
+              >
+                Status
+              </div>
+              <div
+                class="Switch"
+              >
+                <div
+                  class="octo-switch-inner"
+                />
+              </div>
             </div>
           </div>
-          <div
-            class="MenuOption SwitchOption menu-option"
-          >
+          <div>
             <div
-              class="noicon"
-            />
-            <div
-              class="menu-name"
-            >
-              Property 1
-            </div>
-            <div
-              class="Switch"
+              class="MenuOption SwitchOption menu-option"
             >
               <div
-                class="octo-switch-inner"
+                class="noicon"
               />
+              <div
+                class="menu-name"
+              >
+                Property 1
+              </div>
+              <div
+                class="Switch"
+              >
+                <div
+                  class="octo-switch-inner"
+                />
+              </div>
             </div>
           </div>
-          <div
-            class="MenuOption SwitchOption menu-option"
-          >
+          <div>
             <div
-              class="noicon"
-            />
-            <div
-              class="menu-name"
-            >
-              Property 2
-            </div>
-            <div
-              class="Switch"
+              class="MenuOption SwitchOption menu-option"
             >
               <div
-                class="octo-switch-inner"
+                class="noicon"
               />
+              <div
+                class="menu-name"
+              >
+                Property 2
+              </div>
+              <div
+                class="Switch"
+              >
+                <div
+                  class="octo-switch-inner"
+                />
+              </div>
             </div>
           </div>
-          <div
-            class="MenuOption SwitchOption menu-option"
-          >
+          <div>
             <div
-              class="noicon"
-            />
-            <div
-              class="menu-name"
-            >
-              Property 3
-            </div>
-            <div
-              class="Switch"
+              class="MenuOption SwitchOption menu-option"
             >
               <div
-                class="octo-switch-inner"
+                class="noicon"
               />
+              <div
+                class="menu-name"
+              >
+                Property 3
+              </div>
+              <div
+                class="Switch"
+              >
+                <div
+                  class="octo-switch-inner"
+                />
+              </div>
             </div>
           </div>
         </div>

--- a/webapp/src/components/viewHeader/__snapshots__/viewHeaderSortMenu.test.tsx.snap
+++ b/webapp/src/components/viewHeader/__snapshots__/viewHeaderSortMenu.test.tsx.snap
@@ -24,136 +24,148 @@ exports[`components/viewHeader/viewHeaderSortMenu return sort menu 1`] = `
         <div
           class="menu-options"
         >
-          <div
-            aria-label="Manual"
-            class="MenuOption TextOption menu-option"
-            role="button"
-          >
+          <div>
             <div
-              class="noicon"
-            />
-            <div
-              class="menu-name"
+              aria-label="Manual"
+              class="MenuOption TextOption menu-option"
+              role="button"
             >
-              Manual
-            </div>
-            <div
-              class="noicon"
-            />
-          </div>
-          <div
-            aria-label="Revert"
-            class="MenuOption TextOption menu-option"
-            role="button"
-          >
-            <div
-              class="noicon"
-            />
-            <div
-              class="menu-name"
-            >
-              Revert
-            </div>
-            <div
-              class="noicon"
-            />
-          </div>
-          <div
-            class="MenuOption MenuSeparator menu-separator"
-          />
-          <div
-            aria-label="Name"
-            class="MenuOption TextOption menu-option"
-            role="button"
-          >
-            <div
-              class="noicon"
-            />
-            <div
-              class="menu-name"
-            >
-              Name
-            </div>
-            <div
-              class="noicon"
-            />
-          </div>
-          <div
-            aria-label="Status"
-            class="MenuOption TextOption menu-option"
-            role="button"
-          >
-            <div
-              class="noicon"
-            />
-            <div
-              class="menu-name"
-            >
-              Status
-            </div>
-            <div
-              class="noicon"
-            />
-          </div>
-          <div
-            aria-label="Property 1"
-            class="MenuOption TextOption menu-option"
-            role="button"
-          >
-            <div
-              class="noicon"
-            />
-            <div
-              class="menu-name"
-            >
-              Property 1
-            </div>
-            <svg
-              class="SortDownIcon Icon"
-              viewBox="0 0 100 100"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <polyline
-                points="50,20 50,80"
+              <div
+                class="noicon"
               />
-              <polyline
-                points="30,60 50,80 70,60"
+              <div
+                class="menu-name"
+              >
+                Manual
+              </div>
+              <div
+                class="noicon"
               />
-            </svg>
-          </div>
-          <div
-            aria-label="Property 2"
-            class="MenuOption TextOption menu-option"
-            role="button"
-          >
-            <div
-              class="noicon"
-            />
-            <div
-              class="menu-name"
-            >
-              Property 2
             </div>
             <div
-              class="noicon"
-            />
-          </div>
-          <div
-            aria-label="Property 3"
-            class="MenuOption TextOption menu-option"
-            role="button"
-          >
-            <div
-              class="noicon"
-            />
-            <div
-              class="menu-name"
+              aria-label="Revert"
+              class="MenuOption TextOption menu-option"
+              role="button"
             >
-              Property 3
+              <div
+                class="noicon"
+              />
+              <div
+                class="menu-name"
+              >
+                Revert
+              </div>
+              <div
+                class="noicon"
+              />
             </div>
             <div
-              class="noicon"
+              class="MenuOption MenuSeparator menu-separator"
             />
+          </div>
+          <div>
+            <div
+              aria-label="Name"
+              class="MenuOption TextOption menu-option"
+              role="button"
+            >
+              <div
+                class="noicon"
+              />
+              <div
+                class="menu-name"
+              >
+                Name
+              </div>
+              <div
+                class="noicon"
+              />
+            </div>
+          </div>
+          <div>
+            <div
+              aria-label="Status"
+              class="MenuOption TextOption menu-option"
+              role="button"
+            >
+              <div
+                class="noicon"
+              />
+              <div
+                class="menu-name"
+              >
+                Status
+              </div>
+              <div
+                class="noicon"
+              />
+            </div>
+          </div>
+          <div>
+            <div
+              aria-label="Property 1"
+              class="MenuOption TextOption menu-option"
+              role="button"
+            >
+              <div
+                class="noicon"
+              />
+              <div
+                class="menu-name"
+              >
+                Property 1
+              </div>
+              <svg
+                class="SortDownIcon Icon"
+                viewBox="0 0 100 100"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <polyline
+                  points="50,20 50,80"
+                />
+                <polyline
+                  points="30,60 50,80 70,60"
+                />
+              </svg>
+            </div>
+          </div>
+          <div>
+            <div
+              aria-label="Property 2"
+              class="MenuOption TextOption menu-option"
+              role="button"
+            >
+              <div
+                class="noicon"
+              />
+              <div
+                class="menu-name"
+              >
+                Property 2
+              </div>
+              <div
+                class="noicon"
+              />
+            </div>
+          </div>
+          <div>
+            <div
+              aria-label="Property 3"
+              class="MenuOption TextOption menu-option"
+              role="button"
+            >
+              <div
+                class="noicon"
+              />
+              <div
+                class="menu-name"
+              >
+                Property 3
+              </div>
+              <div
+                class="noicon"
+              />
+            </div>
           </div>
         </div>
         <div

--- a/webapp/src/widgets/__snapshots__/propertyMenu.test.tsx.snap
+++ b/webapp/src/widgets/__snapshots__/propertyMenu.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`widgets/PropertyMenu should match snapshot 1`] = `
       >
         <div>
           <input
-            class="PropertyMenu menu-textbox"
+            class="PropertyMenu menu-textbox menu-option"
             spellcheck="true"
             type="text"
             value="test-property"

--- a/webapp/src/widgets/__snapshots__/propertyMenu.test.tsx.snap
+++ b/webapp/src/widgets/__snapshots__/propertyMenu.test.tsx.snap
@@ -11,344 +11,350 @@ exports[`widgets/PropertyMenu should match snapshot 1`] = `
       <div
         class="menu-options"
       >
-        <input
-          class="PropertyMenu menu-textbox"
-          spellcheck="true"
-          type="text"
-          value="test-property"
-        />
-        <div
-          class="MenuOption SubMenuOption menu-option"
-          id="type"
-        >
-          <div
-            class="noicon"
+        <div>
+          <input
+            class="PropertyMenu menu-textbox"
+            spellcheck="true"
+            type="text"
+            value="test-property"
           />
+        </div>
+        <div>
           <div
-            class="menu-name"
-          >
-            Type: Text
-          </div>
-          <svg
-            class="SubmenuTriangleIcon Icon"
-            viewBox="0 0 100 100"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <polygon
-              points="50,35 75,50 50,65"
-            />
-          </svg>
-          <div
-            class="SubMenu Menu noselect bottom"
+            class="MenuOption SubMenuOption menu-option menu-option-active"
+            id="type"
           >
             <div
-              class="menu-contents"
+              class="noicon"
+            />
+            <div
+              class="menu-name"
+            >
+              Type: Text
+            </div>
+            <svg
+              class="SubmenuTriangleIcon Icon"
+              viewBox="0 0 100 100"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <polygon
+                points="50,35 75,50 50,65"
+              />
+            </svg>
+            <div
+              class="SubMenu Menu noselect bottom"
             >
               <div
-                class="menu-options"
+                class="menu-contents"
               >
                 <div
-                  class="MenuOption LabelOption menu-option"
+                  class="menu-options"
                 >
                   <div
-                    class="noicon"
-                  />
-                  <div
-                    class="menu-name"
+                    class="MenuOption LabelOption menu-option"
                   >
-                    <b>
-                      Change property type
-                    </b>
+                    <div
+                      class="noicon"
+                    />
+                    <div
+                      class="menu-name"
+                    >
+                      <b>
+                        Change property type
+                      </b>
+                    </div>
+                    <div
+                      class="noicon"
+                    />
                   </div>
                   <div
-                    class="noicon"
+                    class="MenuOption MenuSeparator menu-separator"
                   />
+                  <div
+                    aria-label="Text"
+                    class="MenuOption TextOption menu-option"
+                    role="button"
+                  >
+                    <div
+                      class="noicon"
+                    />
+                    <div
+                      class="menu-name"
+                    >
+                      Text
+                    </div>
+                    <div
+                      class="noicon"
+                    />
+                  </div>
+                  <div
+                    aria-label="Number"
+                    class="MenuOption TextOption menu-option"
+                    role="button"
+                  >
+                    <div
+                      class="noicon"
+                    />
+                    <div
+                      class="menu-name"
+                    >
+                      Number
+                    </div>
+                    <div
+                      class="noicon"
+                    />
+                  </div>
+                  <div
+                    aria-label="Email"
+                    class="MenuOption TextOption menu-option"
+                    role="button"
+                  >
+                    <div
+                      class="noicon"
+                    />
+                    <div
+                      class="menu-name"
+                    >
+                      Email
+                    </div>
+                    <div
+                      class="noicon"
+                    />
+                  </div>
+                  <div
+                    aria-label="Phone"
+                    class="MenuOption TextOption menu-option"
+                    role="button"
+                  >
+                    <div
+                      class="noicon"
+                    />
+                    <div
+                      class="menu-name"
+                    >
+                      Phone
+                    </div>
+                    <div
+                      class="noicon"
+                    />
+                  </div>
+                  <div
+                    aria-label="URL"
+                    class="MenuOption TextOption menu-option"
+                    role="button"
+                  >
+                    <div
+                      class="noicon"
+                    />
+                    <div
+                      class="menu-name"
+                    >
+                      URL
+                    </div>
+                    <div
+                      class="noicon"
+                    />
+                  </div>
+                  <div
+                    aria-label="Select"
+                    class="MenuOption TextOption menu-option"
+                    role="button"
+                  >
+                    <div
+                      class="noicon"
+                    />
+                    <div
+                      class="menu-name"
+                    >
+                      Select
+                    </div>
+                    <div
+                      class="noicon"
+                    />
+                  </div>
+                  <div
+                    aria-label="Multi Select"
+                    class="MenuOption TextOption menu-option"
+                    role="button"
+                  >
+                    <div
+                      class="noicon"
+                    />
+                    <div
+                      class="menu-name"
+                    >
+                      Multi Select
+                    </div>
+                    <div
+                      class="noicon"
+                    />
+                  </div>
+                  <div
+                    aria-label="Date"
+                    class="MenuOption TextOption menu-option"
+                    role="button"
+                  >
+                    <div
+                      class="noicon"
+                    />
+                    <div
+                      class="menu-name"
+                    >
+                      Date
+                    </div>
+                    <div
+                      class="noicon"
+                    />
+                  </div>
+                  <div
+                    aria-label="Person"
+                    class="MenuOption TextOption menu-option"
+                    role="button"
+                  >
+                    <div
+                      class="noicon"
+                    />
+                    <div
+                      class="menu-name"
+                    >
+                      Person
+                    </div>
+                    <div
+                      class="noicon"
+                    />
+                  </div>
+                  <div
+                    aria-label="Checkbox"
+                    class="MenuOption TextOption menu-option"
+                    role="button"
+                  >
+                    <div
+                      class="noicon"
+                    />
+                    <div
+                      class="menu-name"
+                    >
+                      Checkbox
+                    </div>
+                    <div
+                      class="noicon"
+                    />
+                  </div>
+                  <div
+                    aria-label="Created time"
+                    class="MenuOption TextOption menu-option"
+                    role="button"
+                  >
+                    <div
+                      class="noicon"
+                    />
+                    <div
+                      class="menu-name"
+                    >
+                      Created time
+                    </div>
+                    <div
+                      class="noicon"
+                    />
+                  </div>
+                  <div
+                    aria-label="Created by"
+                    class="MenuOption TextOption menu-option"
+                    role="button"
+                  >
+                    <div
+                      class="noicon"
+                    />
+                    <div
+                      class="menu-name"
+                    >
+                      Created by
+                    </div>
+                    <div
+                      class="noicon"
+                    />
+                  </div>
+                  <div
+                    aria-label="Last updated time"
+                    class="MenuOption TextOption menu-option"
+                    role="button"
+                  >
+                    <div
+                      class="noicon"
+                    />
+                    <div
+                      class="menu-name"
+                    >
+                      Last updated time
+                    </div>
+                    <div
+                      class="noicon"
+                    />
+                  </div>
+                  <div
+                    aria-label="Last updated by"
+                    class="MenuOption TextOption menu-option"
+                    role="button"
+                  >
+                    <div
+                      class="noicon"
+                    />
+                    <div
+                      class="menu-name"
+                    >
+                      Last updated by
+                    </div>
+                    <div
+                      class="noicon"
+                    />
+                  </div>
                 </div>
                 <div
-                  class="MenuOption MenuSeparator menu-separator"
+                  class="menu-spacer hideOnWidescreen"
                 />
                 <div
-                  aria-label="Text"
-                  class="MenuOption TextOption menu-option"
-                  role="button"
+                  class="menu-options hideOnWidescreen"
                 >
                   <div
-                    class="noicon"
-                  />
-                  <div
-                    class="menu-name"
+                    aria-label="Cancel"
+                    class="MenuOption TextOption menu-option menu-cancel"
+                    role="button"
                   >
-                    Text
+                    <div
+                      class="noicon"
+                    />
+                    <div
+                      class="menu-name"
+                    >
+                      Cancel
+                    </div>
+                    <div
+                      class="noicon"
+                    />
                   </div>
-                  <div
-                    class="noicon"
-                  />
-                </div>
-                <div
-                  aria-label="Number"
-                  class="MenuOption TextOption menu-option"
-                  role="button"
-                >
-                  <div
-                    class="noicon"
-                  />
-                  <div
-                    class="menu-name"
-                  >
-                    Number
-                  </div>
-                  <div
-                    class="noicon"
-                  />
-                </div>
-                <div
-                  aria-label="Email"
-                  class="MenuOption TextOption menu-option"
-                  role="button"
-                >
-                  <div
-                    class="noicon"
-                  />
-                  <div
-                    class="menu-name"
-                  >
-                    Email
-                  </div>
-                  <div
-                    class="noicon"
-                  />
-                </div>
-                <div
-                  aria-label="Phone"
-                  class="MenuOption TextOption menu-option"
-                  role="button"
-                >
-                  <div
-                    class="noicon"
-                  />
-                  <div
-                    class="menu-name"
-                  >
-                    Phone
-                  </div>
-                  <div
-                    class="noicon"
-                  />
-                </div>
-                <div
-                  aria-label="URL"
-                  class="MenuOption TextOption menu-option"
-                  role="button"
-                >
-                  <div
-                    class="noicon"
-                  />
-                  <div
-                    class="menu-name"
-                  >
-                    URL
-                  </div>
-                  <div
-                    class="noicon"
-                  />
-                </div>
-                <div
-                  aria-label="Select"
-                  class="MenuOption TextOption menu-option"
-                  role="button"
-                >
-                  <div
-                    class="noicon"
-                  />
-                  <div
-                    class="menu-name"
-                  >
-                    Select
-                  </div>
-                  <div
-                    class="noicon"
-                  />
-                </div>
-                <div
-                  aria-label="Multi Select"
-                  class="MenuOption TextOption menu-option"
-                  role="button"
-                >
-                  <div
-                    class="noicon"
-                  />
-                  <div
-                    class="menu-name"
-                  >
-                    Multi Select
-                  </div>
-                  <div
-                    class="noicon"
-                  />
-                </div>
-                <div
-                  aria-label="Date"
-                  class="MenuOption TextOption menu-option"
-                  role="button"
-                >
-                  <div
-                    class="noicon"
-                  />
-                  <div
-                    class="menu-name"
-                  >
-                    Date
-                  </div>
-                  <div
-                    class="noicon"
-                  />
-                </div>
-                <div
-                  aria-label="Person"
-                  class="MenuOption TextOption menu-option"
-                  role="button"
-                >
-                  <div
-                    class="noicon"
-                  />
-                  <div
-                    class="menu-name"
-                  >
-                    Person
-                  </div>
-                  <div
-                    class="noicon"
-                  />
-                </div>
-                <div
-                  aria-label="Checkbox"
-                  class="MenuOption TextOption menu-option"
-                  role="button"
-                >
-                  <div
-                    class="noicon"
-                  />
-                  <div
-                    class="menu-name"
-                  >
-                    Checkbox
-                  </div>
-                  <div
-                    class="noicon"
-                  />
-                </div>
-                <div
-                  aria-label="Created time"
-                  class="MenuOption TextOption menu-option"
-                  role="button"
-                >
-                  <div
-                    class="noicon"
-                  />
-                  <div
-                    class="menu-name"
-                  >
-                    Created time
-                  </div>
-                  <div
-                    class="noicon"
-                  />
-                </div>
-                <div
-                  aria-label="Created by"
-                  class="MenuOption TextOption menu-option"
-                  role="button"
-                >
-                  <div
-                    class="noicon"
-                  />
-                  <div
-                    class="menu-name"
-                  >
-                    Created by
-                  </div>
-                  <div
-                    class="noicon"
-                  />
-                </div>
-                <div
-                  aria-label="Last updated time"
-                  class="MenuOption TextOption menu-option"
-                  role="button"
-                >
-                  <div
-                    class="noicon"
-                  />
-                  <div
-                    class="menu-name"
-                  >
-                    Last updated time
-                  </div>
-                  <div
-                    class="noicon"
-                  />
-                </div>
-                <div
-                  aria-label="Last updated by"
-                  class="MenuOption TextOption menu-option"
-                  role="button"
-                >
-                  <div
-                    class="noicon"
-                  />
-                  <div
-                    class="menu-name"
-                  >
-                    Last updated by
-                  </div>
-                  <div
-                    class="noicon"
-                  />
-                </div>
-              </div>
-              <div
-                class="menu-spacer hideOnWidescreen"
-              />
-              <div
-                class="menu-options hideOnWidescreen"
-              >
-                <div
-                  aria-label="Cancel"
-                  class="MenuOption TextOption menu-option menu-cancel"
-                  role="button"
-                >
-                  <div
-                    class="noicon"
-                  />
-                  <div
-                    class="menu-name"
-                  >
-                    Cancel
-                  </div>
-                  <div
-                    class="noicon"
-                  />
                 </div>
               </div>
             </div>
           </div>
         </div>
-        <div
-          aria-label="Delete"
-          class="MenuOption TextOption menu-option"
-          role="button"
-        >
+        <div>
           <div
-            class="noicon"
-          />
-          <div
-            class="menu-name"
+            aria-label="Delete"
+            class="MenuOption TextOption menu-option"
+            role="button"
           >
-            Delete
+            <div
+              class="noicon"
+            />
+            <div
+              class="menu-name"
+            >
+              Delete
+            </div>
+            <div
+              class="noicon"
+            />
           </div>
-          <div
-            class="noicon"
-          />
         </div>
       </div>
       <div

--- a/webapp/src/widgets/menu/menu.scss
+++ b/webapp/src/widgets/menu/menu.scss
@@ -134,7 +134,7 @@
 
             flex: 0 0 auto;
 
-            > .menu-option {
+            * > .menu-option {
                 min-height: 44px;
                 width: 100%;
                 padding: 0 20px;

--- a/webapp/src/widgets/menu/menu.scss
+++ b/webapp/src/widgets/menu/menu.scss
@@ -34,7 +34,7 @@
 
         color: rgb(var(--center-channel-color-rgb));
 
-        > .menu-option {
+        * > .menu-option {
             display: flex;
             flex-direction: row;
             align-items: center;
@@ -47,6 +47,10 @@
             cursor: pointer;
 
             &:hover {
+                background: rgba(var(--button-bg-rgb), 0.08);
+            }
+
+            &-active {
                 background: rgba(var(--button-bg-rgb), 0.08);
             }
 
@@ -80,7 +84,7 @@
             }
         }
 
-        > .menu-option.bold-menu-text {
+        * > .menu-option.bold-menu-text {
             font-weight: bold;
         }
     }

--- a/webapp/src/widgets/menu/menu.tsx
+++ b/webapp/src/widgets/menu/menu.tsx
@@ -47,20 +47,13 @@ export default class Menu extends React.PureComponent<Props> {
                                                 })
                                             }
                                         >
-                                            {castedChild.type === React.Fragment ? (
-
-                                                // the isHovering prop cannot be set on React.Fragment
+                                            {castedChild.type === SubMenuOption ? (
                                                 <castedChild.type
                                                     {...castedChild.props}
+                                                    isHovering={i === this.state.hoveringIdx}
                                                 />
                                             ) : (
-                                                <castedChild.type
-                                                    {...castedChild.props}
-                                                    isHovering={
-                                                        i ===
-                                                        this.state.hoveringIdx
-                                                    }
-                                                />
+                                                <castedChild.type {...castedChild.props}/>
                                             )}
                                         </div>
                                     )

--- a/webapp/src/widgets/menu/menu.tsx
+++ b/webapp/src/widgets/menu/menu.tsx
@@ -12,8 +12,8 @@ import LabelOption from './labelOption'
 import './menu.scss'
 
 type Props = {
-    children: React.ReactNode
-    position?: 'top'|'bottom'|'left'|'right'
+    children: React.ReactNode;
+    position?: 'top' | 'bottom' | 'left' | 'right';
 }
 
 export default class Menu extends React.PureComponent<Props> {
@@ -24,13 +24,50 @@ export default class Menu extends React.PureComponent<Props> {
     static Text = TextOption
     static Label = LabelOption
 
+    public state = {
+        hoveringIdx: -1,
+    }
+
     public render(): JSX.Element {
         const {position, children} = this.props
         return (
             <div className={'Menu noselect ' + (position || 'bottom')}>
                 <div className='menu-contents'>
                     <div className='menu-options'>
-                        {children}
+                        {React.Children.map(children, (child, i) => {
+                            if (child !== null) {
+                                if (React.isValidElement(child)) {
+                                    const castedChild = child as React.ReactElement
+
+                                    return (
+                                        <div
+                                            onMouseEnter={() =>
+                                                this.setState({
+                                                    hoveringIdx: i,
+                                                })
+                                            }
+                                        >
+                                            {castedChild.type === React.Fragment ? (
+
+                                                // the isHovering prop cannot be set on React.Fragment
+                                                <castedChild.type
+                                                    {...castedChild.props}
+                                                />
+                                            ) : (
+                                                <castedChild.type
+                                                    {...castedChild.props}
+                                                    isHovering={
+                                                        i ===
+                                                        this.state.hoveringIdx
+                                                    }
+                                                />
+                                            )}
+                                        </div>
+                                    )
+                                }
+                            }
+                            return child
+                        })}
                     </div>
 
                     <div className='menu-spacer hideOnWidescreen'/>

--- a/webapp/src/widgets/menu/menu.tsx
+++ b/webapp/src/widgets/menu/menu.tsx
@@ -10,6 +10,7 @@ import SubMenuOption from './subMenuOption'
 import LabelOption from './labelOption'
 
 import './menu.scss'
+import textInputOption from './textInputOption'
 
 type Props = {
     children: React.ReactNode;
@@ -22,6 +23,7 @@ export default class Menu extends React.PureComponent<Props> {
     static Switch = SwitchOption
     static Separator = SeparatorOption
     static Text = TextOption
+    static TextInput = textInputOption
     static Label = LabelOption
 
     public state = {

--- a/webapp/src/widgets/menu/subMenuOption.tsx
+++ b/webapp/src/widgets/menu/subMenuOption.tsx
@@ -31,7 +31,7 @@ function SubMenuOption(props: SubMenuOptionProps): JSX.Element {
     return (
         <div
             id={props.id}
-            className={`MenuOption SubMenuOption menu-option${openLeftClass} ${isOpen ? 'menu-option-active' : ''}`}
+            className={`MenuOption SubMenuOption menu-option${openLeftClass}${isOpen ? ' menu-option-active' : ''}`}
             onClick={(e: React.MouseEvent) => {
                 e.preventDefault()
                 e.stopPropagation()

--- a/webapp/src/widgets/menu/subMenuOption.tsx
+++ b/webapp/src/widgets/menu/subMenuOption.tsx
@@ -14,6 +14,7 @@ type SubMenuOptionProps = {
     position?: 'bottom' | 'top' | 'left' | 'left-bottom'
     icon?: React.ReactNode
     children: React.ReactNode
+    closeOnLeave?: boolean,
 }
 
 function SubMenuOption(props: SubMenuOptionProps): JSX.Element {
@@ -30,6 +31,7 @@ function SubMenuOption(props: SubMenuOptionProps): JSX.Element {
                     setIsOpen(true)
                 }, 50)
             }}
+            onMouseLeave={() => (props.closeOnLeave ? setIsOpen(false) : null)}
             onClick={(e: React.MouseEvent) => {
                 e.preventDefault()
                 e.stopPropagation()

--- a/webapp/src/widgets/menu/subMenuOption.tsx
+++ b/webapp/src/widgets/menu/subMenuOption.tsx
@@ -1,6 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
-import React, {useState} from 'react'
+import React, {useEffect, useState} from 'react'
 
 import SubmenuTriangleIcon from '../icons/submenuTriangle'
 
@@ -9,12 +9,12 @@ import Menu from '.'
 import './subMenuOption.scss'
 
 type SubMenuOptionProps = {
-    id: string,
-    name: string,
+    id: string
+    name: string
     position?: 'bottom' | 'top' | 'left' | 'left-bottom'
     icon?: React.ReactNode
     children: React.ReactNode
-    closeOnLeave?: boolean,
+    isHovering?: boolean
 }
 
 function SubMenuOption(props: SubMenuOptionProps): JSX.Element {
@@ -22,16 +22,16 @@ function SubMenuOption(props: SubMenuOptionProps): JSX.Element {
 
     const openLeftClass = props.position === 'left' || props.position === 'left-bottom' ? ' open-left' : ''
 
+    useEffect(() => {
+        if (props.isHovering !== undefined) {
+            setIsOpen(props.isHovering)
+        }
+    }, [props.isHovering])
+
     return (
         <div
             id={props.id}
-            className={`MenuOption SubMenuOption menu-option${openLeftClass}`}
-            onMouseEnter={() => {
-                setTimeout(() => {
-                    setIsOpen(true)
-                }, 50)
-            }}
-            onMouseLeave={() => (props.closeOnLeave ? setIsOpen(false) : null)}
+            className={`MenuOption SubMenuOption menu-option${openLeftClass} ${isOpen ? 'menu-option-active' : ''}`}
             onClick={(e: React.MouseEvent) => {
                 e.preventDefault()
                 e.stopPropagation()

--- a/webapp/src/widgets/menu/textInputOption.tsx
+++ b/webapp/src/widgets/menu/textInputOption.tsx
@@ -1,0 +1,41 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+import React, {useState, useRef, useEffect} from 'react'
+
+type TextInputOptionProps = {
+    initialValue: string,
+    onValueChanged: (value: string) => void
+}
+
+function TextInputOption(props: TextInputOptionProps): JSX.Element {
+    const nameTextbox = useRef<HTMLInputElement>(null)
+    const [value, setValue] = useState(props.initialValue)
+
+    useEffect(() => {
+        nameTextbox.current?.focus()
+        nameTextbox.current?.setSelectionRange(0, value.length)
+    }, [])
+
+    return (
+        <input
+            ref={nameTextbox}
+            type='text'
+            className='PropertyMenu menu-textbox menu-option'
+            onClick={(e) => e.stopPropagation()}
+            onChange={(e) => setValue(e.target.value)}
+            value={value}
+            onBlur={() => props.onValueChanged(value)}
+            onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === 'Escape') {
+                    props.onValueChanged(value)
+                    e.stopPropagation()
+                    if (e.key === 'Enter') {
+                        e.target.dispatchEvent(new Event('menuItemClicked'))
+                    }
+                }
+            }}
+            spellCheck={true}
+        />)
+}
+
+export default React.memo(TextInputOption)

--- a/webapp/src/widgets/propertyMenu.tsx
+++ b/webapp/src/widgets/propertyMenu.tsx
@@ -1,11 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
-<<<<<<< HEAD
-import React, {useState, useRef, useEffect} from 'react'
-=======
 import React from 'react'
-import debounce from 'lodash/debounce'
->>>>>>> 04fc4e8b (Refactor input into TextInputOption component)
 import {useIntl, IntlShape} from 'react-intl'
 
 import {PropertyType} from '../blocks/board'

--- a/webapp/src/widgets/propertyMenu.tsx
+++ b/webapp/src/widgets/propertyMenu.tsx
@@ -109,7 +109,7 @@ const PropertyMenu = React.memo((props: Props) => {
             <input
                 ref={nameTextbox}
                 type='text'
-                className='PropertyMenu menu-textbox'
+                className='PropertyMenu menu-textbox menu-option'
                 onClick={(e) => e.stopPropagation()}
                 onChange={(e) => {
                     setName(e.target.value)

--- a/webapp/src/widgets/propertyMenu.tsx
+++ b/webapp/src/widgets/propertyMenu.tsx
@@ -109,7 +109,7 @@ const PropertyMenu = React.memo((props: Props) => {
             >
                 <PropertyTypes
                     label={intl.formatMessage({id: 'PropertyMenu.changeType', defaultMessage: 'Change property type'})}
-                    onTypeSelected={(type: PropertyType) => props.onTypeAndNameChanged(type, name)}
+                    onTypeSelected={(type: PropertyType) => props.onTypeAndNameChanged(type, props.propertyName)}
                 />
             </Menu.SubMenu>
             <Menu.Text

--- a/webapp/src/widgets/propertyMenu.tsx
+++ b/webapp/src/widgets/propertyMenu.tsx
@@ -1,6 +1,11 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
+<<<<<<< HEAD
 import React, {useState, useRef, useEffect} from 'react'
+=======
+import React from 'react'
+import debounce from 'lodash/debounce'
+>>>>>>> 04fc4e8b (Refactor input into TextInputOption component)
 import {useIntl, IntlShape} from 'react-intl'
 
 import {PropertyType} from '../blocks/board'
@@ -91,41 +96,17 @@ export const PropertyTypes = (props: TypesProps): JSX.Element => {
 
 const PropertyMenu = React.memo((props: Props) => {
     const intl = useIntl()
-    const nameTextbox = useRef<HTMLInputElement>(null)
-    const [name, setName] = useState(props.propertyName)
 
     const deleteText = intl.formatMessage({
         id: 'PropertyMenu.Delete',
         defaultMessage: 'Delete',
     })
 
-    useEffect(() => {
-        nameTextbox.current?.focus()
-        nameTextbox.current?.setSelectionRange(0, name.length)
-    }, [])
-
     return (
         <Menu>
-            <input
-                ref={nameTextbox}
-                type='text'
-                className='PropertyMenu menu-textbox menu-option'
-                onClick={(e) => e.stopPropagation()}
-                onChange={(e) => {
-                    setName(e.target.value)
-                }}
-                value={name}
-                onBlur={() => props.onTypeAndNameChanged(props.propertyType, name)}
-                onKeyDown={(e) => {
-                    if (e.key === 'Enter' || e.key === 'Escape') {
-                        props.onTypeAndNameChanged(props.propertyType, name)
-                        e.stopPropagation()
-                        if (e.key === 'Enter') {
-                            e.target.dispatchEvent(new Event('menuItemClicked'))
-                        }
-                    }
-                }}
-                spellCheck={true}
+            <Menu.TextInput
+                initialValue={props.propertyName}
+                onValueChanged={(n) => props.onTypeAndNameChanged(props.propertyType, n)}
             />
             <Menu.SubMenu
                 id='type'


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

In #1553 the `onMouseLeave` callback was removed which lead to the settings sub menus not closing properly. This PR adds a flag to close a submenu on mouse leave. 

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

Fixes #1581 
