### PR TITLE
[MM-36643] Use Mattermost SiteURL to determine rudder cookie domain

### DIFF
--- a/mattermost-plugin/webapp/src/index.tsx
+++ b/mattermost-plugin/webapp/src/index.tsx
@@ -172,7 +172,14 @@ export default class Plugin {
             }
 
             if (rudderKey !== '') {
-                rudderAnalytics.load(rudderKey, rudderUrl)
+                const rudderCfg = {} as {setCookieDomain: string}
+                if (siteURL && siteURL !== '') {
+                    try {
+                        rudderCfg.setCookieDomain = new URL(siteURL).hostname
+                        // eslint-disable-next-line no-empty
+                    } catch (_) {}
+                }
+                rudderAnalytics.load(rudderKey, rudderUrl, rudderCfg)
 
                 rudderAnalytics.identify(config?.telemetryid, {}, TELEMETRY_OPTIONS)
 


### PR DESCRIPTION
#### Summary
When mattermost is installed on a subdomain (e.g. `mattermost.example.com`), rudder parses the top-level domain and sets their cookies using a general `.example.com` making the cookie available in every subdomain. This PR ensures the cookie is set to the actual subdomain by parsing SiteURL from the config

#### Related PR
Same fix on the webapp https://github.com/mattermost/mattermost-webapp/pull/9764

#### Ticket Link
Related to https://mattermost.atlassian.net/browse/MM-36643

