### PR TITLE
Move BlockType2IDType from utils to model

### DIFF
--- a/server/model/blocktype.go
+++ b/server/model/blocktype.go
@@ -6,6 +6,8 @@ package model
 import (
 	"errors"
 	"strings"
+
+	"github.com/mattermost/focalboard/server/utils"
 )
 
 // BlockType represents a block type.
@@ -24,6 +26,7 @@ func (bt BlockType) String() string {
 	return string(bt)
 }
 
+// BlockTypeFromString returns an appropriate BlockType for the specified string.
 func BlockTypeFromString(s string) (BlockType, error) {
 	switch strings.ToLower(s) {
 	case "board":
@@ -38,6 +41,21 @@ func BlockTypeFromString(s string) (BlockType, error) {
 		return TypeComment, nil
 	}
 	return TypeUnknown, ErrInvalidBlockType{s}
+}
+
+// BlockType2IDType returns an appropriate IDType for the specified BlockType.
+func BlockType2IDType(blockType BlockType) utils.IDType {
+	switch blockType {
+	case TypeBoard:
+		return utils.IDTypeBoard
+	case TypeCard:
+		return utils.IDTypeCard
+	case TypeView:
+		return utils.IDTypeView
+	case TypeText, TypeComment:
+		return utils.IDTypeBlock
+	}
+	return utils.IDTypeNone
 }
 
 // ErrInvalidBlockType is returned wherever an invalid block type was provided.

--- a/server/utils/utils.go
+++ b/server/utils/utils.go
@@ -4,8 +4,6 @@ import (
 	"encoding/json"
 	"time"
 
-	"github.com/mattermost/focalboard/server/model"
-
 	mm_model "github.com/mattermost/mattermost-server/v6/model"
 )
 
@@ -29,21 +27,6 @@ const (
 // type of entity or a `7` if unknown type.
 func NewID(idType IDType) string {
 	return string(idType) + mm_model.NewId()
-}
-
-// BlockType2IDType returns an appropriate IDType for the specified BlockType.
-func BlockType2IDType(blockType model.BlockType) IDType {
-	switch blockType {
-	case model.TypeBoard:
-		return IDTypeBoard
-	case model.TypeCard:
-		return IDTypeCard
-	case model.TypeView:
-		return IDTypeView
-	case model.TypeText, model.TypeComment:
-		return IDTypeBlock
-	}
-	return IDTypeNone
 }
 
 // GetMillis is a convenience method to get milliseconds since epoch.


### PR DESCRIPTION
#### Summary
The recently added `BlockType2IDType` method was put into `utils` but created a cyclic dependency with `model`.  Things in `utils` should not depend on `model`.  This PR moves the method to `model`.

#### Ticket Link
NONE