### PR TITLE
GH-2257: Calculation column order to be based on view

### DIFF
--- a/webapp/src/components/table/calculation/calculationRow.tsx
+++ b/webapp/src/components/table/calculation/calculationRow.tsx
@@ -39,7 +39,7 @@ const CalculationRow = (props: Props): JSX.Element => {
 
     const templates: IPropertyTemplate[] = [
         titleTemplate,
-        ...props.board.fields.cardProperties.filter((template) => props.activeView.fields.visiblePropertyIds.includes(template.id)),
+        ...props.activeView.fields.visiblePropertyIds.map((id) => props.board.fields.cardProperties.find((t) => t.id === id)).filter((i) => i) as IPropertyTemplate[],
     ]
 
     const selectedCalculations = props.board.fields.columnCalculations || []


### PR DESCRIPTION
#### Summary
A change was made in v0.12 to start using the views "visibleProperties" to define the order of properties. Previously, all views based order on the boards "cardProperties" order.

This PR updates the calculationRows to use the view's "visibleProperties".

#### Ticket Link

  Fixes https://github.com/mattermost/focalboard/issues/2257

