### PR TITLE
Redirect to new routes when visiting a board with the legacy ones

### DIFF
--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -85,13 +85,6 @@ const App = React.memo((): JSX.Element => {
     const me = useAppSelector<IUser|null>(getMe)
     const dispatch = useAppDispatch()
 
-    // this is a temporary solution while we're using legacy routes
-    // for shared boards as a way to disable websockets, and should be
-    // removed when anonymous plugin routes are implemented. This
-    // check is used to detect if we're running inside the plugin but
-    // in a legacy route
-    const inPluginLegacy = window.location.pathname.includes('/plugins/focalboard/')
-
     useEffect(() => {
         dispatch(fetchLanguage())
         dispatch(fetchMe())
@@ -106,7 +99,12 @@ const App = React.memo((): JSX.Element => {
         }, [])
     }
 
-    if (!inPluginLegacy) {
+    // this is a temporary solution while we're using legacy routes
+    // for shared boards as a way to disable websockets, and should be
+    // removed when anonymous plugin routes are implemented. This
+    // check is used to detect if we're running inside the plugin but
+    // in a legacy route
+    if (!Utils.isFocalboardLegacy()) {
         useEffect(() => {
             wsClient.open()
             return () => {

--- a/webapp/src/pages/boardPage.tsx
+++ b/webapp/src/pages/boardPage.tsx
@@ -53,6 +53,12 @@ const BoardPage = (props: Props): JSX.Element => {
 
     let workspaceId = match.params.workspaceId || UserSettings.lastWorkspaceId || '0'
 
+    // if we're in a legacy route and not showing a shared board,
+    // redirect to the new URL schema equivalent
+    if (Utils.isFocalboardLegacy() && !props.readonly) {
+        window.location.href = window.location.href.replace('/plugins/focalboard', '/boards')
+    }
+
     // TODO: Make this less brittle. This only works because this is the root render function
     useEffect(() => {
         workspaceId = match.params.workspaceId || workspaceId

--- a/webapp/src/utils.ts
+++ b/webapp/src/utils.ts
@@ -508,6 +508,13 @@ class Utils {
         return Boolean(window.isFocalboardPlugin)
     }
 
+    // this is a temporary solution while we're using legacy routes
+    // for shared boards as a way to check if we're accessing the
+    // legacy routes inside the plugin
+    static isFocalboardLegacy(): boolean {
+        return window.location.pathname.includes('/plugins/focalboard')
+    }
+
     static fixBlock(block: Block): Block {
         switch (block.type) {
         case 'board':


### PR DESCRIPTION
#### Summary
This PR redirects the user to the new plugin routes if it detects they're visiting an old legacy board URL.
