### PR TITLE
Remove link to deleted css file

### DIFF
--- a/webapp/html-templates/page.ejs
+++ b/webapp/html-templates/page.ejs
@@ -9,7 +9,6 @@
 
     <script>window.baseURL = '{{.BaseURL}}'</script>
     <link rel="icon" href="{{.BaseURL}}/static/favicon.svg?v=1" />
-    <link rel="stylesheet" href="{{.BaseURL}}/static/easymde.min.css">
 </head>
 
 <body class="focalboard-body">


### PR DESCRIPTION
#### Summary
There is no file `easymde.min.css` after switching from `react-simplemde-editor` to `draft-js`

#### Ticket Link
No ticket.
