### PR TITLE
Shows the version change banner only on plugin update and tries to reconnect when the interface is refreshed

### DIFF
--- a/mattermost-plugin/webapp/src/index.tsx
+++ b/mattermost-plugin/webapp/src/index.tsx
@@ -67,7 +67,7 @@ type Props = {
 }
 
 const MainApp = (props: Props) => {
-    wsClient.initPlugin(manifest.id, props.webSocketClient)
+    wsClient.initPlugin(manifest.id, manifest.version, props.webSocketClient)
 
     useEffect(() => {
         document.body.classList.add('focalboard-body')

--- a/webapp/src/utils.test.ts
+++ b/webapp/src/utils.test.ts
@@ -132,4 +132,18 @@ describe('utils', () => {
             expect(Utils.displayDateTime(date, intl)).toBe(`July 09, ${previousYear}, 5:35 AM`)
         })
     })
+
+    describe('compare versions', () => {
+        it('should return one if b > a', () => {
+            expect(Utils.compareVersions('0.9.4', '0.10.0')).toBe(1)
+        })
+
+        it('should return zero if a = b', () => {
+            expect(Utils.compareVersions('1.2.3', '1.2.3')).toBe(0)
+        })
+
+        it('should return minus one if b < a', () => {
+            expect(Utils.compareVersions('10.9.4', '10.9.2')).toBe(-1)
+        })
+    })
 })

--- a/webapp/src/utils.ts
+++ b/webapp/src/utils.ts
@@ -546,41 +546,39 @@ class Utils {
     }
 
     /**
-     * Boolean function to check if a version is greater than another.
+     * Function to check how a version compares to another
      *
-     * currentVersionParam: The version being checked
-     * compareVersionParam: The version to compare the former version against
-     *
-     * eg.  currentVersionParam = 4.16.0, compareVersionParam = 4.17.0 returns false
-     *      currentVersionParam = 4.16.1, compareVersionParam = 4.16.1 returns true
+     * eg.  versionA = 4.16.0, versionB = 4.17.0 returns  1
+     *      versionA = 4.16.1, versionB = 4.16.1 returns  0
+     *      versionA = 4.16.1, versionB = 4.15.0 returns -1
      */
-    static isVersionGreaterThanOrEqualTo(currentVersionParam: string, compareVersionParam: string): boolean {
-        if (currentVersionParam === compareVersionParam) {
-            return true
+    static compareVersions(versionA: string, versionB: string): number {
+        if (versionA === versionB) {
+            return 0
         }
 
         // We only care about the numbers
-        const currentVersionNumber = (currentVersionParam || '').split('.').filter((x) => (/^[0-9]+$/).exec(x) !== null)
-        const compareVersionNumber = (compareVersionParam || '').split('.').filter((x) => (/^[0-9]+$/).exec(x) !== null)
+        const versionANumber = (versionA || '').split('.').filter((x) => (/^[0-9]+$/).exec(x) !== null)
+        const versionBNumber = (versionB || '').split('.').filter((x) => (/^[0-9]+$/).exec(x) !== null)
 
-        for (let i = 0; i < Math.max(currentVersionNumber.length, compareVersionNumber.length); i++) {
-            const currentVersion = parseInt(currentVersionNumber[i], 10) || 0
-            const compareVersion = parseInt(compareVersionNumber[i], 10) || 0
-            if (currentVersion > compareVersion) {
-                return true
+        for (let i = 0; i < Math.max(versionANumber.length, versionBNumber.length); i++) {
+            const a = parseInt(versionANumber[i], 10) || 0
+            const b = parseInt(versionBNumber[i], 10) || 0
+            if (a > b) {
+                return -1
             }
 
-            if (currentVersion < compareVersion) {
-                return false
+            if (a < b) {
+                return 1
             }
         }
 
         // If all components are equal, then return true
-        return true
+        return 0
     }
 
     static isDesktop(): boolean {
-        return Utils.isDesktopApp() && Utils.isVersionGreaterThanOrEqualTo(Utils.getDesktopVersion(), '5.0.0')
+        return Utils.isDesktopApp() && (Utils.compareVersions(Utils.getDesktopVersion(), '5.0.0') <= 0)
     }
 
     static getReadToken(): string {


### PR DESCRIPTION
#### Summary
The new version banner is showing on every plugin update, as there is no way to distinguish which plugin has been changed in the websocket message. This PR compares the new Boards version with the current one and only shows the version banner in that case.

For the cases where an update happens and the interface is refreshed, the previous fix would not work because of the plugin lifecycle, so we trigger a delayed reconnect as a temporal solution so the interface doesn't become unresponsive.

A more complete solution would be to ACK the websocket subscription message so the plugin can retry until the server acknowledges the subscription and could show a warning in the meantime.