### PR TITLE
Add `chown` for nobody in the docker run example

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -3,8 +3,10 @@
 ## Docker
 
 The Dockerfile gives a quick and easy way to pull the latest Focalboard server and deploy it locally.
+Please note that if you wish to have persistence and mount a volume for the `/data` directory, the host directory must be owned by user `nobody`.
 
 ```
+sudo chown -R nobody /home/user/focalboard-data
 docker build -t focalboard .
 docker run -it -v "/home/user/focalboard-data:/data" -p 80:8000 focalboard
 ```


### PR DESCRIPTION
#### Summary
As mentioned in the last comment on #670, there is an error if you run the Docker image with the instruction of the current readme, mounting a directory as `/data`.

This error (`unable to open database file: no such file or directory`) arises if the host directory is not owned by the user `nobody`.

WIth this PR, I propose to add this information to the README, as well as the `chown` command in the code snippet.