### PR TITLE
Fix #2136. Show release month+year for version.

### DIFF
--- a/webapp/src/components/__snapshots__/topBar.test.tsx.snap
+++ b/webapp/src/components/__snapshots__/topBar.test.tsx.snap
@@ -18,8 +18,9 @@ exports[`src/components/topBar should match snapshot for focalboardPlugin 1`] = 
     >
       <div
         class="version"
+        title="v1.0.0"
       >
-        v1.0.0
+        Feb 2022
       </div>
     </div>
   </div>

--- a/webapp/src/components/__snapshots__/workspace.test.tsx.snap
+++ b/webapp/src/components/__snapshots__/workspace.test.tsx.snap
@@ -54,8 +54,9 @@ exports[`src/components/workspace return workspace and showcard 1`] = `
                     >
                       <div
                         class="version"
+                        title="v1.0.0"
                       >
-                        v1.0.0
+                        Feb 2022
                       </div>
                     </div>
                   </div>
@@ -1213,8 +1214,9 @@ exports[`src/components/workspace should match snapshot 1`] = `
                     >
                       <div
                         class="version"
+                        title="v1.0.0"
                       >
-                        v1.0.0
+                        Feb 2022
                       </div>
                     </div>
                   </div>

--- a/webapp/src/components/sidebar/__snapshots__/sidebar.test.tsx.snap
+++ b/webapp/src/components/sidebar/__snapshots__/sidebar.test.tsx.snap
@@ -51,8 +51,9 @@ exports[`components/sidebarSidebar global templates 1`] = `
                   >
                     <div
                       class="version"
+                      title="v0.14.0"
                     >
-                      v0.14.0
+                      Feb 2022
                     </div>
                   </div>
                 </div>
@@ -235,8 +236,9 @@ exports[`components/sidebarSidebar sidebar hidden 1`] = `
                   >
                     <div
                       class="version"
+                      title="v0.14.0"
                     >
-                      v0.14.0
+                      Feb 2022
                     </div>
                   </div>
                 </div>
@@ -609,8 +611,9 @@ exports[`components/sidebarSidebar sidebar in dashboard page 1`] = `
                   >
                     <div
                       class="version"
+                      title="v0.14.0"
                     >
-                      v0.14.0
+                      Feb 2022
                     </div>
                   </div>
                 </div>

--- a/webapp/src/components/sidebar/sidebarUserMenu.tsx
+++ b/webapp/src/components/sidebar/sidebarUserMenu.tsx
@@ -43,8 +43,11 @@ const SidebarUserMenu = React.memo(() => {
                             <FocalboardLogoIcon/>
                             <span>{'Focalboard'}</span>
                             <div className='versionFrame'>
-                                <div className='version'>
-                                    {`v${Constants.versionString}`}
+                                <div
+                                    className='version'
+                                    title={`v${Constants.versionString}`}
+                                >
+                                    {Constants.versionDisplayString}
                                 </div>
                             </div>
                         </div>

--- a/webapp/src/components/topBar.tsx
+++ b/webapp/src/components/topBar.tsx
@@ -29,8 +29,11 @@ const TopBar = React.memo((): JSX.Element => {
                     />
                 </a>
                 <div className='versionFrame'>
-                    <div className='version'>
-                        {`v${Constants.versionString}`}
+                    <div
+                        className='version'
+                        title={`v${Constants.versionString}`}
+                    >
+                        {Constants.versionDisplayString}
                     </div>
                 </div>
             </div>

--- a/webapp/src/constants.ts
+++ b/webapp/src/constants.ts
@@ -21,6 +21,7 @@ class Constants {
     static readonly badgesColumnId = '__badges'
 
     static readonly versionString = '0.14.0'
+    static readonly versionDisplayString = 'Feb 2022'
 
     static readonly languages = [
         {

--- a/webapp/src/pages/dashboard/__snapshots__/dashboardPage.test.tsx.snap
+++ b/webapp/src/pages/dashboard/__snapshots__/dashboardPage.test.tsx.snap
@@ -54,8 +54,9 @@ exports[`pages/dashboard/DashboardPage base case 1`] = `
                     >
                       <div
                         class="version"
+                        title="v0.14.0"
                       >
-                        v0.14.0
+                        Feb 2022
                       </div>
                     </div>
                   </div>


### PR DESCRIPTION
#### Summary
Replace the version display with the release Month+year. Show the version number on hover.

<img width="177" alt="Screen Shot 2022-01-18 at 10 23 08 AM" src="https://user-images.githubusercontent.com/46905241/149996171-83cd9581-1f13-4bdd-b27b-19d78fb51b0e.png">

#### Ticket Link
#2136