### PR TITLE
Bug - Rewrote Logic of MenuWrapper to Accept onBlur

### DIFF
--- a/webapp/src/components/kanban/kanbanCard.tsx
+++ b/webapp/src/components/kanban/kanbanCard.tsx
@@ -57,23 +57,32 @@ const KanbanCard = React.memo((props: Props) => {
             style={{opacity: isDragging ? 0.5 : 1}}
             onClick={props.onClick}
         >
-            {!props.readonly &&
+            {!props.readonly && (
                 <MenuWrapper
                     className='optionsMenu'
                     stopPropagationOnToggle={true}
+                    onMouseBlur={false}
                 >
                     <IconButton icon={<OptionsIcon/>}/>
                     <Menu position='left'>
                         <Menu.Text
                             icon={<DeleteIcon/>}
                             id='delete'
-                            name={intl.formatMessage({id: 'KanbanCard.delete', defaultMessage: 'Delete'})}
-                            onClick={() => mutator.deleteBlock(card, 'delete card')}
+                            name={intl.formatMessage({
+                                id: 'KanbanCard.delete',
+                                defaultMessage: 'Delete',
+                            })}
+                            onClick={() =>
+                                mutator.deleteBlock(card, 'delete card')
+                            }
                         />
                         <Menu.Text
                             icon={<DuplicateIcon/>}
                             id='duplicate'
-                            name={intl.formatMessage({id: 'KanbanCard.duplicate', defaultMessage: 'Duplicate'})}
+                            name={intl.formatMessage({
+                                id: 'KanbanCard.duplicate',
+                                defaultMessage: 'Duplicate',
+                            })}
                             onClick={() => {
                                 mutator.duplicateCard(
                                     card.id,
@@ -91,7 +100,10 @@ const KanbanCard = React.memo((props: Props) => {
                         <Menu.Text
                             icon={<LinkIcon/>}
                             id='copy'
-                            name={intl.formatMessage({id: 'KanbanCard.copyLink', defaultMessage: 'Copy link'})}
+                            name={intl.formatMessage({
+                                id: 'KanbanCard.copyLink',
+                                defaultMessage: 'Copy link',
+                            })}
                             onClick={() => {
                                 let cardLink = window.location.href
 
@@ -100,16 +112,30 @@ const KanbanCard = React.memo((props: Props) => {
                                 }
 
                                 Utils.copyTextToClipboard(cardLink)
-                                sendFlashMessage({content: intl.formatMessage({id: 'KanbanCard.copiedLink', defaultMessage: 'Copied!'}), severity: 'high'})
+                                sendFlashMessage({
+                                    content: intl.formatMessage({
+                                        id: 'KanbanCard.copiedLink',
+                                        defaultMessage: 'Copied!',
+                                    }),
+                                    severity: 'high',
+                                })
                             }}
                         />
                     </Menu>
                 </MenuWrapper>
-            }
+            )}
 
             <div className='octo-icontitle'>
-                { card.fields.icon ? <div className='octo-icon'>{card.fields.icon}</div> : undefined }
-                <div key='__title'>{card.title || intl.formatMessage({id: 'KanbanCard.untitled', defaultMessage: 'Untitled'})}</div>
+                {card.fields.icon ? (
+                    <div className='octo-icon'>{card.fields.icon}</div>
+                ) : undefined}
+                <div key='__title'>
+                    {card.title ||
+                        intl.formatMessage({
+                            id: 'KanbanCard.untitled',
+                            defaultMessage: 'Untitled',
+                        })}
+                </div>
             </div>
             {visiblePropertyTemplates.map((template) => (
                 <Tooltip

--- a/webapp/src/widgets/menuWrapper.tsx
+++ b/webapp/src/widgets/menuWrapper.tsx
@@ -10,6 +10,7 @@ type Props = {
     stopPropagationOnToggle?: boolean;
     className?: string
     disabled?: boolean
+    onMouseBlur?: boolean
 }
 
 const MenuWrapper = React.memo((props: Props) => {
@@ -25,6 +26,9 @@ const MenuWrapper = React.memo((props: Props) => {
     }
 
     const closeOnBlur = (e: Event) => {
+        if (props.onMouseBlur === false) {
+            return
+        }
         if (e.target && node.current?.contains(e.target as Node)) {
             return
         }
@@ -59,17 +63,29 @@ const MenuWrapper = React.memo((props: Props) => {
         }
         setOpen(!open)
     }
-
-    useEffect(() => {
-        document.addEventListener('menuItemClicked', close, true)
-        document.addEventListener('click', closeOnBlur, true)
-        document.addEventListener('keyup', keyboardClose, true)
-        return () => {
-            document.removeEventListener('menuItemClicked', close, true)
-            document.removeEventListener('click', closeOnBlur, true)
-            document.removeEventListener('keyup', keyboardClose, true)
-        }
-    }, [])
+    if (props.onMouseBlur === false) {
+        useEffect(() => {
+            document.addEventListener('menuItemClicked', close, true)
+            document.addEventListener('click', closeOnBlur, false)
+            document.addEventListener('keyup', keyboardClose, true)
+            return () => {
+                document.removeEventListener('menuItemClicked', close, true)
+                document.removeEventListener('click', closeOnBlur, false)
+                document.removeEventListener('keyup', keyboardClose, true)
+            }
+        }, [])
+    } else {
+        useEffect(() => {
+            document.addEventListener('menuItemClicked', close, true)
+            document.addEventListener('click', closeOnBlur, true)
+            document.addEventListener('keyup', keyboardClose, true)
+            return () => {
+                document.removeEventListener('menuItemClicked', close, true)
+                document.removeEventListener('click', closeOnBlur, true)
+                document.removeEventListener('keyup', keyboardClose, true)
+            }
+        }, [])
+    }
 
     const {children} = props
     let className = 'MenuWrapper'


### PR DESCRIPTION
Signed-off-by: Adithya Krishna <aadithya794@gmail.com>

#### Summary
The MenuWrapper component was triggering when mouse was outside the scope, to facilitate future scope, I've rewritten the logic of the onBlur part.
onMouseBlur when set to false, will stop the menu from collapsing and the default value will be true to prevent breakage of existing code

#### Ticket Link
This PR Fixes #1007 

