### PR TITLE
Fix #2346. Revert to Windows 2019 for GitHub actions

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -111,7 +111,7 @@ jobs:
         path: ${{ github.workspace }}/mac/dist/focalboard-mac.zip
 
   windows:
-    runs-on: windows-latest
+    runs-on: windows-2019
 
     steps:
     - name: Checkout

--- a/.github/workflows/prod-release.yml
+++ b/.github/workflows/prod-release.yml
@@ -106,7 +106,7 @@ jobs:
         path: ${{ github.workspace }}/mac/dist/focalboard-mac.zip
 
   windows:
-    runs-on: windows-latest
+    runs-on: windows-2019
 
     steps:
     - name: Checkout


### PR DESCRIPTION
#### Summary
Revert to use the Windows 2019 image for GitHub builds for now. Note that `windows-latest` just [changed to Server 2022](https://github.com/actions/virtual-environments/issues/4856), which caused this build break.

#### Ticket Link
#2346