### PR TITLE
GH-1805: Replace unfurl link with card title

### DIFF
--- a/mattermost-plugin/server/plugin.go
+++ b/mattermost-plugin/server/plugin.go
@@ -356,7 +356,7 @@ func getFirstLinkAndShortenAllBoardsLink(postMessage string) (firstLink, newPost
 
 			if seen := seenLinks[link]; !seen && isBoardsLink(link) {
 				markdownFormattedLink := fmt.Sprintf("[%s](%s)", "<Jump To Card>", link)
-				newPostMessage = strings.Replace(newPostMessage, link, markdownFormattedLink, -1)
+				newPostMessage = strings.ReplaceAll(newPostMessage, link, markdownFormattedLink)
 				seenLinks[link] = true
 			}
 		}

--- a/mattermost-plugin/server/plugin.go
+++ b/mattermost-plugin/server/plugin.go
@@ -355,6 +355,7 @@ func getFirstLinkAndShortenAllBoardsLink(postMessage string) (firstLink, newPost
 			}
 
 			if seen := seenLinks[link]; !seen && isBoardsLink(link) {
+				// TODO: Make sure that <Jump To Card> is Internationalized and translated to the Users Language preference
 				markdownFormattedLink := fmt.Sprintf("[%s](%s)", "<Jump To Card>", link)
 				newPostMessage = strings.ReplaceAll(newPostMessage, link, markdownFormattedLink)
 				seenLinks[link] = true

--- a/mattermost-plugin/server/plugin.go
+++ b/mattermost-plugin/server/plugin.go
@@ -291,7 +291,8 @@ func postWithBoardsEmbed(post *mmModel.Post, showBoardsUnfurl bool) *mmModel.Pos
 		return post
 	}
 
-	firstLink := getFirstLink(post.Message)
+	firstLink, newPostMessage := getFirstLinkAndShortenAllBoardsLink(post.Message)
+	post.Message = newPostMessage
 
 	if firstLink == "" {
 		return post
@@ -342,26 +343,32 @@ func postWithBoardsEmbed(post *mmModel.Post, showBoardsUnfurl bool) *mmModel.Pos
 	return post
 }
 
-func getFirstLink(str string) string {
-	firstLink := ""
+func getFirstLinkAndShortenAllBoardsLink(postMessage string) (firstLink, newPostMessage string) {
+	newPostMessage = postMessage
+	seenLinks := make(map[string]bool)
+	markdown.Inspect(postMessage, func(blockOrInline interface{}) bool {
+		if autoLink, ok := blockOrInline.(*markdown.Autolink); ok {
+			link := autoLink.Destination()
 
-	markdown.Inspect(str, func(blockOrInline interface{}) bool {
-		if _, ok := blockOrInline.(*markdown.Autolink); ok {
-			if link := blockOrInline.(*markdown.Autolink).Destination(); firstLink == "" {
+			if firstLink == "" {
 				firstLink = link
-				return false
+			}
+
+			if seen := seenLinks[link]; !seen && isBoardsLink(link) {
+				markdownFormattedLink := fmt.Sprintf("[%s](%s)", "<Jump To Card>", link)
+				newPostMessage = strings.Replace(newPostMessage, link, markdownFormattedLink, -1)
+				seenLinks[link] = true
 			}
 		}
 		if inlineLink, ok := blockOrInline.(*markdown.InlineLink); ok {
 			if link := inlineLink.Destination(); firstLink == "" {
 				firstLink = link
-				return false
 			}
 		}
 		return true
 	})
 
-	return firstLink
+	return firstLink, newPostMessage
 }
 
 func returnBoardsParams(pathArray []string) (workspaceID, boardID, viewID, cardID string) {
@@ -405,4 +412,24 @@ func returnBoardsParams(pathArray []string) (workspaceID, boardID, viewID, cardI
 		cardID = pathArray[index+7]
 	}
 	return workspaceID, boardID, viewID, cardID
+}
+
+func isBoardsLink(link string) bool {
+	u, err := url.Parse(link)
+
+	if err != nil {
+		return false
+	}
+
+	urlPath := u.Path
+	urlPath = strings.TrimPrefix(urlPath, "/")
+	urlPath = strings.TrimSuffix(urlPath, "/")
+	pathSplit := strings.Split(strings.ToLower(urlPath), "/")
+
+	if len(pathSplit) == 0 {
+		return false
+	}
+
+	workspaceID, boardID, viewID, cardID := returnBoardsParams(pathSplit)
+	return workspaceID != "" && boardID != "" && viewID != "" && cardID != ""
 }


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Replaces **RAW** Focalboard Card links with `<Jump To Card>` unlocalized

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Fixes https://github.com/mattermost/focalboard/issues/1805 

Concluded Solution (from above Issue)
![image](https://user-images.githubusercontent.com/17804942/143383449-f1e42434-986c-4758-92a7-79ba979e30bb.png)



![image](https://user-images.githubusercontent.com/17804942/143382569-416cbaf1-68d1-4fbb-8ea0-fc11694227b4.png)

![image](https://user-images.githubusercontent.com/17804942/143382614-1a019bce-94fd-44c5-9419-e35ef330aafc.png)

![image](https://user-images.githubusercontent.com/17804942/143382688-c017b37f-e4be-41d0-ae00-d689a3151878.png)
