### PR TITLE
Shows "(Deleted User)" instead of UUID when user not found

### DIFF
--- a/server/services/store/mattermostauthlayer/mattermostauthlayer.go
+++ b/server/services/store/mattermostauthlayer/mattermostauthlayer.go
@@ -434,7 +434,7 @@ func (s *MattermostAuthLayer) userWorkspacesFromRows(rows *sql.Rows) ([]model.Us
 
 			for _, userID := range userIDs {
 				user, exists := users[userID]
-				//Shows "(Deleted User)" instead of long, unreadable UUID in case the user is not found
+				// Shows "(Deleted User)" instead of long, unreadable UUID in case the user is not found
 				username := "(Deleted User)"
 				if exists {
 					username = user.Username

--- a/server/services/store/mattermostauthlayer/mattermostauthlayer.go
+++ b/server/services/store/mattermostauthlayer/mattermostauthlayer.go
@@ -434,7 +434,8 @@ func (s *MattermostAuthLayer) userWorkspacesFromRows(rows *sql.Rows) ([]model.Us
 
 			for _, userID := range userIDs {
 				user, exists := users[userID]
-				username := userID
+				//Shows "(Deleted User)" instead of long, unreadable UUID in case the user is not found
+				username := "(Deleted User)"
 				if exists {
 					username = user.Username
 				}


### PR DESCRIPTION
In case a user is not found, at present unreadable and long UUIDs are shown which kill the look and feel of the application. This patch replaces the UUID with a more explanatory string.

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

