### PR TITLE
Website 012422 download links

### DIFF
--- a/website/site/content/download/mattermost/_index.md
+++ b/website/site/content/download/mattermost/_index.md
@@ -5,9 +5,9 @@ section: "download"
 weight: 2
 ---
 
-Focalboard is installed with Mattermost v6.0, where it's called Boards. To access and use Boards, [install or upgrade to Mattermost v6.0 or later](https://mattermost.com/get-started/?utm_source=focalboard&utm_campaign=focalboard). Then, select the Product menu in the top left corner of Mattermost and choose **Boards**.
+Focalboard is installed with Mattermost v6 and later, where it's called Boards. You can [install Mattermost as a self-hosted server](https://mattermost.com/deploy/?utm_source=focalboard&utm_campaign=focalboard) or [sign up for Mattermost Cloud](https://customers.mattermost.com/cloud/signup?utm_source=focalboard&utm_campaign=focalboard).
 
-No additional server or web-proxy configuration is required.
+## Mattermost Boards usage notes:
 
 ### Enable shared boards
 

--- a/website/site/content/download/personal-edition/_index.md
+++ b/website/site/content/download/personal-edition/_index.md
@@ -7,4 +7,7 @@ weight: 1
 
 If you are new to Focalboard, [Personal Desktop](desktop) is the fastest way to try it out.
 
-You can also set up [Personal Server](ubuntu) on Ubuntu to use it with your team, and import boards from Personal Desktop.
+To use it with your team, use [Mattermost Boards](../mattermost).
+You can import boards from Personal Desktop to Mattermost Boards.
+
+You can also set up the standalone Development or Personal Server on [Ubuntu](ubuntu) or with [Docker](docker).

--- a/website/site/content/download/personal-edition/desktop.md
+++ b/website/site/content/download/personal-edition/desktop.md
@@ -11,9 +11,13 @@ Personal Desktop is a fully contained, standalone app meant for a single user, t
 
 Download Focalboard from the [Mac App Store](https://apps.apple.com/app/apple-store/id1556908618?pt=2114704&ct=website&mt=8).
 
+<a href="https://apps.apple.com/app/apple-store/id1556908618?pt=2114704&ct=website&mt=8"><img src="/img/mac-app-store.svg" style="max-height: 40px;" /></a>
+
 #### Windows
 
 Download Focalboard from the [Microsoft App Store](https://www.microsoft.com/store/apps/9NLN2T0SX9VF?cid=website).
+
+<a href="https://www.microsoft.com/store/apps/9NLN2T0SX9VF?cid=website"><img src="/img/ms-app-store.svg" style="max-height: 40px;" /></a>
 
 Or download `focalboard-win.zip` from the latest [release on GitHub](https://github.com/mattermost/focalboard/releases).
 

--- a/website/site/content/download/personal-edition/desktop.md
+++ b/website/site/content/download/personal-edition/desktop.md
@@ -15,9 +15,11 @@ Download Focalboard from the [Mac App Store](https://apps.apple.com/app/apple-st
 
 Download Focalboard from the [Microsoft App Store](https://www.microsoft.com/store/apps/9NLN2T0SX9VF?cid=website).
 
+Or download `focalboard-win.zip` from the latest [release on GitHub](https://github.com/mattermost/focalboard/releases).
+
 #### Linux Desktop
 
-To install Personal Desktop for Linux:
+To install Personal Desktop for Linux
 1. Download `focalboard-linux.tar.gz` from the latest [release on GitHub](https://github.com/mattermost/focalboard/releases)
 2. Unpack the .tar.gz archive
 4. Open `focalboard-app` from within the `focalboard-app` folder

--- a/website/site/layouts/partials/hero.html
+++ b/website/site/layouts/partials/hero.html
@@ -30,7 +30,7 @@
 
 		<div class="homepage-intro__text">
 			<p>
-				We're currently in early-access beta, and are looking for feedback. So please <a href="download/personal-edition/">download it today</a> and <a href="https://docs.google.com/forms/d/e/1FAIpQLSdTq7M69Pdlz71CwucaSEG0FCK1M_WRvIbZbPr2imfT2QvUCQ/viewform?usp=sf_link" target="_blank" rel="noopener">let us know what you think</a>.
+				We welcome your feedback! So please <a href="download/personal-edition/">download it today</a> and <a href="https://docs.google.com/forms/d/e/1FAIpQLSdTq7M69Pdlz71CwucaSEG0FCK1M_WRvIbZbPr2imfT2QvUCQ/viewform?usp=sf_link" target="_blank" rel="noopener">let us know what you think</a>.
 			</p>
 
 			<p>


### PR DESCRIPTION
#### Summary
Update several download links on the website, including the App Store links (and added the App Store icons) and Mattermost. Also streamlined and tweaked some of the wording.

Note: Changes are live on [focalboard.com](https://www.focalboard.com/) now. You can review the changes there (refreshing your browser may be needed to clear the cache).
