### PR TITLE
GH-1692: Show card preview in @mention notification DM

### DIFF
--- a/mattermost-plugin/server/plugin.go
+++ b/mattermost-plugin/server/plugin.go
@@ -287,9 +287,8 @@ func postWithBoardsEmbed(post *mmModel.Post, showBoardsUnfurl bool) *mmModel.Pos
 
 	// Trim away the first / because otherwise after we split the string, the first element in the array is a empty element
 	urlPath := u.Path
-	if strings.HasPrefix(urlPath, "/") {
-		urlPath = u.Path[1:]
-	}
+	urlPath = strings.TrimPrefix(urlPath, "/")
+	urlPath = strings.TrimSuffix(urlPath, "/")
 	pathSplit := strings.Split(strings.ToLower(urlPath), "/")
 	queryParams := u.Query()
 
@@ -332,6 +331,13 @@ func getFirstLink(str string) string {
 		if _, ok := blockOrInline.(*markdown.Autolink); ok {
 			if link := blockOrInline.(*markdown.Autolink).Destination(); firstLink == "" {
 				firstLink = link
+				return false
+			}
+		}
+		if inlineLink, ok := blockOrInline.(*markdown.InlineLink); ok {
+			if link := inlineLink.Destination(); firstLink == "" {
+				firstLink = link
+				return false
 			}
 		}
 		return true


### PR DESCRIPTION
#### Summary
This PR adds unfurl meta-data when creating @mention notification posts.  This includes support for unfurling of inline links, meaning any posts with inline links will now unfurl.

#### Ticket Link
Fixes https://github.com/mattermost/focalboard/issues/1692