### PR TITLE
Fied a bug where user Cannot edit description block if only a space

### DIFF
--- a/webapp/src/components/markdownEditor.scss
+++ b/webapp/src/components/markdownEditor.scss
@@ -20,6 +20,8 @@
     }
 
     .octo-editor-preview {
+        min-height: 2em;
+
         a {
             &:hover {
                 text-decoration: underline;
@@ -31,10 +33,6 @@
             word-break: break-word;
         }
     }
-
-    /* .dialog .octo-editor-preview {
-        min-height: 100px;
-    } */
 
     .octo-editor-activeEditor {
         overflow: hidden;


### PR DESCRIPTION
#### Summary
Fixed a bug where the user cannot edit description block if only a space.

#### Ticket Link
Fixes #2063

The problem was that only a space in the text, the HTML element didn't take any height, so the user couldn't click on the element to trigger an edit.
