### PR TITLE
[GH-1602] enableMode changed for required files

### DIFF
--- a/config.json
+++ b/config.json
@@ -16,7 +16,7 @@
 	"session_expire_time": 2592000,
 	"session_refresh_time": 18000,
 	"localOnly": false,
-	"enableLocalMode": true,
+	"enableLocalMode": false,
 	"localModeSocketLocation": "/var/tmp/focalboard_local.socket",
 	"authMode": "native",
 	"logging_cfg_file": "",

--- a/docker/config.json
+++ b/docker/config.json
@@ -12,6 +12,6 @@
     "session_expire_time": 2592000,
     "session_refresh_time": 18000,
     "localOnly": false,
-    "enableLocalMode": true,
+    "enableLocalMode": false,
     "localModeSocketLocation": "/var/tmp/focalboard_local.socket"
 }

--- a/docker/server_config.json
+++ b/docker/server_config.json
@@ -11,6 +11,6 @@
   "session_expire_time": 2592000,
   "session_refresh_time": 18000,
   "localOnly": false,
-  "enableLocalMode": true,
+  "enableLocalMode": false,
   "localModeSocketLocation": "/var/tmp/focalboard_local.socket"
 }

--- a/server-config.json
+++ b/server-config.json
@@ -12,6 +12,6 @@
     "session_expire_time": 2592000,
     "session_refresh_time": 18000,
     "localOnly": false,
-    "enableLocalMode": true,
+    "enableLocalMode": false,
     "localModeSocketLocation": "/var/tmp/focalboard_local.socket"
 }

--- a/webapp/src/components/table/tableRow.tsx
+++ b/webapp/src/components/table/tableRow.tsx
@@ -107,6 +107,7 @@ const TableRow = React.memo((props: Props) => {
                         onCancel={() => setTitle(card.title || '')}
                         readonly={props.readonly}
                         spellCheck={true}
+                        autoExpand={false}
                     />
                 </div>
 

--- a/website/site/content/guide/admin/_index.md
+++ b/website/site/content/guide/admin/_index.md
@@ -23,12 +23,14 @@ Personal server settings are stored in `config.json` and are read when the serve
 | session_expire_time | Session expiration time in seconds | 2592000
 | session_refresh_time | Session refresh time in seconds   | 18000
 | localOnly | Only allow connections from localhost        | `false`
-| enableLocalMode | Enable admin APIs on local Unix port   | `true`
+| enableLocalMode | Enable admin APIs on local Unix port   | `false`
 | localModeSocketLocation | Location of local Unix port    | `/var/tmp/focalboard_local.socket`
 
 ## Resetting passwords
 
 By default, personal server exposes admin APIs on a local Unix socket at `/var/tmp/focalboard_local.socket`. This is configurable using the `enableLocalMode` and `localModeSocketLocation` settings in `config.json`.
+
+First set the enableLocalMode setting to true, restart the server, then run the reset password script
 
 To reset a user's password, you can use the following `reset-password.sh` script:
 


### PR DESCRIPTION

#### Summary
The enableLocalMode is said to be false and the following information is added to the reset password file.

#### Ticket Link

  Fixes https://github.com/mattermost/focalboard/issues/1602


