### PR TITLE
[GH-1946] Fix losing focus for the card title in the dialog

### DIFF
--- a/webapp/src/components/markdownEditorInput/markdownEditorInput.tsx
+++ b/webapp/src/components/markdownEditorInput/markdownEditorInput.tsx
@@ -75,18 +75,14 @@ const MarkdownEditorInput = (props: Props): ReactElement => {
 
     useEffect(() => {
         if (isEditing) {
-            setEditorState(EditorState.moveSelectionToEnd(editorState))
+            if (initialText === '') {
+                setEditorState(EditorState.createEmpty())
+            } else {
+                setEditorState(EditorState.moveSelectionToEnd(editorState))
+            }
             setTimeout(() => ref.current?.focus(), 200)
         }
     }, [isEditing])
-
-    useEffect(() => {
-        if (initialText === '' && !isEditing) {
-            setTimeout(() => {
-                setEditorState(EditorState.createEmpty())
-            }, 200)
-        }
-    }, [initialText, isEditing])
 
     const customKeyBindingFn = useCallback((e: React.KeyboardEvent) => {
         if (isMentionPopoverOpen || isEmojiPopoverOpen) {

--- a/webapp/src/components/markdownEditorInput/markdownEditorInput.tsx
+++ b/webapp/src/components/markdownEditorInput/markdownEditorInput.tsx
@@ -74,27 +74,19 @@ const MarkdownEditorInput = (props: Props): ReactElement => {
     }, [])
 
     useEffect(() => {
-        setTimeout(() => ref.current?.focus(), 200)
-    })
-
-    useEffect(() => {
-        let isMounted = true
-        if (isEditing && isMounted) {
+        if (isEditing) {
             setEditorState(EditorState.moveSelectionToEnd(editorState))
-        }
-
-        return () => {
-            isMounted = false
+            setTimeout(() => ref.current?.focus(), 200)
         }
     }, [isEditing])
 
     useEffect(() => {
-        if (initialText === '') {
+        if (initialText === '' && !isEditing) {
             setTimeout(() => {
                 setEditorState(EditorState.createEmpty())
             }, 200)
         }
-    }, [initialText])
+    }, [initialText, isEditing])
 
     const customKeyBindingFn = useCallback((e: React.KeyboardEvent) => {
         if (isMentionPopoverOpen || isEmojiPopoverOpen) {


### PR DESCRIPTION
#### Summary
Don't set focus for `MarkdownEditorInput` on mount if it is not in editing state.
Also fixes `at-mention` popup appearing in top-right corner of screen after re-focus.

#### Ticket Link
Fixes #1946
Fixes #1877 