### PR TITLE
Fix #1999, fix #2002: Alt italics regex without lookbehind

### DIFF
--- a/webapp/src/components/live-markdown-plugin/inline-styles/italicStyleStrategy.ts
+++ b/webapp/src/components/live-markdown-plugin/inline-styles/italicStyleStrategy.ts
@@ -11,10 +11,22 @@ const createItalicStyleStrategy = (): InlineStrategy => {
 		'(?<=\\*\\*)(\\*)(?!\\*)(.*?[^\\*]+)(?<!\\*)\\*(?![^\\*]\\*)|(?<!\\*)(\\*)(?!\\*)(.*?[^\\*]+)(?<!\\*)\\*(?=\\*\\*)' // ***italic* and bold** **bold and *italic***
     const boldWrappedUnderscoreRegex =
 		'(?<=__)(_)(?!_)(.*?[^_]+)(?<!_)_(?![^_]_)|(?<!_)(_)(?!_)(.*?[^_]+)(?<!_)_(?=__)' // ___italic_ and bold__ __bold and _italic___
-    const italicRegex = new RegExp(
-        `${asteriskDelimitedRegex}|${underscoreDelimitedRegex}|${strongEmphasisRegex}|${boldWrappedAsteriskRegex}|${boldWrappedUnderscoreRegex}`,
-        'g',
-    )
+    let italicRegex: RegExp
+    try {
+        italicRegex = new RegExp(
+            `${asteriskDelimitedRegex}|${underscoreDelimitedRegex}|${strongEmphasisRegex}|${boldWrappedAsteriskRegex}|${boldWrappedUnderscoreRegex}`,
+            'g',
+        )
+    } catch {
+        // Safari (as of 15.2) doesn't support RegEx lookbacks (https://caniuse.com/js-regexp-lookbehind)
+        const altAsteriskDelimitedRegex = '([^\\*]|^)(\\*)([^\\*]+)(\\*)(?!\\*)' // *italic*
+        const altUnderscoreDelimitedRegex = '([^_]|^)(_)([^_]+)(_)(?!_)' // _italic_
+        // TODO: Add support for boldWrappedAsteriskRegex and boldWrappedUnderscoreRegex
+        italicRegex = new RegExp(
+            `${altAsteriskDelimitedRegex}|${altUnderscoreDelimitedRegex}|${strongEmphasisRegex}`,
+            'g',
+        )
+    }
 
     const italicDelimiterRegex = /^(\*\*\*|\*|___|_)|(\*\*\*|\*|___|_)$/g
 


### PR DESCRIPTION
#### Summary
The RegEx compiler throws an unhandled error on Safari because it doesn't support Lookbehinds. Change is to catch the exception and use an alternative, simplified regex.

Note: The alternative doesn't support complex nested bold and italics fully (e.g. ***italic* and bold** **bold and *italic***), but even the original had some issues. Those are rare, and only affect the preview (final rendering with markedjs should be correct), so leaving that for a future improvement (contributions welcome!).

#### Ticket Link
#1999 and #2002.