### PR TITLE
Don't notify @mentioned users who are not members of channel

### DIFF
--- a/mattermost-plugin/server/notifications.go
+++ b/mattermost-plugin/server/notifications.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/mattermost/focalboard/server/services/notify"
@@ -66,4 +67,12 @@ func (da *pluginAPIAdapter) GetTeamMember(teamID string, userID string) (*model.
 
 func (da *pluginAPIAdapter) GetChannelByID(channelID string) (*model.Channel, error) {
 	return da.client.Channel.Get(channelID)
+}
+
+func (da *pluginAPIAdapter) GetChannelMember(channelID string, userID string) (*model.ChannelMember, error) {
+	return da.client.Channel.GetMember(channelID, userID)
+}
+
+func (da *pluginAPIAdapter) IsErrNotFound(err error) bool {
+	return errors.Is(err, pluginapi.ErrNotFound)
 }

--- a/server/services/notify/plugindelivery/user_test.go
+++ b/server/services/notify/plugindelivery/user_test.go
@@ -140,6 +140,14 @@ func (m pluginAPIMock) GetChannelByID(channelID string) (*mm_model.Channel, erro
 	return nil, ErrNotFound{}
 }
 
+func (m pluginAPIMock) GetChannelMember(channelID string, userID string) (*mm_model.ChannelMember, error) {
+	return nil, ErrNotFound{}
+}
+
+func (m pluginAPIMock) IsErrNotFound(err error) bool {
+	return false
+}
+
 type ErrNotFound struct{}
 
 func (e ErrNotFound) Error() string {


### PR DESCRIPTION
#### Summary
This PR ensures that users mentioned on a card that are not members of the channel do not get notified.  This is a silent fail, a if the author typed a non-existent user e.g. `@nouser`

#### Ticket Link
Fixes https://github.com/mattermost/focalboard/issues/1879
