### PR TITLE
Don't log error msg when multiple nodes try processing a notification hint

### DIFF
--- a/server/services/notify/notifysubscriptions/notifier.go
+++ b/server/services/notify/notifysubscriptions/notifier.go
@@ -129,7 +129,11 @@ func (n *notifier) notify() {
 
 	hint, err = n.store.GetNextNotificationHint(true)
 	if err != nil {
-		// try again later
+		if store.IsErrNotFound(err) {
+			// Expected when multiple nodes in a cluster try to process the same hint at the same time.
+			// This simply means the other node won. Returning here will simply try fetching another hint.
+			return
+		}
 		n.logger.Error("notify - error fetching next notification", mlog.Err(err))
 		return
 	}

--- a/server/services/store/sqlstore/notificationhints.go
+++ b/server/services/store/sqlstore/notificationhints.go
@@ -195,7 +195,7 @@ func (s *SQLStore) getNextNotificationHint(db sq.BaseRunner, remove bool) (*mode
 		if rows == 0 {
 			// another node likely has grabbed this hint for processing concurrently; let that node handle it
 			// and we'll return an error here so we try again.
-			return nil, fmt.Errorf("cannot delete missing hint while getting next notification hint: %w", err)
+			return nil, store.NewErrNotFound(hint.BlockID)
 		}
 	}
 


### PR DESCRIPTION
#### Summary
This PR fixes an issue where errors are logged when multiple nodes in a cluster try to process a notification hint at the same time. This is an expected condition and should not error.

#### Ticket Link
Fixes https://github.com/mattermost/focalboard/issues/2165

Issue was reported here: https://community.mattermost.com/core/pl/r7zfhdrqnidu8pdf9tk8dgr4ro