### PR TITLE
Reduce noise in logs

### DIFF
--- a/mattermost-plugin/server/plugin.go
+++ b/mattermost-plugin/server/plugin.go
@@ -112,7 +112,7 @@ func (p *Plugin) OnActivate() error {
 		db = layeredStore
 	}
 
-	p.wsPluginAdapter = ws.NewPluginAdapter(p.API, auth.New(cfg, db))
+	p.wsPluginAdapter = ws.NewPluginAdapter(p.API, auth.New(cfg, db), logger)
 
 	backendParams := notifyBackendParams{
 		cfg:        cfg,

--- a/server/ws/helpers_test.go
+++ b/server/ws/helpers_test.go
@@ -7,6 +7,7 @@ import (
 	wsMocks "github.com/mattermost/focalboard/server/ws/mocks"
 
 	mmModel "github.com/mattermost/mattermost-server/v6/model"
+	"github.com/mattermost/mattermost-server/v6/shared/mlog"
 
 	"github.com/golang/mock/gomock"
 )
@@ -32,7 +33,7 @@ func SetupTestHelper(t *testing.T) *TestHelper {
 		api:  mockAPI,
 		auth: mockAuth,
 		ctrl: ctrl,
-		pa:   NewPluginAdapter(mockAPI, mockAuth),
+		pa:   NewPluginAdapter(mockAPI, mockAuth, mlog.CreateConsoleTestLogger(true, mlog.LvlDebug)),
 	}
 }
 


### PR DESCRIPTION
#### Summary
This PR reduces noise in the log output by changing `BroadcastingBlockChange` and `BroadcastingSubscriptionChange` log events from `info` to `debug`.

The logger calls are also changed to use the PluginLogAdapter like the rest of the FB server.  This is in preparation for a future PR on MM server to accept raw Logr records and preserve the true stack trace.

#### Ticket Link
Fixes https://github.com/mattermost/focalboard/issues/2246