### PR TITLE
Fixed a bug where block IDs weren't being updated in `contentOrder`

### DIFF
--- a/server/api/api.go
+++ b/server/api/api.go
@@ -411,7 +411,7 @@ func (a *API) handlePostBlocks(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	blocks = model.GenerateBlockIDs(blocks)
+	blocks = model.GenerateBlockIDs(blocks, a.logger)
 
 	auditRec := a.makeAuditRecord(r, "postBlocks", audit.Fail)
 	defer a.audit.LogRecord(audit.LevelModify, auditRec)
@@ -1005,7 +1005,7 @@ func (a *API) handleImport(w http.ResponseWriter, r *http.Request) {
 
 	ctx := r.Context()
 	session := ctx.Value(sessionContextKey).(*model.Session)
-	_, err = a.app.InsertBlocks(*container, model.GenerateBlockIDs(blocks), session.UserID, false)
+	_, err = a.app.InsertBlocks(*container, model.GenerateBlockIDs(blocks, a.logger), session.UserID, false)
 	if err != nil {
 		a.errorResponse(w, r.URL.Path, http.StatusInternalServerError, "", err)
 		return


### PR DESCRIPTION
#### Summary
Fixed a bug where block IDs weren't being updated in `contentOrder`. When we updated the block IDs, we weren't updating them in `contentOrder` array, causing blocks to point to incorrect blocks belonging outside the current workspace.

#### Ticket Link
Fixes #2017 
