### PR TITLE
GH-1685: Error if workspace is undefined

### DIFF
--- a/webapp/src/store/initialLoad.ts
+++ b/webapp/src/store/initialLoad.ts
@@ -22,6 +22,11 @@ export const initialLoad = createAsyncThunk(
             client.getAllBlocks(),
             getUserWorkspaces(),
         ])
+
+        // if no workspace, either bad id, or user doesn't have access
+        if (workspace === undefined) {
+            throw new Error('Workspace undefined')
+        }
         return {
             workspace,
             workspaceUsers,


### PR DESCRIPTION
#### Summary
When a workspace is not defined, the api call returns an `undefined` workspace, not an error. This PR updates the initial load to throw an error if the workspace is not returned. 

#### Ticket Link
https://github.com/mattermost/focalboard/issues/1685
