### PR TITLE
Revert "implement registry for channel intro button (#2181)"

### DIFF
--- a/mattermost-plugin/webapp/src/index.tsx
+++ b/mattermost-plugin/webapp/src/index.tsx
@@ -20,7 +20,6 @@ import store from '../../../webapp/src/store'
 import GlobalHeader from '../../../webapp/src/components/globalHeader/globalHeader'
 import FocalboardIcon from '../../../webapp/src/widgets/icons/logo'
 import {setMattermostTheme} from '../../../webapp/src/theme'
-import {UserSettings} from '../../../webapp/src/userSettings'
 
 import TelemetryClient, {TelemetryCategory, TelemetryActions} from '../../../webapp/src/telemetry/telemetryClient'
 
@@ -140,16 +139,6 @@ export default class Plugin {
                 window.open(`${windowAny.frontendBaseURL}/workspace/${currentChannel}`, '_blank', 'noopener')
             }
             this.channelHeaderButtonId = registry.registerChannelHeaderButtonAction(<FocalboardIcon/>, goToFocalboardWorkspace, 'Boards', 'Boards')
-
-            const goToFocalboardTemplate = () => {
-                const currentChannel = mmStore.getState().entities.channels.currentChannelId
-                TelemetryClient.trackEvent(TelemetryCategory, TelemetryActions.ClickChannelIntro, {workspaceID: currentChannel})
-                UserSettings.lastBoardId = null
-                UserSettings.lastViewId = null
-                window.open(`${windowAny.frontendBaseURL}/workspace/${currentChannel}`, '_blank', 'noopener')
-            }
-            this.channelHeaderButtonId = registry.registerChannelIntroButtonAction(<FocalboardIcon/>, goToFocalboardTemplate, 'Boards')
-
             this.registry.registerProduct('/boards', 'product-boards', 'Boards', '/boards/welcome', MainApp, HeaderComponent)
             this.registry.registerPostWillRenderEmbedComponent((embed) => embed.type === 'boards', BoardsUnfurl, false)
         } else {

--- a/mattermost-plugin/webapp/src/types/mattermost-webapp/index.d.ts
+++ b/mattermost-plugin/webapp/src/types/mattermost-webapp/index.d.ts
@@ -3,7 +3,6 @@
 export interface PluginRegistry {
     registerPostTypeComponent(typeName: string, component: React.ElementType)
     registerChannelHeaderButtonAction(icon: React.Element, action: () => void, dropdownText: string, tooltipText: string)
-    registerChannelIntroButtonAction(icon: React.Element, action: () => void, tooltipText: string)
     registerCustomRoute(route: string, component: React.ElementType)
     registerProductRoute(route: string, component: React.ElementType)
     unregisterComponent(componentId: string)

--- a/webapp/src/telemetry/telemetryClient.ts
+++ b/webapp/src/telemetry/telemetryClient.ts
@@ -8,7 +8,6 @@ export const TelemetryCategory = 'boards'
 
 export const TelemetryActions = {
     ClickChannelHeader: 'clickChannelHeader',
-    ClickChannelIntro: 'channelIntro_boardLink',
     ViewBoard: 'viewBoard',
     CreateBoard: 'createBoard',
     DuplicateBoard: 'duplicateBoard',


### PR DESCRIPTION
#### Summary
This reverts commit 7e0fb26875d6eaf63b5df22cfd568a313ab9e622.

Reverts code change for adding "Boards" to the Channel Introduction. The mattermost-webapp code did not make the cutoff. 

This only needs reverted in the 'release-0.14' branch. The Main branch is fine as the code now exists in mattermost-webapp.

#### Ticket Link

  Fixes https://github.com/mattermost/focalboard/issues/2251

