### PR TITLE
Fix Image and text Elements

### DIFF
--- a/webapp/src/components/content/textElement.tsx
+++ b/webapp/src/components/content/textElement.tsx
@@ -26,7 +26,7 @@ const TextElement = (props: Props): JSX.Element => {
             placeholderText={intl.formatMessage({id: 'ContentBlock.editText', defaultMessage: 'Edit text...'})}
             onBlur={(text) => {
                 if (text !== block.title) {
-                    mutator.changeBlockTitle(block.id, block.title, text, intl.formatMessage({id: 'ContentBlock.editCardText', defaultMessage: 'edit card text'}))
+                    mutator.changeBlockTitle(block.boardId, block.id, block.title, text, intl.formatMessage({id: 'ContentBlock.editCardText', defaultMessage: 'edit card text'}))
                 }
             }}
             readonly={readonly}


### PR DESCRIPTION

#### Summary
Image Fix -
octoClient image calls have changed, update the API to match the octoClient calls for images.

Text Fix -
Pass BoardID to mutator for BlockTitleChange

#### Ticket Link
  Fixes https://github.com/mattermost/focalboard/issues/2356
  
  And 
 
  # Sev 1: Adding an image doesn’t work

