### PR TITLE
Update property template mutators to use boards API

### DIFF
--- a/webapp/src/blocks/__snapshots__/board.test.ts.snap
+++ b/webapp/src/blocks/__snapshots__/board.test.ts.snap
@@ -1,5 +1,115 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`board tests correctly generate patches for boards and blocks should add fields on update and remove it in the undo 1`] = `
+Array [
+  Object {
+    "blockIDs": Array [
+      "7ppxdyor67u3weof591f9ot736a",
+    ],
+    "blockPatches": Array [
+      Object {
+        "deletedFields": Array [],
+        "updatedFields": Object {
+          "newField": "new field",
+        },
+      },
+    ],
+    "boardIDs": Array [
+      "brqajobpz4uhu774rbuq4i5enmy",
+    ],
+    "boardPatches": Array [
+      Object {
+        "deletedCardProperties": Array [],
+        "deletedColumnCalculations": Array [],
+        "deletedProperties": Array [],
+        "updatedCardProperties": Array [],
+        "updatedColumnCalculations": Object {},
+        "updatedProperties": Object {},
+      },
+    ],
+  },
+  Object {
+    "blockIDs": Array [
+      "7ppxdyor67u3weof591f9ot736a",
+    ],
+    "blockPatches": Array [
+      Object {
+        "deletedFields": Array [
+          "newField",
+        ],
+        "updatedFields": Object {},
+      },
+    ],
+    "boardIDs": Array [
+      "brqajobpz4uhu774rbuq4i5enmy",
+    ],
+    "boardPatches": Array [
+      Object {
+        "deletedCardProperties": Array [],
+        "deletedColumnCalculations": Array [],
+        "deletedProperties": Array [],
+        "updatedCardProperties": Array [],
+        "updatedColumnCalculations": Object {},
+        "updatedProperties": Object {},
+      },
+    ],
+  },
+]
+`;
+
+exports[`board tests correctly generate patches for boards and blocks should generate two empty patches for the same board and block 1`] = `
+Array [
+  Object {
+    "blockIDs": Array [
+      "7b43sk681o86ckkqdt9h3yrod5c",
+    ],
+    "blockPatches": Array [
+      Object {
+        "deletedFields": Array [],
+        "updatedFields": Object {},
+      },
+    ],
+    "boardIDs": Array [
+      "brqajobpz4uhu774rbuq4i5enmy",
+    ],
+    "boardPatches": Array [
+      Object {
+        "deletedCardProperties": Array [],
+        "deletedColumnCalculations": Array [],
+        "deletedProperties": Array [],
+        "updatedCardProperties": Array [],
+        "updatedColumnCalculations": Object {},
+        "updatedProperties": Object {},
+      },
+    ],
+  },
+  Object {
+    "blockIDs": Array [
+      "7b43sk681o86ckkqdt9h3yrod5c",
+    ],
+    "blockPatches": Array [
+      Object {
+        "deletedFields": Array [],
+        "updatedFields": Object {},
+      },
+    ],
+    "boardIDs": Array [
+      "brqajobpz4uhu774rbuq4i5enmy",
+    ],
+    "boardPatches": Array [
+      Object {
+        "deletedCardProperties": Array [],
+        "deletedColumnCalculations": Array [],
+        "deletedProperties": Array [],
+        "updatedCardProperties": Array [],
+        "updatedColumnCalculations": Object {},
+        "updatedProperties": Object {},
+      },
+    ],
+  },
+]
+`;
+
 exports[`board tests correctly generate patches from two boards should add card properties on the redo and remove them on the undo 1`] = `
 Array [
   Object {

--- a/webapp/src/blocks/board.test.ts
+++ b/webapp/src/blocks/board.test.ts
@@ -2,7 +2,8 @@
 // See LICENSE.txt for license information.
 import {TestBlockFactory} from '../test/testBlockFactory'
 
-import {createPatchesFromBoards, createBoard, IPropertyTemplate} from './board'
+import {createPatchesFromBoards, createBoard, IPropertyTemplate, createPatchesFromBoardsAndBlocks} from './board'
+import {createBlock} from './block'
 
 describe('board tests', () => {
     describe('correctly generate patches from two boards', () => {
@@ -15,12 +16,12 @@ describe('board tests', () => {
         it('should add properties on the update patch and remove them on the undo', () => {
             const board = TestBlockFactory.createBoard()
             board.properties = {
-                "prop1": "val1",
-                "prop2": "val2",
+                prop1: 'val1',
+                prop2: 'val2',
             }
             const oldBoard = createBoard(board)
             oldBoard.properties = {
-                "prop2": "val2",
+                prop2: 'val2',
             }
 
             const result = createPatchesFromBoards(board, oldBoard)
@@ -98,13 +99,32 @@ describe('board tests', () => {
             const board = TestBlockFactory.createBoard()
             const oldBoard = createBoard(board)
             board.columnCalculations = {
-                "cal1": "val1",
+                cal1: 'val1',
             }
             oldBoard.columnCalculations = {
-                "cal1": "another-val1",
+                cal1: 'another-val1',
             }
 
             const result = createPatchesFromBoards(board, oldBoard)
+            expect(result).toMatchSnapshot()
+        })
+    })
+
+    describe('correctly generate patches for boards and blocks', () => {
+        const board = TestBlockFactory.createBoard()
+        const card = TestBlockFactory.createCard()
+
+        it('should generate two empty patches for the same board and block', () => {
+            const result = createPatchesFromBoardsAndBlocks(board, board, [card.id], [card], [card])
+            expect(result).toMatchSnapshot()
+        })
+
+        it('should add fields on update and remove it in the undo', () => {
+            const oldBlock = TestBlockFactory.createText(card)
+            const newBlock = createBlock(oldBlock)
+            newBlock.fields.newField = 'new field'
+
+            const result = createPatchesFromBoardsAndBlocks(board, board, [newBlock.id], [newBlock], [oldBlock])
             expect(result).toMatchSnapshot()
         })
     })

--- a/webapp/src/octoClient.ts
+++ b/webapp/src/octoClient.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 import {Block, BlockPatch} from './blocks/block'
-import {Board, BoardsAndBlocks, BoardPatch, BoardMember} from './blocks/board'
+import {Board, BoardsAndBlocks, BoardsAndBlocksPatch, BoardPatch, BoardMember} from './blocks/board'
 import {ISharing} from './blocks/sharing'
 import {OctoUtils} from './octoUtils'
 import {IUser, UserWorkspace} from './user'
@@ -334,11 +334,24 @@ class OctoClient {
     async deleteBoardsAndBlocks(boardIds: string[], blockIds: string[]): Promise<Response> {
         Utils.log(`deleteBoardsAndBlocks: ${boardIds.length} board(s) ${blockIds.length} block(s)`)
         Utils.log(`\t Boards ${boardIds.join(', ')}`)
-        Utils.log(`\t Blocks ${boardIds.join(', ')}`)
+        Utils.log(`\t Blocks ${blockIds.join(', ')}`)
 
         const body = JSON.stringify({boards: boardIds, blocks: blockIds})
         return fetch(this.getBaseURL() + '/api/v1/boards-and-blocks', {
             method: 'DELETE',
+            headers: this.headers(),
+            body,
+        })
+    }
+
+    async patchBoardsAndBlocks(babp: BoardsAndBlocksPatch): Promise<Response> {
+        Utils.log(`patchBoardsAndBlocks: ${babp.boardIDs.length} board(s) ${babp.blockIDs.length} block(s)`)
+        Utils.log(`\t Board ${babp.boardIDs.join(', ')}`)
+        Utils.log(`\t Blocks ${babp.blockIDs.join(', ')}`)
+
+        const body = JSON.stringify(babp)
+        return fetch(this.getBaseURL() + '/api/v1/boards-and-blocks', {
+            method: 'PATCH',
             headers: this.headers(),
             body,
         })


### PR DESCRIPTION
#### Summary
Reimplements the function `insertPropertyTemplate`, `duplicatePropertyTemplate`, and `changePropertyTypeAndName` to use the boards API.

Also completed the implementation of patchBlocksAndBoards() and use that implementation.

#### Ticket Link
https://community.mattermost.com/boards/workspace/qgsck6cts3fwpqwyjiupjm5cde/b4ctmm917q3rzdfi451qtuxjzcw/v3ng1gwe7wtfaijukrhp8siwcpy/ci5zu37mhw7bjbe6ppyi6ra3jow

