### PR TITLE
fix comments being set backwards

### DIFF
--- a/webapp/src/components/markdownEditorInput/markdownEditorInput.tsx
+++ b/webapp/src/components/markdownEditorInput/markdownEditorInput.tsx
@@ -47,13 +47,12 @@ const MarkdownEditorInput = (props: Props): ReactElement => {
     , [workspaceUsers])
     const ref = useRef<Editor>(null)
 
-    const generateEditorState = (text?: string) => {
-        const state = EditorState.createWithContent(ContentState.createFromText(text || ''))
-        return EditorState.moveSelectionToEnd(state)
+    const generateEditorState = (text?: string): EditorState => {
+        return EditorState.createWithContent(ContentState.createFromText(text || ''))
     }
 
     const [editorState, setEditorState] = useState(() => {
-        return generateEditorState(initialText)
+        return EditorState.moveSelectionToEnd(generateEditorState(initialText))
     })
 
     // avoiding stale closure


### PR DESCRIPTION
#### Summary
Fix for https://github.com/mattermost/focalboard/issues/2036 causes comments to be entered backwards. This PR fixes that issue while keeping the prior fix intact.

#### Ticket Link
  Fixes https://github.com/mattermost/focalboard/issues/2075

