### PR TITLE
fix crash in DeleteBlock

### DIFF
--- a/server/api/api.go
+++ b/server/api/api.go
@@ -1594,8 +1594,8 @@ func (a *API) handleCreateSubscription(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// check for valid block
-	_, err = a.app.GetBlockWithID(*container, sub.BlockID)
-	if err != nil {
+	block, err := a.app.GetBlockWithID(*container, sub.BlockID)
+	if err != nil || block == nil {
 		a.errorResponse(w, r.URL.Path, http.StatusBadRequest, "invalid blockID", err)
 		return
 	}

--- a/server/app/blocks.go
+++ b/server/app/blocks.go
@@ -151,6 +151,11 @@ func (a *App) DeleteBlock(c store.Container, blockID string, modifiedBy string) 
 		return err
 	}
 
+	if block == nil {
+		// deleting non-existing block not considered an error
+		return nil
+	}
+
 	err = a.store.DeleteBlock(c, blockID, modifiedBy)
 	if err != nil {
 		return err

--- a/server/integrationtests/subscriptions_test.go
+++ b/server/integrationtests/subscriptions_test.go
@@ -20,10 +20,37 @@ func createTestSubscriptions(client *client.Client, num int, workspaceID string)
 		return nil, "", fmt.Errorf("cannot get current user: %w", resp.Error)
 	}
 
+	board := model.Block{
+		ID:       utils.NewID(utils.IDTypeBoard),
+		RootID:   workspaceID,
+		CreateAt: 1,
+		UpdateAt: 1,
+		Type:     model.TypeBoard,
+	}
+	boards, resp := client.InsertBlocks([]model.Block{board})
+	if resp.Error != nil {
+		return nil, "", fmt.Errorf("cannot insert test board block: %w", resp.Error)
+	}
+	board = boards[0]
+
 	for n := 0; n < num; n++ {
+		newBlock := model.Block{
+			ID:       utils.NewID(utils.IDTypeCard),
+			RootID:   board.ID,
+			CreateAt: 1,
+			UpdateAt: 1,
+			Type:     model.TypeCard,
+		}
+
+		newBlocks, resp := client.InsertBlocks([]model.Block{newBlock})
+		if resp.Error != nil {
+			return nil, "", fmt.Errorf("cannot insert test card block: %w", resp.Error)
+		}
+		newBlock = newBlocks[0]
+
 		sub := &model.Subscription{
-			BlockType:      model.TypeCard,
-			BlockID:        utils.NewID(utils.IDTypeCard),
+			BlockType:      newBlock.Type,
+			BlockID:        newBlock.ID,
 			WorkspaceID:    workspaceID,
 			SubscriberType: model.SubTypeUser,
 			SubscriberID:   user.ID,


### PR DESCRIPTION
#### Summary
Investigating a crash reported in MM cloud was traced to a DeleteBlock API call from the client.  The block was already deleted by the time the request hit the server.  I can see several ways this can happen:

- multiple people deleted a block at the same time
- single user trying to delete a block a second time before receiving the result from the first

The main issue is that `sqlstore.getBlock` returns a nil block and nil error when the block id doesn't exist.  Some callers of this API only check the error and either crash or don't crash completely by accident.  For example, `PatchBlock` will crash (or not) based on timing.  `PatchBlocks` will silently fail patching the batch and return success to the client.

A ticket exists to have store APIs that return a single entity return a `NotFound` error as needed.  This PR simply corrects one crash instance.

Note:  a `crash` in this context means an unhandled panic and the plugin no longer functioning until it is restarted.
 
#### Ticket Link
NONE