### PR TITLE
Modify store creation not to fail on template initialization failure

### DIFF
--- a/server/services/store/sqlstore/sqlstore.go
+++ b/server/services/store/sqlstore/sqlstore.go
@@ -44,11 +44,8 @@ func New(dbType, connectionString, tablePrefix string, logger *mlog.Logger, db *
 		return nil, err
 	}
 
-	err = store.InitializeTemplates()
-	if err != nil {
+	if err := store.InitializeTemplates(); err != nil {
 		logger.Error(`InitializeTemplates failed`, mlog.Err(err))
-
-		return nil, err
 	}
 
 	return store, nil


### PR DESCRIPTION
#### Summary
Modify how the store is initialized not to fail in case the templates are not initialized correctly, but to log the error and continue normally.

Fixes https://github.com/mattermost/focalboard/issues/1515
