### PR TITLE
Fixes "Something went wrong" error when selecting certain templates

### DIFF
--- a/webapp/src/store/contents.ts
+++ b/webapp/src/store/contents.ts
@@ -66,7 +66,7 @@ export function getCardContents(cardId: string): (state: RootState) => Array<Con
                 for (const contentId of card.fields.contentOrder) {
                     if (typeof contentId === 'string' && contents[contentId]) {
                         result.push(contents[contentId])
-                    } else if (typeof contentId === 'object') {
+                    } else if (typeof contentId === 'object' && contentId) {
                         const subResult: ContentBlock[] = []
                         for (const subContentId of contentId) {
                             if (typeof subContentId === 'string' && contents[subContentId]) {


### PR DESCRIPTION
#### Summary
This PR adds a null check which was crashing the client after creating a board from certain templates.

#### Ticket Link
fixes https://github.com/mattermost/focalboard/issues/2238