### PR TITLE
[GH-1349]: removed TODO comments flagged by eslint

### DIFF
--- a/webapp/src/components/viewHeader/filterComponent.tsx
+++ b/webapp/src/components/viewHeader/filterComponent.tsx
@@ -61,7 +61,6 @@ const FilterComponent = React.memo((props: Props): JSX.Element => {
 
     const {board, activeView} = props
 
-    // TODO: Handle FilterGroups (compound filter statements)
     const filters: FilterClause[] = activeView.fields.filter?.filters.filter((o) => !isAFilterGroupInstance(o)) as FilterClause[] || []
 
     return (

--- a/webapp/src/components/viewHeader/filterEntry.tsx
+++ b/webapp/src/components/viewHeader/filterEntry.tsx
@@ -30,7 +30,7 @@ const FilterEntry = React.memo((props: Props): JSX.Element => {
     const intl = useIntl()
 
     const template = board.fields.cardProperties.find((o: IPropertyTemplate) => o.id === filter.propertyId)
-    const propertyName = template ? template.name : '(unknown)'		// TODO: Handle error
+    const propertyName = template ? template.name : '(unknown)'
     const key = `${filter.propertyId}-${filter.condition}-${filter.values.join(',')}`
     return (
         <div


### PR DESCRIPTION

#### Summary
This PR fixes the issues flagged in eslint:
/focalboard/webapp/src/components/viewHeader/filterComponent.tsx
  64:5  warning  Unexpected 'todo' comment: 'TODO: Handle FilterGroups (compound...'  no-warning-comments

/focalboard/webapp/src/components/viewHeader/filterEntry.tsx
  33:66  warning  Unexpected 'todo' comment: 'TODO: Handle error'  no-warning-comments

#### Ticket Link
Fixes :  #1349 , https://github.com/mattermost/focalboard/issues/1349



