### PR TITLE
Don't show `Follow` button on card template

### DIFF
--- a/webapp/src/components/cardDialog.tsx
+++ b/webapp/src/components/cardDialog.tsx
@@ -50,6 +50,7 @@ const CardDialog = (props: Props): JSX.Element => {
     const comments = useAppSelector(getCardComments(props.cardId))
     const intl = useIntl()
     const me = useAppSelector<IUser|null>(getMe)
+    const isTemplate = card && card.fields.isTemplate
 
     const [showConfirmationDialogBox, setShowConfirmationDialogBox] = useState<boolean>(false)
     const makeTemplateClicked = async () => {
@@ -126,7 +127,7 @@ const CardDialog = (props: Props): JSX.Element => {
                     sendFlashMessage({content: intl.formatMessage({id: 'CardDialog.copiedLink', defaultMessage: 'Copied!'}), severity: 'high'})
                 }}
             />
-            {(card && !card.fields.isTemplate) &&
+            {!isTemplate &&
                 <Menu.Text
                     id='makeTemplate'
                     name='New template from card'
@@ -167,9 +168,9 @@ const CardDialog = (props: Props): JSX.Element => {
             <Dialog
                 onClose={props.onClose}
                 toolsMenu={!props.readonly && menu}
-                toolbar={toolbar}
+                toolbar={!isTemplate && toolbar}
             >
-                {card && card.fields.isTemplate &&
+                {isTemplate &&
                     <div className='banner'>
                         <FormattedMessage
                             id='CardDialog.editing-template'


### PR DESCRIPTION
#### Summary
This PR ensures the `Follow` button does not appear when displaying a card template.

#### Ticket Link
fixes https://github.com/mattermost/focalboard/issues/2250