### PR TITLE
Added Docker Config Volume

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -33,6 +33,7 @@ EXPOSE 8000/tcp
 
 EXPOSE 8000/tcp 9092/tcp
 
+VOLUME /opt/focalboard
 VOLUME /data
 
 CMD ["/opt/focalboard/bin/focalboard-server"]


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
There were three Possible Choices to Implement a Mount for a Config File in Docker:

1) docker run -v:
You could specify a Volume at the Start of a Container, but it has the Problem that the Folder on the Container, gets overwritten by the Host. So the Config File would have needed to be Included Explicitly. Additional, it would have needed to be separated from the Other files, because they would have been deleted otherwise in the Process of mounting. 

2) Docker Volume:
Instead of creating it at runtime, it could be created beforehand, which would solve the Above Issue and would Allow for Sharing of Files from the Container with the Host. But this would complicate the Setup needed even further. Therefore, three was chosen. 

3) Dockerfile Volume:
As the focalboard Database already gets its own Volume Created in the Dockerfile to persist, I added a Volume Creation for the Config File as well in the Dockerfile. This requires less Setup, while still allowing for Easy Access of the Config File.

The Config File Source on the Host System can be found via the following Command:
`docker inspect *Container Name* | grep -B 1 "/opt/focalboard" | grep "Source"`
Be Aware that with a WSL 2 Docker Setup under Windows, the Folder Location differs from the one displayed.

(Note: The Container needs to be Restarted for the Updates to take Place)

#### Ticket Link
Provides Solution too https://github.com/mattermost/focalboard/issues/1889


