### PR TITLE
Replace `npm install` with `npm ci` to ensure dependencies are properly pinned during CI/CD

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,8 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
 
-    - name: npm install
-      run: cd webapp; npm install
+    - name: npm ci
+      run: cd webapp; npm ci
 
     - name: ESLint
       run: cd webapp; npm run check

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -28,8 +28,8 @@ jobs:
     - name: Replace token 2 webapp
       run: sed -i -e "s,placeholder_rudder_key,${{ secrets.RUDDER_DEV_KEY }},g" ${{ github.workspace }}/mattermost-plugin/webapp/src/index.tsx
 
-    - name: npm install
-      run: cd webapp; npm install --no-optional
+    - name: npm ci
+      run: cd webapp; npm ci --no-optional
 
     - name: Set up Go
       uses: actions/setup-go@v2
@@ -87,8 +87,8 @@ jobs:
     - name: Replace token 2 webapp
       run: sed -i -e "s,placeholder_rudder_key,${{ secrets.RUDDER_DEV_KEY }},g" ${{ github.workspace }}/mattermost-plugin/webapp/src/index.tsx
 
-    - name: npm install
-      run: cd webapp; npm install --no-optional
+    - name: npm ci
+      run: cd webapp; npm ci --no-optional
 
     - name: Set up Go
       uses: actions/setup-go@v2
@@ -132,8 +132,8 @@ jobs:
     - name: Add msbuild to PATH
       uses: microsoft/setup-msbuild@v1.0.2
 
-    - name: npm install
-      run: cd webapp; npm install --no-optional
+    - name: npm ci
+      run: cd webapp; npm ci --no-optional
 
     - name: Set up Go
       uses: actions/setup-go@v2
@@ -184,8 +184,8 @@ jobs:
     - name: Replace token 2 webapp
       run: sed -i -e "s,placeholder_rudder_key,${{ secrets.RUDDER_DEV_KEY }},g" ${{ github.workspace }}/mattermost-plugin/webapp/src/index.tsx
 
-    - name: npm install
-      run: cd webapp; npm install --no-optional
+    - name: npm ci
+      run: cd webapp; npm ci --no-optional
 
     - name: Set up Go
       uses: actions/setup-go@v2
@@ -200,8 +200,8 @@ jobs:
     - name: Build webapp
       run: make webapp
 
-    - name: npm install plugin dependencies
-      run: cd mattermost-plugin/webapp; npm install --no-optional
+    - name: npm ci plugin dependencies
+      run: cd mattermost-plugin/webapp; npm ci --no-optional
 
     - name: Build plugin
       run: cd mattermost-plugin; make dist

--- a/.github/workflows/prod-release.yml
+++ b/.github/workflows/prod-release.yml
@@ -23,8 +23,8 @@ jobs:
     - name: Replace token 2 webapp
       run: sed -i -e "s,placeholder_rudder_key,${{ secrets.RUDDER_PROD_KEY }},g" ${{ github.workspace }}/mattermost-plugin/webapp/src/index.tsx
 
-    - name: npm install
-      run: cd webapp; npm install --no-optional
+    - name: npm ci
+      run: cd webapp; npm ci --no-optional
 
     - name: Set up Go
       uses: actions/setup-go@v2
@@ -82,8 +82,8 @@ jobs:
     - name: Replace token 2 webapp
       run: sed -i -e "s,placeholder_rudder_key,${{ secrets.RUDDER_PROD_KEY }},g" ${{ github.workspace }}/mattermost-plugin/webapp/src/index.tsx
 
-    - name: npm install
-      run: cd webapp; npm install --no-optional
+    - name: npm ci
+      run: cd webapp; npm ci --no-optional
 
     - name: Set up Go
       uses: actions/setup-go@v2
@@ -127,8 +127,8 @@ jobs:
     - name: Add msbuild to PATH
       uses: microsoft/setup-msbuild@v1.0.2
 
-    - name: npm install
-      run: cd webapp; npm install --no-optional
+    - name: npm ci
+      run: cd webapp; npm ci --no-optional
 
     - name: Set up Go
       uses: actions/setup-go@v2
@@ -179,8 +179,8 @@ jobs:
     - name: Replace token 2 webapp
       run: sed -i -e "s,placeholder_rudder_key,${{ secrets.RUDDER_PROD_KEY }},g" ${{ github.workspace }}/mattermost-plugin/webapp/src/index.tsx
 
-    - name: npm install
-      run: cd webapp; npm install --no-optional
+    - name: npm ci
+      run: cd webapp; npm ci --no-optional
 
     - name: Set up Go
       uses: actions/setup-go@v2
@@ -195,8 +195,8 @@ jobs:
     - name: Build webapp
       run: make webapp
 
-    - name: npm install plugin dependencies
-      run: cd mattermost-plugin/webapp; npm install --no-optional
+    - name: npm ci plugin dependencies
+      run: cd mattermost-plugin/webapp; npm ci --no-optional
 
     - name: Build plugin
       run: cd mattermost-plugin; make dist


### PR DESCRIPTION
Running `npm ci` instead of `npm install` essentially verifies dependencies match the intended versions and makes the build fail if they don't match, please see https://stackoverflow.com/questions/52499617/what-is-the-difference-between-npm-install-and-npm-ci#53325242 and the npm docs for more information.