### PR TITLE
[GH-1883] Fix error page button to follow base URL

### DIFF
--- a/webapp/src/pages/errorPage.tsx
+++ b/webapp/src/pages/errorPage.tsx
@@ -2,12 +2,15 @@
 // See LICENSE.txt for license information.
 import React from 'react'
 import {FormattedMessage} from 'react-intl'
+import {useHistory} from 'react-router-dom'
 
 import octoClient from '../octoClient'
 import Button from '../widgets/buttons/button'
 import './errorPage.scss'
 
 const ErrorPage = React.memo(() => {
+    const history = useHistory()
+
     return (
         <div className='ErrorPage'>
             <div className='title'>{'Error'}</div>
@@ -22,7 +25,7 @@ const ErrorPage = React.memo(() => {
                 filled={true}
                 onClick={async () => {
                     await octoClient.logout()
-                    window.location.href = '/login'
+                    history.push("/login")
                 }}
             >
                 <FormattedMessage


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Fixes `/error` page button to follow base URL.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Fixes #1883 

#### Test steps
1. Set up focalboard on subpath
1. Visit `/<subpath>/error` and click button
1. Page should now be `/<subpath>/login` (instead of `/login`)