### PR TITLE
GitHub: workflows: Use macOS 11 and Xcode 13.2.1

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -68,7 +68,7 @@ jobs:
         path: ${{ github.workspace }}/linux/dist/focalboard-linux.tar.gz
 
   macos:
-    runs-on: macos-10.15
+    runs-on: macos-11
 
     steps:
 
@@ -101,7 +101,7 @@ jobs:
     - name: Build macOS
       run: make mac-app
       env:
-        DEVELOPER_DIR: /Applications/Xcode_12.4.app/Contents/Developer
+        DEVELOPER_DIR: /Applications/Xcode_13.2.1.app/Contents/Developer
         BUILD_NUMBER: ${{ github.run_id }}
 
     - name: Upload macOS package

--- a/.github/workflows/prod-release.yml
+++ b/.github/workflows/prod-release.yml
@@ -63,7 +63,7 @@ jobs:
         path: ${{ github.workspace }}/linux/dist/focalboard-linux.tar.gz
 
   macos:
-    runs-on: macos-10.15
+    runs-on: macos-11
 
     steps:
 
@@ -96,7 +96,7 @@ jobs:
     - name: Build macOS
       run: make mac-app
       env:
-        DEVELOPER_DIR: /Applications/Xcode_12.4.app/Contents/Developer
+        DEVELOPER_DIR: /Applications/Xcode_13.2.1.app/Contents/Developer
         BUILD_NUMBER: ${{ github.run_id }}
 
     - name: Upload macOS package

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ You can build standalone apps that package the server to run locally against SQL
 * Mac:
     * `make mac-app`
     * run `mac/dist/Focalboard.app`
-    * *Requires: macOS Catalina (10.15)+, Xcode 12+.*
+    * *Requires: macOS 11.3+, Xcode 13.2.1+*
 * Linux:
     * Install webgtk dependencies
         * `sudo apt-get install libgtk-3-dev`


### PR DESCRIPTION
#### Summary
Update GitHub workflows to use macOS 11 and Xcode 13.2.1, to support latest features for Mac.
