### PR TITLE
Disable `max-lines` ESLint rule

### DIFF
--- a/webapp/.eslintrc.json
+++ b/webapp/.eslintrc.json
@@ -25,6 +25,7 @@
     }
   },
   "rules": {
+		"max-lines": "off",
     "no-unused-expressions": 0,
     "babel/no-unused-expressions": [2, {"allowShortCircuit": true}],
     "eol-last": ["error", "always"],

--- a/webapp/.eslintrc.json
+++ b/webapp/.eslintrc.json
@@ -25,7 +25,7 @@
     }
   },
   "rules": {
-		"max-lines": "off",
+    "max-lines": "off",
     "no-unused-expressions": 0,
     "babel/no-unused-expressions": [2, {"allowShortCircuit": true}],
     "eol-last": ["error", "always"],


### PR DESCRIPTION
#### Summary
There are several webapp files that exceed the default ESLint max-lines rule.  This PR disables the rule to avoid polluting the VSCode problems view with these warnings.

#### Ticket Link
NONE