### PR TITLE
make testing all databases the default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,10 +102,10 @@ watch-single-user: modd-precheck ## Run both server and webapp in single user mo
 watch-server-test: modd-precheck ## Run server tests watching for changes
 	modd -f modd-servertest.conf
 
-server-test: ## Run server tests
+server-test: server-test-sqlite server-test-mysql server-test-postgres ## Run server tests
+
+server-test-sqlite: ## Run server tests using sqlite
 	cd server; go test -race -v -count=1 ./...
-
-
 
 server-test-mysql: export FB_UNIT_TESTING=1
 server-test-mysql: export FB_STORE_TEST_DB_TYPE=mysql


### PR DESCRIPTION
#### Summary
This PR makes testing all databases the default.  `make server-test` will test sqlite, mysql, and postgres.  

If you want the fast unit test cycle, use `make server-test-sqlite` 

#### Ticket Link
NONE