### PR TITLE
updated fix for comments display backwards

### DIFF
--- a/webapp/src/components/markdownEditorInput/markdownEditorInput.tsx
+++ b/webapp/src/components/markdownEditorInput/markdownEditorInput.tsx
@@ -47,12 +47,13 @@ const MarkdownEditorInput = (props: Props): ReactElement => {
     , [workspaceUsers])
     const ref = useRef<Editor>(null)
 
-    const generateEditorState = (text?: string): EditorState => {
-        return EditorState.createWithContent(ContentState.createFromText(text || ''))
+    const generateEditorState = (text?: string) => {
+        const state = EditorState.createWithContent(ContentState.createFromText(text || ''))
+        return EditorState.moveSelectionToEnd(state)
     }
 
     const [editorState, setEditorState] = useState(() => {
-        return EditorState.moveSelectionToEnd(generateEditorState(initialText))
+        return generateEditorState(initialText)
     })
 
     // avoiding stale closure
@@ -91,7 +92,7 @@ const MarkdownEditorInput = (props: Props): ReactElement => {
             }
             setTimeout(() => ref.current?.focus(), 200)
         }
-    }, [isEditing])
+    }, [isEditing, initialText])
 
     const customKeyBindingFn = useCallback((e: React.KeyboardEvent) => {
         if (isMentionPopoverOpen || isEmojiPopoverOpen) {


### PR DESCRIPTION
#### Summary
Fix for https://github.com/mattermost/focalboard/issues/2036 causes comments to be entered backwards. This PR fixes that issue while keeping the prior fix intact.

Reverts https://github.com/mattermost/focalboard/issues/2076

#### Ticket Link
  Fixes https://github.com/mattermost/focalboard/issues/2075

