### PR TITLE
Moving the history instance creation after the plugin initialization (to honor the SiteURL config)

### DIFF
--- a/mattermost-plugin/webapp/webpack.config.js
+++ b/mattermost-plugin/webapp/webpack.config.js
@@ -118,7 +118,7 @@ module.exports = {
                         options: {
                             name: '[name].[ext]',
                             outputPath: 'static',
-                            publicPath: '/plugins/focalboard/static/',
+                            publicPath: '/static/',
                         },
                     },
                     {

--- a/webapp/src/components/__snapshots__/shareBoardComponent.test.tsx.snap
+++ b/webapp/src/components/__snapshots__/shareBoardComponent.test.tsx.snap
@@ -41,11 +41,11 @@ exports[`src/components/shareBoardComponent return shareBoardComponent and click
       >
         <a
           class="shareUrl"
-          href="http://localhost/plugins/focalboard/workspace/1/shared/1/1?r=oneToken"
+          href="http://localhost/workspace/1/shared/1/1?r=oneToken"
           rel="noreferrer"
           target="_blank"
         >
-          http://localhost/plugins/focalboard/workspace/1/shared/1/1?r=oneToken
+          http://localhost/workspace/1/shared/1/1?r=oneToken
         </a>
         <button
           type="button"
@@ -112,11 +112,11 @@ exports[`src/components/shareBoardComponent return shareBoardComponent and click
       >
         <a
           class="shareUrl"
-          href="http://localhost/plugins/focalboard/workspace/1/shared/1/1?r=oneToken"
+          href="http://localhost/workspace/1/shared/1/1?r=oneToken"
           rel="noreferrer"
           target="_blank"
         >
-          http://localhost/plugins/focalboard/workspace/1/shared/1/1?r=oneToken
+          http://localhost/workspace/1/shared/1/1?r=oneToken
         </a>
         <button
           type="button"
@@ -183,11 +183,11 @@ exports[`src/components/shareBoardComponent return shareBoardComponent and click
       >
         <a
           class="shareUrl"
-          href="http://localhost/plugins/focalboard/workspace/1/shared/1/1?r=oneToken"
+          href="http://localhost/workspace/1/shared/1/1?r=oneToken"
           rel="noreferrer"
           target="_blank"
         >
-          http://localhost/plugins/focalboard/workspace/1/shared/1/1?r=oneToken
+          http://localhost/workspace/1/shared/1/1?r=oneToken
         </a>
         <button
           type="button"
@@ -254,11 +254,11 @@ exports[`src/components/shareBoardComponent return shareBoardComponent and click
       >
         <a
           class="shareUrl"
-          href="http://localhost/plugins/focalboard/workspace/1/shared/1/1?r=aToken"
+          href="http://localhost/workspace/1/shared/1/1?r=aToken"
           rel="noreferrer"
           target="_blank"
         >
-          http://localhost/plugins/focalboard/workspace/1/shared/1/1?r=aToken
+          http://localhost/workspace/1/shared/1/1?r=aToken
         </a>
         <button
           type="button"
@@ -366,11 +366,82 @@ exports[`src/components/shareBoardComponent should match snapshot with sharing 1
       >
         <a
           class="shareUrl"
-          href="http://localhost/plugins/focalboard/workspace/1/shared/1/1?r=oneToken"
+          href="http://localhost/workspace/1/shared/1/1?r=oneToken"
           rel="noreferrer"
           target="_blank"
         >
-          http://localhost/plugins/focalboard/workspace/1/shared/1/1?r=oneToken
+          http://localhost/workspace/1/shared/1/1?r=oneToken
+        </a>
+        <button
+          type="button"
+        >
+          <span>
+            Copy link
+          </span>
+        </button>
+      </div>
+      <div
+        class="row"
+      >
+        <button
+          type="button"
+        >
+          <span>
+            Regenerate token
+          </span>
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`src/components/shareBoardComponent should match snapshot with sharing and subpath 1`] = `
+<div>
+  <div
+    class="Modal bottom"
+  >
+    <div
+      class="toolbar hideOnWidescreen"
+    >
+      <button
+        aria-label="Close"
+        class="Button IconButton"
+        title="Close"
+        type="button"
+      >
+        <i
+          class="CompassIcon icon-close CloseIcon"
+        />
+      </button>
+    </div>
+    <div
+      class="ShareBoardComponent"
+    >
+      <div
+        class="row"
+      >
+        <div>
+          Anyone with the link can view this board and all cards in it.
+        </div>
+        <div
+          class="Switch on"
+        >
+          <div
+            class="octo-switch-inner"
+          />
+        </div>
+      </div>
+      <div
+        class="row"
+      >
+        <a
+          class="shareUrl"
+          href="http://localhost/test-subpath/plugins/boards/workspace/1/shared/1/1?r=oneToken"
+          rel="noreferrer"
+          target="_blank"
+        >
+          http://localhost/test-subpath/plugins/boards/workspace/1/shared/1/1?r=oneToken
         </a>
         <button
           type="button"
@@ -442,6 +513,77 @@ exports[`src/components/shareBoardComponent should match snapshot with sharing a
           target="_blank"
         >
           http://localhost/shared/1/1?r=oneToken
+        </a>
+        <button
+          type="button"
+        >
+          <span>
+            Copy link
+          </span>
+        </button>
+      </div>
+      <div
+        class="row"
+      >
+        <button
+          type="button"
+        >
+          <span>
+            Regenerate token
+          </span>
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`src/components/shareBoardComponent should match snapshot with sharing and without workspaceId and subpath 1`] = `
+<div>
+  <div
+    class="Modal bottom"
+  >
+    <div
+      class="toolbar hideOnWidescreen"
+    >
+      <button
+        aria-label="Close"
+        class="Button IconButton"
+        title="Close"
+        type="button"
+      >
+        <i
+          class="CompassIcon icon-close CloseIcon"
+        />
+      </button>
+    </div>
+    <div
+      class="ShareBoardComponent"
+    >
+      <div
+        class="row"
+      >
+        <div>
+          Anyone with the link can view this board and all cards in it.
+        </div>
+        <div
+          class="Switch on"
+        >
+          <div
+            class="octo-switch-inner"
+          />
+        </div>
+      </div>
+      <div
+        class="row"
+      >
+        <a
+          class="shareUrl"
+          href="http://localhost/test-subpath/plugins/boards/shared/1/1?r=oneToken"
+          rel="noreferrer"
+          target="_blank"
+        >
+          http://localhost/test-subpath/plugins/boards/shared/1/1?r=oneToken
         </a>
         <button
           type="button"

--- a/webapp/src/components/shareBoardComponent.tsx
+++ b/webapp/src/components/shareBoardComponent.tsx
@@ -84,13 +84,13 @@ const ShareBoardComponent = React.memo((props: Props): JSX.Element => {
             viewId: match.params.viewId,
             workspaceId: match.params.workspaceId,
         })
-        shareUrl.pathname = newPath
+        shareUrl.pathname = Utils.buildURL(newPath)
     } else {
         const newPath = generatePath('/shared/:boardId/:viewId', {
             boardId: match.params.boardId,
             viewId: match.params.viewId,
         })
-        shareUrl.pathname = newPath
+        shareUrl.pathname = Utils.buildURL(newPath)
     }
 
     return (

--- a/webapp/src/components/shareBoardComponent.tsx
+++ b/webapp/src/components/shareBoardComponent.tsx
@@ -79,7 +79,7 @@ const ShareBoardComponent = React.memo((props: Props): JSX.Element => {
     shareUrl.searchParams.set('r', readToken)
 
     if (match.params.workspaceId) {
-        const newPath = generatePath('/plugins/focalboard/workspace/:workspaceId/shared/:boardId/:viewId', {
+        const newPath = generatePath('/workspace/:workspaceId/shared/:boardId/:viewId', {
             boardId: match.params.boardId,
             viewId: match.params.viewId,
             workspaceId: match.params.workspaceId,

--- a/webapp/src/pages/welcome/__snapshots__/welcomePage.test.tsx.snap
+++ b/webapp/src/pages/welcome/__snapshots__/welcomePage.test.tsx.snap
@@ -19,12 +19,54 @@ exports[`pages/welcome Welcome Page shows Explore Page 1`] = `
       <img
         alt="Boards Welcome Image"
         class="WelcomePage__image WelcomePage__image--large"
-        src="test-file-stub"
+        src="http://localhost/test-file-stub"
       />
       <img
         alt="Boards Welcome Image"
         class="WelcomePage__image WelcomePage__image--small"
-        src="test-file-stub"
+        src="http://localhost/test-file-stub"
+      />
+      <button
+        class="Button filled size--large"
+        type="button"
+      >
+        <span>
+          Explore
+        </span>
+        <i
+          class="CompassIcon icon-chevron-right Icon Icon--right"
+        />
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`pages/welcome Welcome Page shows Explore Page with subpath 1`] = `
+<div>
+  <div
+    class="WelcomePage"
+  >
+    <div>
+      <h1
+        class="text-heading9"
+      >
+        Welcome To Boards
+      </h1>
+      <div
+        class="WelcomePage__subtitle"
+      >
+        Boards is a project management tool that helps define, organize, track and manage work across teams, using a familiar kanban board view
+      </div>
+      <img
+        alt="Boards Welcome Image"
+        class="WelcomePage__image WelcomePage__image--large"
+        src="http://localhost/subpath/test-file-stub"
+      />
+      <img
+        alt="Boards Welcome Image"
+        class="WelcomePage__image WelcomePage__image--small"
+        src="http://localhost/subpath/test-file-stub"
       />
       <button
         class="Button filled size--large"

--- a/webapp/src/pages/welcome/welcomePage.test.tsx
+++ b/webapp/src/pages/welcome/welcomePage.test.tsx
@@ -40,7 +40,7 @@ describe('pages/welcome', () => {
     })
 
     test('Welcome Page shows Explore Page with subpath', () => {
-        w.baseURL = "/subpath"
+        w.baseURL = '/subpath'
         const {container} = render(wrapIntl(
             <Router history={history}>
                 <WelcomePage/>

--- a/webapp/src/pages/welcome/welcomePage.test.tsx
+++ b/webapp/src/pages/welcome/welcomePage.test.tsx
@@ -16,13 +16,31 @@ import {wrapIntl} from '../../testUtils'
 
 import WelcomePage from './welcomePage'
 
+const w = (window as any)
+const oldBaseURL = w.baseURL
+
 beforeEach(() => {
     UserSettings.welcomePageViewed = null
+})
+
+afterEach(() => {
+    w.baseURL = oldBaseURL
 })
 
 describe('pages/welcome', () => {
     const history = createMemoryHistory()
     test('Welcome Page shows Explore Page', () => {
+        const {container} = render(wrapIntl(
+            <Router history={history}>
+                <WelcomePage/>
+            </Router>,
+        ))
+        expect(screen.getByText('Explore')).toBeDefined()
+        expect(container).toMatchSnapshot()
+    })
+
+    test('Welcome Page shows Explore Page with subpath', () => {
+        w.baseURL = "/subpath"
         const {container} = render(wrapIntl(
             <Router history={history}>
                 <WelcomePage/>

--- a/webapp/src/pages/welcome/welcomePage.tsx
+++ b/webapp/src/pages/welcome/welcomePage.tsx
@@ -11,6 +11,7 @@ import BoardWelcomeSmallPNG from '../../../static/boards-welcome-small.png'
 import Button from '../../widgets/buttons/button'
 import CompassIcon from '../../widgets/icons/compassIcon'
 import {UserSettings} from '../../userSettings'
+import {Utils} from '../../utils'
 
 import './welcomePage.scss'
 
@@ -52,14 +53,14 @@ const WelcomePage = React.memo(() => {
 
                 {/* This image will be rendered on large screens over 2000px */}
                 <img
-                    src={BoardWelcomePNG}
+                    src={Utils.buildURL(BoardWelcomePNG, true)}
                     className='WelcomePage__image WelcomePage__image--large'
                     alt='Boards Welcome Image'
                 />
 
                 {/* This image will be rendered on small screens below 2000px */}
                 <img
-                    src={BoardWelcomeSmallPNG}
+                    src={Utils.buildURL(BoardWelcomeSmallPNG, true)}
                     className='WelcomePage__image WelcomePage__image--small'
                     alt='Boards Welcome Image'
                 />

--- a/webapp/src/utils.ts
+++ b/webapp/src/utils.ts
@@ -36,7 +36,7 @@ enum IDType {
 class Utils {
     static createGuid(idType: IDType): string {
         const data = Utils.randomArray(16)
-        return idType + this.base32encode(data, false)
+        return idType + Utils.base32encode(data, false)
     }
 
     static blockTypeToIDType(blockType: string | undefined): IDType {
@@ -128,10 +128,10 @@ class Utils {
     static canvas : HTMLCanvasElement | undefined
     static getTextWidth(displayText: string, fontDescriptor: string): number {
         if (displayText !== '') {
-            if (!this.canvas) {
-                this.canvas = document.createElement('canvas') as HTMLCanvasElement
+            if (!Utils.canvas) {
+                Utils.canvas = document.createElement('canvas') as HTMLCanvasElement
             }
-            const context = this.canvas.getContext('2d')
+            const context = Utils.canvas.getContext('2d')
             if (context) {
                 context.font = fontDescriptor
                 const metrics = context.measureText(displayText)
@@ -481,7 +481,7 @@ class Utils {
     }
 
     static getFrontendBaseURL(absolute?: boolean): string {
-        let frontendBaseURL = window.frontendBaseURL || this.getBaseURL(absolute)
+        let frontendBaseURL = window.frontendBaseURL || Utils.getBaseURL(absolute)
         frontendBaseURL = frontendBaseURL.replace(/\/+$/, '')
         if (frontendBaseURL.indexOf('/') === 0) {
             frontendBaseURL = frontendBaseURL.slice(1)
@@ -493,7 +493,7 @@ class Utils {
     }
 
     static buildURL(path: string, absolute?: boolean): string {
-        const baseURL = this.getBaseURL()
+        const baseURL = Utils.getBaseURL()
         let finalPath = baseURL + path
         if (path.indexOf('/') !== 0) {
             finalPath = baseURL + '/' + path


### PR DESCRIPTION
Fixes #1766
Fixes #2032

This fixes the problem, but doesn't sorted out the multiple ways of getting the URLs.