### PR TITLE
[GH-1709] Fix Missing Socket when Building Application under Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ npm-debug.log*
 pids
 *.pid
 *.seed
+*.socket
 
 # OS Files
 .DS_Store

--- a/config.json
+++ b/config.json
@@ -17,7 +17,7 @@
 	"session_refresh_time": 18000,
 	"localOnly": false,
 	"enableLocalMode": true,
-	"localModeSocketLocation": "/var/tmp/focalboard_local.socket",
+	"localModeSocketLocation": "./focalboard_local.socket",
 	"authMode": "native",
 	"logging_cfg_file": "",
 	"audit_cfg_file": "",

--- a/server/server/server.go
+++ b/server/server/server.go
@@ -373,6 +373,13 @@ func (s *Server) startLocalModeServer() error {
 		ConnContext: api.SetContextConn,
 	}
 
+	// If the socket file doesn't exist, create it, or append to the file
+	f, err := os.OpenFile(s.config.LocalModeSocketLocation, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		s.logger.Error("Unable to create Socket File:", mlog.Err(err))
+	}
+	f.Close()
+
 	// TODO: Close and delete socket file on shutdown
 	if err := syscall.Unlink(s.config.LocalModeSocketLocation); err != nil {
 		s.logger.Error("Unable to unlink socket.", mlog.Err(err))

--- a/server/server/server.go
+++ b/server/server/server.go
@@ -373,14 +373,16 @@ func (s *Server) startLocalModeServer() error {
 		ConnContext: api.SetContextConn,
 	}
 
-	// If the socket file doesn't exist, create it, or append to the file
-	f, err := os.OpenFile(s.config.LocalModeSocketLocation, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
-	if err != nil {
-		s.logger.Error("Unable to create Socket File:", mlog.Err(err))
+	// If the socket file doesn't exist
+	if _, err := os.Stat(s.config.LocalModeSocketLocation); errors.Is(err, os.ErrNotExist) {
+		//Create it
+		f, err := os.OpenFile(s.config.LocalModeSocketLocation, os.O_APPEND|os.O_CREATE, 0644)
+		if err != nil {
+			s.logger.Error("Unable to create Socket File:", mlog.Err(err))
+		}
+		f.Close()
 	}
-	f.Close()
 
-	// TODO: Close and delete socket file on shutdown
 	if err := syscall.Unlink(s.config.LocalModeSocketLocation); err != nil {
 		s.logger.Error("Unable to unlink socket.", mlog.Err(err))
 	}
@@ -409,6 +411,12 @@ func (s *Server) stopLocalModeServer() {
 	if s.localModeServer != nil {
 		_ = s.localModeServer.Close()
 		s.localModeServer = nil
+	}
+
+	//Remove Socket File on Stop
+	err := os.Remove(s.config.LocalModeSocketLocation)
+	if err != nil {
+		s.logger.Warn("Error Deleting the Local Mode Socket File", mlog.Err(err))
 	}
 }
 

--- a/server/server/server.go
+++ b/server/server/server.go
@@ -373,9 +373,7 @@ func (s *Server) startLocalModeServer() error {
 		ConnContext: api.SetContextConn,
 	}
 
-	// If the socket file doesn't exist
 	if _, err := os.Stat(s.config.LocalModeSocketLocation); errors.Is(err, os.ErrNotExist) {
-		//Create it
 		f, err := os.OpenFile(s.config.LocalModeSocketLocation, os.O_APPEND|os.O_CREATE, 0644)
 		if err != nil {
 			s.logger.Error("Unable to create Socket File:", mlog.Err(err))
@@ -413,7 +411,6 @@ func (s *Server) stopLocalModeServer() {
 		s.localModeServer = nil
 	}
 
-	//Remove Socket File on Stop
 	err := os.Remove(s.config.LocalModeSocketLocation)
 	if err != nil {
 		s.logger.Warn("Error Deleting the Local Mode Socket File", mlog.Err(err))


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
The Pull Request Fixes the Bug encountered in the below Ticket when trying to Build for Windows.
As the default Path: "/var/tmp/focalboard_local.socket" is not Available under Windows, it was moved into the Local Folder.
Additionally, the Socket File will now be created if it does no Already Exist, and gets Deleted on Stop Server.

##### Note:
Be Aware because of: https://github.com/microsoft/vscode-go/issues/2387
I could not Test the Stop Code.

Additionally, someone should confirm that it still can be Build under Linux as Normal. 

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://github.com/mattermost/focalboard/issues/1709
