### PR TITLE
Fix panic in PropDef.GetValue for `person` property types.

### DIFF
--- a/server/model/properties.go
+++ b/server/model/properties.go
@@ -17,6 +17,7 @@ var ErrInvalidPropSchema = errors.New("invalid property schema")
 var ErrInvalidProperty = errors.New("invalid property")
 var ErrInvalidPropertyValue = errors.New("invalid property value")
 var ErrInvalidPropertyValueType = errors.New("invalid property value type")
+var ErrPersonNotFound = errors.New("person property not a valid user")
 var ErrInvalidDate = errors.New("invalid date property")
 
 // PropValueResolver allows PropDef.GetValue to further decode property values, such as
@@ -90,6 +91,9 @@ func (pd PropDef) GetValue(v interface{}, resolver PropValueResolver) (string, e
 			user, err := resolver.GetUserByID(userID)
 			if err != nil {
 				return "", err
+			}
+			if user == nil {
+				return "", ErrPersonNotFound
 			}
 			return user.Username, nil
 		}

--- a/server/model/properties.go
+++ b/server/model/properties.go
@@ -17,7 +17,6 @@ var ErrInvalidPropSchema = errors.New("invalid property schema")
 var ErrInvalidProperty = errors.New("invalid property")
 var ErrInvalidPropertyValue = errors.New("invalid property value")
 var ErrInvalidPropertyValueType = errors.New("invalid property value type")
-var ErrPersonNotFound = errors.New("person property not a valid user")
 var ErrInvalidDate = errors.New("invalid date property")
 
 // PropValueResolver allows PropDef.GetValue to further decode property values, such as
@@ -93,7 +92,7 @@ func (pd PropDef) GetValue(v interface{}, resolver PropValueResolver) (string, e
 				return "", err
 			}
 			if user == nil {
-				return "", ErrPersonNotFound
+				return userID, nil
 			}
 			return user.Username, nil
 		}


### PR DESCRIPTION
#### Summary
This PR fixes a panic when resolving model.User for `person` property types when the user is not found (e.g. board imported from a different server).  The `GetUserByID` API can return a nil user and nil error.

#### Ticket Link
NONE