### PR TITLE
Fix sql syntax error for SearchUsersByTeam

### DIFF
--- a/server/api/api.go
+++ b/server/api/api.go
@@ -280,8 +280,8 @@ func (a *API) handleGetBlocks(w http.ResponseWriter, r *http.Request) {
 
 	if board.IsTemplate {
 		if !a.permissions.HasPermissionToTeam(userID, board.TeamID, model.PermissionViewTeam) {
-			fmt.Println("FAILING HERE", userID, boardID, model.PermissionViewBoard)
-			a.errorResponse(w, r.URL.Path, http.StatusForbidden, "", PermissionError{"access denied to board"})
+			fmt.Println("FAILING HERE for template", userID, boardID, model.PermissionViewBoard)
+			a.errorResponse(w, r.URL.Path, http.StatusForbidden, "", PermissionError{"access denied to board template"})
 			return
 		}
 	} else {
@@ -1886,7 +1886,7 @@ func (a *API) handleGetTeamUsers(w http.ResponseWriter, r *http.Request) {
 
 	users, err := a.app.SearchTeamUsers(teamID, searchQuery)
 	if err != nil {
-		a.errorResponse(w, r.URL.Path, http.StatusInternalServerError, "", err)
+		a.errorResponse(w, r.URL.Path, http.StatusInternalServerError, "searchQuery="+searchQuery, err)
 		return
 	}
 

--- a/server/services/store/mattermostauthlayer/mattermostauthlayer.go
+++ b/server/services/store/mattermostauthlayer/mattermostauthlayer.go
@@ -265,7 +265,8 @@ func (s *MattermostAuthLayer) getQueryBuilder() sq.StatementBuilderType {
 
 func (s *MattermostAuthLayer) GetUsersByTeam(teamID string) ([]*model.User, error) {
 	query := s.getQueryBuilder().
-		Select("u.id", "u.username", "u.props", "u.CreateAt as create_at", "u.UpdateAt as update_at", "u.DeleteAt as delete_at", "b.UserId IS NOT NULL AS is_bot").
+		Select("u.id", "u.username", "u.props", "u.CreateAt as create_at", "u.UpdateAt as update_at",
+			"u.DeleteAt as delete_at", "b.UserId IS NOT NULL AS is_bot").
 		From("Users as u").
 		Join("TeamMembers as tm ON tm.UserID = u.ID").
 		LeftJoin("Bots b ON ( b.UserId = Users.ID )").
@@ -288,10 +289,11 @@ func (s *MattermostAuthLayer) GetUsersByTeam(teamID string) ([]*model.User, erro
 
 func (s *MattermostAuthLayer) SearchUsersByTeam(teamID string, searchQuery string) ([]*model.User, error) {
 	query := s.getQueryBuilder().
-		Select("u.id", "u.username", "u.props", "u.CreateAt as create_at", "u.UpdateAt as update_at", "u.DeleteAt as delete_at", "b.UserId IS NOT NULL AS is_bot").
+		Select("u.id", "u.username", "u.props", "u.CreateAt as create_at", "u.UpdateAt as update_at",
+			"u.DeleteAt as delete_at", "b.UserId IS NOT NULL AS is_bot").
 		From("Users as u").
-		Join("TeamMembers as tm ON tm.UserID = u.ID").
-		LeftJoin("Bots b ON ( b.UserId = Users.ID )").
+		Join("TeamMembers as tm ON tm.UserID = u.id").
+		LeftJoin("Bots b ON ( b.UserId = u.id )").
 		Where(sq.Eq{"u.deleteAt": 0}).
 		Where(sq.Or{
 			sq.Like{"u.username": "%" + searchQuery + "%"},

--- a/server/services/store/sqlstore/user.go
+++ b/server/services/store/sqlstore/user.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/mattermost/focalboard/server/model"
 	"github.com/mattermost/focalboard/server/utils"
+
 	"github.com/mattermost/mattermost-server/v6/shared/mlog"
 )
 


### PR DESCRIPTION
#### Summary
This PR fixes a syntax error in the SQL for `(*MattermostAuthLayer) SearchUsersByTeam`.  This resulted in all board's `Share` dialog not auto-filling the users drop-down and not allowing users to be added to the share list.

#### Ticket Link
NONE