### PR TITLE
Fix export archive file extension

### DIFF
--- a/webapp/src/archiver.ts
+++ b/webapp/src/archiver.ts
@@ -27,7 +27,7 @@ class Archiver {
                     link.style.display = 'none'
 
                     const date = new Date()
-                    const filename = `archive-${date.getFullYear()}-${date.getMonth() + 1}-${date.getDate()}.focalboard`
+                    const filename = `archive-${date.getFullYear()}-${date.getMonth() + 1}-${date.getDate()}.boardarchive`
 
                     const file = new Blob([blob], {type: 'application/octet-stream'})
                     link.href = URL.createObjectURL(file)


### PR DESCRIPTION
#### Summary
Use correct file extension when exporting archives (`.boardarchive`)

#### Ticket Link
Fixes https://github.com/mattermost/focalboard/issues/2239