### PR TITLE
Fix #1745. Delete socket only if it exists

### DIFF
--- a/server/server/server.go
+++ b/server/server/server.go
@@ -374,8 +374,11 @@ func (s *Server) startLocalModeServer() error {
 	}
 
 	// TODO: Close and delete socket file on shutdown
-	if err := syscall.Unlink(s.config.LocalModeSocketLocation); err != nil {
-		s.logger.Error("Unable to unlink socket.", mlog.Err(err))
+	// Delete existing socket if it exists
+	if _, err := os.Stat(s.config.LocalModeSocketLocation); err == nil {
+		if err := syscall.Unlink(s.config.LocalModeSocketLocation); err != nil {
+			s.logger.Error("Unable to unlink socket.", mlog.Err(err))
+		}
 	}
 
 	socket := s.config.LocalModeSocketLocation

--- a/webapp/src/components/properties/lastModifiedAt/__snapshots__/lastModifiedAt.test.tsx.snap
+++ b/webapp/src/components/properties/lastModifiedAt/__snapshots__/lastModifiedAt.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`componnets/properties/lastModifiedAt should match snapshot 1`] = `
   <div
     class="LastModifiedAt octo-propertyvalue readonly"
   >
-    June 15, 4:22 PM
+    June 15, 2021, 4:22 PM
   </div>
 </div>
 `;

--- a/webapp/src/components/table/__snapshots__/table.test.tsx.snap
+++ b/webapp/src/components/table/__snapshots__/table.test.tsx.snap
@@ -219,7 +219,7 @@ exports[`components/table/Table extended should match snapshot with CreatedBy 1`
             <div
               class="CreatedAt octo-propertyvalue readonly"
             >
-              June 15, 4:22 PM
+              June 15, 2021, 4:22 PM
             </div>
           </div>
         </div>
@@ -307,7 +307,7 @@ exports[`components/table/Table extended should match snapshot with CreatedBy 1`
             <div
               class="CreatedAt octo-propertyvalue readonly"
             >
-              June 15, 4:22 PM
+              June 15, 2021, 4:22 PM
             </div>
           </div>
         </div>
@@ -995,7 +995,7 @@ exports[`components/table/Table extended should match snapshot with UpdatedAt 1`
             <div
               class="LastModifiedAt octo-propertyvalue readonly"
             >
-              June 20, 12:22 PM
+              June 20, 2021, 12:22 PM
             </div>
           </div>
         </div>
@@ -1083,7 +1083,7 @@ exports[`components/table/Table extended should match snapshot with UpdatedAt 1`
             <div
               class="LastModifiedAt octo-propertyvalue readonly"
             >
-              June 22, 11:23 AM
+              June 22, 2021, 11:23 AM
             </div>
           </div>
         </div>


### PR DESCRIPTION
#### Summary
Previously, we try to unlink the existing admin local socket on startup, even if the file doesn't exists. This results in a confusing error log, even though it doesn't cause a failure. The change is to only try to unlink the socket file if it exists.

#### Ticket Link
#1745