### PR TITLE
Gh 2077 mac app update

### DIFF
--- a/webapp/src/wsclient.ts
+++ b/webapp/src/wsclient.ts
@@ -427,7 +427,6 @@ class WSClient {
         }
 
         this.sendCommand(command)
-        console.log('unsubscribeToWorkspace')
     }
 
     subscribeToWorkspace(workspaceId: string): void {
@@ -442,7 +441,6 @@ class WSClient {
         }
 
         this.sendCommand(command)
-        console.log('subscribeToWorkspace')
     }
 
     unsubscribeFromBlocks(workspaceId: string, blockIds: string[], readToken = ''): void {

--- a/webapp/src/wsclient.ts
+++ b/webapp/src/wsclient.ts
@@ -256,10 +256,10 @@ class WSClient {
 
         ws.onopen = () => {
             Utils.log('WSClient webSocket opened.')
+            this.state = 'open'
             for (const handler of this.onStateChange) {
                 handler(this, 'open')
             }
-            this.state = 'open'
         }
 
         ws.onerror = (e) => {
@@ -427,6 +427,7 @@ class WSClient {
         }
 
         this.sendCommand(command)
+        console.log('unsubscribeToWorkspace')
     }
 
     subscribeToWorkspace(workspaceId: string): void {
@@ -441,6 +442,7 @@ class WSClient {
         }
 
         this.sendCommand(command)
+        console.log('subscribeToWorkspace')
     }
 
     unsubscribeFromBlocks(workspaceId: string, blockIds: string[], readToken = ''): void {


### PR DESCRIPTION
#### Summary
This appears to be a timing issue in JS / React:
1. UseEffect in Boardpage.tsx subscribes and unsubscribes to workspace changes on the websocket (wsClient)
2. The cleanup routine returned from useEffect does the unsubscribe
3. With the Mac App (single-user), there's a pattern of useEffect, useEffect-cleanup, useEffect
4. However, in that last useEffect call, wsClient.state is 'init' (on [this line](https://github.com/mattermost/focalboard/blob/main/webapp/src/pages/boardPage.tsx#L206)), so subscribe isn't called
5. This is because wsClient is still somewhere in the [opening routine](https://github.com/mattermost/focalboard/blob/main/webapp/src/wsclient.ts#L259).

The fix is to update `wsClient.state` at the beginning of `ws.onopen`.

I've only observed this happening in the Mac App, and not in Safari against Personal Server. It's probably due to random differences in timing. There ultimately might be a more robust way to handle "re-entering" wsclient state changes, or change subscriptions.

#### Ticket Link
#2077