### PR TITLE
Make block type a proper type

### DIFF
--- a/server/app/blocks.go
+++ b/server/app/blocks.go
@@ -171,11 +171,11 @@ func (a *App) getBoardAndCard(c store.Container, block *model.Block) (board *mod
 	iter := block
 	for {
 		count++
-		if board == nil && iter.Type == "board" {
+		if board == nil && iter.Type == model.TypeBoard {
 			board = iter
 		}
 
-		if card == nil && iter.Type == "card" {
+		if card == nil && iter.Type == model.TypeCard {
 			card = iter
 		}
 

--- a/server/integrationtests/blocks_test.go
+++ b/server/integrationtests/blocks_test.go
@@ -25,14 +25,14 @@ func TestGetBlocks(t *testing.T) {
 			RootID:   blockID1,
 			CreateAt: 1,
 			UpdateAt: 1,
-			Type:     "board",
+			Type:     model.TypeBoard,
 		},
 		{
 			ID:       blockID2,
 			RootID:   blockID2,
 			CreateAt: 1,
 			UpdateAt: 1,
-			Type:     "board",
+			Type:     model.TypeBoard,
 		},
 	}
 	_, resp = th.Client.InsertBlocks(newBlocks)
@@ -68,7 +68,7 @@ func TestPostBlock(t *testing.T) {
 			RootID:   blockID1,
 			CreateAt: 1,
 			UpdateAt: 1,
-			Type:     "board",
+			Type:     model.TypeBoard,
 			Title:    "New title",
 		}
 
@@ -93,14 +93,14 @@ func TestPostBlock(t *testing.T) {
 				RootID:   blockID2,
 				CreateAt: 1,
 				UpdateAt: 1,
-				Type:     "board",
+				Type:     model.TypeBoard,
 			},
 			{
 				ID:       blockID3,
 				RootID:   blockID3,
 				CreateAt: 1,
 				UpdateAt: 1,
-				Type:     "board",
+				Type:     model.TypeBoard,
 			},
 		}
 
@@ -126,7 +126,7 @@ func TestPostBlock(t *testing.T) {
 			RootID:   blockID1,
 			CreateAt: 1,
 			UpdateAt: 20,
-			Type:     "board",
+			Type:     model.TypeBoard,
 			Title:    "Updated title",
 		}
 
@@ -159,7 +159,7 @@ func TestPatchBlock(t *testing.T) {
 		RootID:   blockID,
 		CreateAt: 1,
 		UpdateAt: 1,
-		Type:     "board",
+		Type:     model.TypeBoard,
 		Title:    "New title",
 		Fields:   map[string]interface{}{"test": "test value", "test2": "test value 2"},
 	}
@@ -260,7 +260,7 @@ func TestDeleteBlock(t *testing.T) {
 			RootID:   blockID,
 			CreateAt: 1,
 			UpdateAt: 1,
-			Type:     "board",
+			Type:     model.TypeBoard,
 			Title:    "New title",
 		}
 
@@ -309,7 +309,7 @@ func TestGetSubtree(t *testing.T) {
 				RootID:   parentBlockID,
 				CreateAt: 1,
 				UpdateAt: 1,
-				Type:     "board",
+				Type:     model.TypeBoard,
 			},
 			{
 				ID:       childBlockID1,
@@ -317,7 +317,7 @@ func TestGetSubtree(t *testing.T) {
 				ParentID: parentBlockID,
 				CreateAt: 2,
 				UpdateAt: 2,
-				Type:     "card",
+				Type:     model.TypeCard,
 			},
 			{
 				ID:       childBlockID2,
@@ -325,7 +325,7 @@ func TestGetSubtree(t *testing.T) {
 				ParentID: parentBlockID,
 				CreateAt: 2,
 				UpdateAt: 2,
-				Type:     "card",
+				Type:     model.TypeCard,
 			},
 		}
 

--- a/server/model/block.go
+++ b/server/model/block.go
@@ -34,7 +34,7 @@ type Block struct {
 
 	// The block type
 	// required: true
-	Type string `json:"type"`
+	Type BlockType `json:"type"`
 
 	// The display title
 	// required: false
@@ -78,7 +78,7 @@ type BlockPatch struct {
 
 	// The block type
 	// required: false
-	Type *string `json:"type"`
+	Type *BlockType `json:"type"`
 
 	// The display title
 	// required: false
@@ -112,7 +112,7 @@ func (b Block) LogClone() interface{} {
 		ID       string
 		ParentID string
 		RootID   string
-		Type     string
+		Type     BlockType
 	}{
 		ID:       b.ID,
 		ParentID: b.ParentID,

--- a/server/model/blocktype.go
+++ b/server/model/blocktype.go
@@ -1,0 +1,56 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package model
+
+import (
+	"errors"
+	"strings"
+)
+
+// BlockType represents a block type.
+type BlockType string
+
+const (
+	TypeUnknown = "unknown"
+	TypeBoard   = "board"
+	TypeCard    = "card"
+	TypeView    = "view"
+	TypeText    = "text"
+	TypeComment = "comment"
+)
+
+func (bt BlockType) String() string {
+	return string(bt)
+}
+
+func BlockTypeFromString(s string) (BlockType, error) {
+	switch strings.ToLower(s) {
+	case "board":
+		return TypeBoard, nil
+	case "card":
+		return TypeCard, nil
+	case "view":
+		return TypeView, nil
+	case "text":
+		return TypeText, nil
+	case "comment":
+		return TypeComment, nil
+	}
+	return TypeUnknown, ErrInvalidBlockType{s}
+}
+
+// ErrInvalidBlockType is returned wherever an invalid block type was provided.
+type ErrInvalidBlockType struct {
+	Type string
+}
+
+func (e ErrInvalidBlockType) Error() string {
+	return e.Type + " is an invalid block type."
+}
+
+// IsErrInvalidBlockType returns true if `err` is a IsErrInvalidBlockType or wraps one.
+func IsErrInvalidBlockType(err error) bool {
+	var eibt *ErrInvalidBlockType
+	return errors.As(err, &eibt)
+}

--- a/server/services/notify/notifymentions/mentions_backend.go
+++ b/server/services/notify/notifymentions/mentions_backend.go
@@ -6,6 +6,7 @@ package notifymentions
 import (
 	"fmt"
 
+	"github.com/mattermost/focalboard/server/model"
 	"github.com/mattermost/focalboard/server/services/notify"
 	"github.com/wiggin77/merror"
 
@@ -50,7 +51,7 @@ func (b *Backend) BlockChanged(evt notify.BlockChangeEvent) error {
 		return nil
 	}
 
-	if evt.BlockChanged.Type != "text" && evt.BlockChanged.Type != "comment" {
+	if evt.BlockChanged.Type != model.TypeText && evt.BlockChanged.Type != model.TypeComment {
 		return nil
 	}
 

--- a/server/services/notify/notifymentions/mentions_test.go
+++ b/server/services/notify/notifymentions/mentions_test.go
@@ -38,7 +38,7 @@ func Test_extractMentions(t *testing.T) {
 func makeBlock(text string) *model.Block {
 	return &model.Block{
 		ID:    mm_model.NewId(),
-		Type:  "comment",
+		Type:  model.TypeComment,
 		Title: text,
 	}
 }

--- a/server/services/notify/plugindelivery/message.go
+++ b/server/services/notify/plugindelivery/message.go
@@ -17,7 +17,7 @@ const (
 
 func formatMessage(author string, extract string, card string, link string, block *model.Block) string {
 	template := defDescriptionTemplate
-	if block.Type == "comment" {
+	if block.Type == model.TypeComment {
 		template = defCommentTemplate
 	}
 	return fmt.Sprintf(template, author, card, link, extract)

--- a/server/services/store/sqlstore/initialize.go
+++ b/server/services/store/sqlstore/initialize.go
@@ -43,7 +43,7 @@ func (s *SQLStore) importInitialTemplates() error {
 	for i := range archive.Blocks {
 		s.logger.Trace("insert block",
 			mlog.String("blockID", archive.Blocks[i].ID),
-			mlog.String("block_type", archive.Blocks[i].Type),
+			mlog.String("block_type", archive.Blocks[i].Type.String()),
 			mlog.String("block_title", archive.Blocks[i].Title),
 		)
 		err := s.InsertBlock(globalContainer, &archive.Blocks[i], "system")


### PR DESCRIPTION
#### Summary
While working on notifications it became apparent that block types were just strings sprinkled throughout the code (server-side).  This PR turns those strings into constants of a concrete type.  

Also prevents the linter complaining once we hit three instances of a block type string in a package.

#### Ticket Link
NONE