### PR TITLE
Update readme: Personal Desktop links

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,10 @@ Focalboard can also be installed as a standalone [personal server](https://www.f
 
 ### Focalboard Personal Desktop (Windows, Mac or Linux Desktop)
 
-Try out **Focalboard Personal Desktop** by going to the Windows Store or the Apple AppStore, searching for `Focalboard` and installing to run the compiled version locally.
-
-If you're running a Linux Desktop, [download the latest `focalboard-linux.tar.gz` release](https://github.com/mattermost/focalboard/releases), unpack the `.tar.gz` archive, and open `focalboard-app` from the `focalboard-app` folder.
-
-Note: For Windows and Mac users, while we don't yet offer **Focalboard Personal Desktop** outside of Store-based installs, it is in [consideration for the future](https://github.com/mattermost/focalboard/issues/99) (please upvote the ticket if you're interested in this addition).
+Try out the single-user **Focalboard Personal Desktop**:
+* macOS: Download from the [Mac App Store](https://apps.apple.com/us/app/focalboard-insiders/id1556908618?mt=12).
+* Windows: Download from the [Windows App Store](https://www.microsoft.com/store/productId/9NLN2T0SX9VF) or download `focalboard-win.zip` from the [latest release](https://github.com/mattermost/focalboard/releases), unpack, and run `Focalboard.exe`
+* Linux Desktop: Download `focalboard-linux.tar.gz` from the [latest release](https://github.com/mattermost/focalboard/releases), unpack, and open `focalboard-app`
 
 ### Mattermost Boards
 


### PR DESCRIPTION
#### Summary
Cleaned up the Try Focalboard section, and added direct links to the Mac and Windows App Stores.
