### PR TITLE
Fix #1908. Pass version to feedback form.

### DIFF
--- a/website/site/content/fwlink/feedback-boards.html
+++ b/website/site/content/fwlink/feedback-boards.html
@@ -1,12 +1,20 @@
 <html>
     <head>
-        <meta http-equiv="refresh" content="0;url=https://docs.google.com/forms/d/e/1FAIpQLSfNLwUsG6zazDYxt_fgCV-ThH5_R9ycPTTgRTJ1DVnXuuyD7Q/viewform" />
         <title>Page Moved</title>
         <script type="text/javascript">
-            window.location.replace("https://docs.google.com/forms/d/e/1FAIpQLSfNLwUsG6zazDYxt_fgCV-ThH5_R9ycPTTgRTJ1DVnXuuyD7Q/viewform");
+            var urlParams = new URLSearchParams(window.location.search);
+            var version = urlParams.get('v');
+            var url = 'https://docs.google.com/forms/d/e/1FAIpQLSfNLwUsG6zazDYxt_fgCV-ThH5_R9ycPTTgRTJ1DVnXuuyD7Q/viewform?usp=pp_url&entry.797568877=' + version;
+
+            var link = document.getElementById("mainLink");
+            if (link && link.href) {
+                link.href = url;
+            }
+
+            window.location.replace(url);
         </script>
     </head>
     <body>
-        This page has moved. Click <a href="https://docs.google.com/forms/d/e/1FAIpQLSfNLwUsG6zazDYxt_fgCV-ThH5_R9ycPTTgRTJ1DVnXuuyD7Q/viewform">here</a> to go to the new page.
+        This page has moved. Click <a id="mainLink" href="https://docs.google.com/forms/d/e/1FAIpQLSfNLwUsG6zazDYxt_fgCV-ThH5_R9ycPTTgRTJ1DVnXuuyD7Q/viewform">here</a> to go to the new page.
     </body>
 </html>

--- a/website/site/content/fwlink/feedback-focalboard.html
+++ b/website/site/content/fwlink/feedback-focalboard.html
@@ -1,12 +1,20 @@
 <html>
     <head>
-        <meta http-equiv="refresh" content="0;url=https://docs.google.com/forms/d/e/1FAIpQLSdTq7M69Pdlz71CwucaSEG0FCK1M_WRvIbZbPr2imfT2QvUCQ/viewform" />
         <title>Page Moved</title>
         <script type="text/javascript">
-            window.location.replace("https://docs.google.com/forms/d/e/1FAIpQLSdTq7M69Pdlz71CwucaSEG0FCK1M_WRvIbZbPr2imfT2QvUCQ/viewform");
+            var urlParams = new URLSearchParams(window.location.search);
+            var version = urlParams.get('v');
+            var url = 'https://docs.google.com/forms/d/e/1FAIpQLSdTq7M69Pdlz71CwucaSEG0FCK1M_WRvIbZbPr2imfT2QvUCQ/viewform?usp=pp_url&entry.1003590493=' + version;
+
+            var link = document.getElementById("mainLink");
+            if (link && link.href) {
+                link.href = url;
+            }
+
+            window.location.replace(url);
         </script>
     </head>
     <body>
-        This page has moved. Click <a href="https://docs.google.com/forms/d/e/1FAIpQLSdTq7M69Pdlz71CwucaSEG0FCK1M_WRvIbZbPr2imfT2QvUCQ/viewform">here</a> to go to the new page.
+        This page has moved. Click <a id="mainLink" href="https://docs.google.com/forms/d/e/1FAIpQLSdTq7M69Pdlz71CwucaSEG0FCK1M_WRvIbZbPr2imfT2QvUCQ/viewform">here</a> to go to the new page.
     </body>
 </html>


### PR DESCRIPTION
#### Summary
The feedback link was already passing the version number. This change passes that along to the feedback form for recording. This update is for both Boards and Focalboard. To test, you may beed to clear your browser cache.

#### Ticket Link
#1908