### PR TITLE
[GH-1730]: Clear search on view change

### DIFF
--- a/webapp/src/components/centerPanel.test.tsx
+++ b/webapp/src/components/centerPanel.test.tsx
@@ -15,6 +15,16 @@ import {Constants} from '../constants'
 
 import CenterPanel from './centerPanel'
 Object.defineProperty(Constants, 'versionString', {value: '1.0.0'})
+jest.mock('react-router-dom', () => {
+    const originalModule = jest.requireActual('react-router-dom')
+
+    return {
+        ...originalModule,
+        useRouteMatch: jest.fn(() => {
+            return {url: '/board/view'}
+        }),
+    }
+})
 jest.mock('../utils')
 jest.mock('../mutator')
 jest.mock('../telemetry/telemetryClient')

--- a/webapp/src/components/viewHeader/viewHeader.test.tsx
+++ b/webapp/src/components/viewHeader/viewHeader.test.tsx
@@ -17,6 +17,17 @@ const board = TestBlockFactory.createBoard()
 const activeView = TestBlockFactory.createBoardView(board)
 const card = TestBlockFactory.createCard(board)
 
+jest.mock('react-router-dom', () => {
+    const originalModule = jest.requireActual('react-router-dom')
+
+    return {
+        ...originalModule,
+        useRouteMatch: jest.fn(() => {
+            return {url: '/board/view'}
+        }),
+    }
+})
+
 describe('components/viewHeader/viewHeader', () => {
     const state = {
         users: {

--- a/webapp/src/components/viewHeader/viewHeaderSearch.test.tsx
+++ b/webapp/src/components/viewHeader/viewHeaderSearch.test.tsx
@@ -11,6 +11,17 @@ import {mockStateStore, wrapIntl} from '../../testUtils'
 
 import ViewHeaderSearch from './viewHeaderSearch'
 
+jest.mock('react-router-dom', () => {
+    const originalModule = jest.requireActual('react-router-dom')
+
+    return {
+        ...originalModule,
+        useRouteMatch: jest.fn(() => {
+            return {url: '/board/view'}
+        }),
+    }
+})
+
 describe('components/viewHeader/ViewHeaderSearch', () => {
     const state = {
         users: {

--- a/webapp/src/components/viewHeader/viewHeaderSearch.tsx
+++ b/webapp/src/components/viewHeader/viewHeaderSearch.tsx
@@ -1,6 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 import React, {useState, useRef, useEffect, useMemo} from 'react'
+import {useRouteMatch} from 'react-router-dom'
 import {FormattedMessage, useIntl} from 'react-intl'
 import {useHotkeys} from 'react-hotkeys-hook'
 import {debounce} from 'lodash'
@@ -15,10 +16,12 @@ const ViewHeaderSearch = (): JSX.Element => {
     const searchText = useAppSelector<string>(getSearchText)
     const dispatch = useAppDispatch()
     const intl = useIntl()
+    const match = useRouteMatch<{viewId?: string}>()
 
     const searchFieldRef = useRef<{focus(selectAll?: boolean): void}>(null)
     const [isSearching, setIsSearching] = useState(Boolean(searchText))
     const [searchValue, setSearchValue] = useState(searchText)
+    const [currentView, setCurrentView] = useState(match.params?.viewId)
 
     const dispatchSearchText = (value: string) => {
         dispatch(setSearchText(value))
@@ -26,6 +29,20 @@ const ViewHeaderSearch = (): JSX.Element => {
 
     const debouncedDispatchSearchText = useMemo(
         () => debounce(dispatchSearchText, 200), [])
+
+    useEffect(() => {
+        const viewId = match.params?.viewId
+        if (viewId !== currentView) {
+            setCurrentView(viewId)
+            setSearchValue('')
+            setIsSearching(false)
+
+            // Previously debounced calls to change the search text should be cancelled
+            // to avoid resetting the search text.
+            debouncedDispatchSearchText.cancel()
+            dispatchSearchText('')
+        }
+    }, [match.url])
 
     useEffect(() => {
         return () => {


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Added a state to search component that stores the viewId and when the view is changed the search is cleared. Let me know if there is any better approach / improvement to this approach.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Fixes #1730.
