### PR TITLE
Removing transactions from sqlite backend

### DIFF
--- a/server/services/store/generators/main.go
+++ b/server/services/store/generators/main.go
@@ -82,6 +82,7 @@ type storeMetadata struct {
 var blacklistedStoreMethodNames = map[string]bool{
 	"Shutdown":      true,
 	"IsErrNotFound": true,
+	"DBType":        true,
 }
 
 func extractMethodMetadata(method *ast.Field, src []byte) methodData {

--- a/server/services/store/generators/transactional_store.go.tmpl
+++ b/server/services/store/generators/transactional_store.go.tmpl
@@ -25,6 +25,9 @@ import (
 {{range $index, $element := .Methods}}
 func (s *SQLStore) {{$index}}({{$element.Params | joinParamsWithType}}) {{$element.Results | joinResultsForSignature}} {
     {{- if $element.WithTransaction}}
+    	if s.dbType == sqliteDBType {
+    	    return s.{{$index | renameStoreMethod}}(s.db, {{$element.Params | joinParams}})
+    	}
     	tx, txErr := s.db.BeginTx(context.Background(), nil)
         if txErr != nil {
             return {{ genErrorResultsVars $element.Results "txErr"}}

--- a/server/services/store/mockstore/mockstore.go
+++ b/server/services/store/mockstore/mockstore.go
@@ -93,6 +93,20 @@ func (mr *MockStoreMockRecorder) CreateUser(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateUser", reflect.TypeOf((*MockStore)(nil).CreateUser), arg0)
 }
 
+// DBType mocks base method.
+func (m *MockStore) DBType() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DBType")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// DBType indicates an expected call of DBType.
+func (mr *MockStoreMockRecorder) DBType() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DBType", reflect.TypeOf((*MockStore)(nil).DBType))
+}
+
 // DeleteBlock mocks base method.
 func (m *MockStore) DeleteBlock(arg0 store.Container, arg1, arg2 string) error {
 	m.ctrl.T.Helper()

--- a/server/services/store/sqlstore/blocks.go
+++ b/server/services/store/sqlstore/blocks.go
@@ -444,6 +444,11 @@ func (s *SQLStore) patchBlocks(db sq.BaseRunner, c store.Container, blockPatches
 }
 
 func (s *SQLStore) insertBlocks(db sq.BaseRunner, c store.Container, blocks []model.Block, userID string) error {
+	for _, block := range blocks {
+		if block.RootID == "" {
+			return RootIDNilError{}
+		}
+	}
 	for i := range blocks {
 		err := s.insertBlock(db, c, &blocks[i], userID)
 		if err != nil {

--- a/server/services/store/sqlstore/public_methods.go
+++ b/server/services/store/sqlstore/public_methods.go
@@ -43,6 +43,9 @@ func (s *SQLStore) CreateUser(user *model.User) error {
 }
 
 func (s *SQLStore) DeleteBlock(c store.Container, blockID string, modifiedBy string) error {
+	if s.dbType == sqliteDBType {
+		return s.deleteBlock(s.db, c, blockID, modifiedBy)
+	}
 	tx, txErr := s.db.BeginTx(context.Background(), nil)
 	if txErr != nil {
 		return txErr
@@ -254,6 +257,9 @@ func (s *SQLStore) HasWorkspaceAccess(userID string, workspaceID string) (bool, 
 }
 
 func (s *SQLStore) InsertBlock(c store.Container, block *model.Block, userID string) error {
+	if s.dbType == sqliteDBType {
+		return s.insertBlock(s.db, c, block, userID)
+	}
 	tx, txErr := s.db.BeginTx(context.Background(), nil)
 	if txErr != nil {
 		return txErr
@@ -275,6 +281,9 @@ func (s *SQLStore) InsertBlock(c store.Container, block *model.Block, userID str
 }
 
 func (s *SQLStore) InsertBlocks(c store.Container, blocks []model.Block, userID string) error {
+	if s.dbType == sqliteDBType {
+		return s.insertBlocks(s.db, c, blocks, userID)
+	}
 	tx, txErr := s.db.BeginTx(context.Background(), nil)
 	if txErr != nil {
 		return txErr
@@ -296,6 +305,9 @@ func (s *SQLStore) InsertBlocks(c store.Container, blocks []model.Block, userID 
 }
 
 func (s *SQLStore) PatchBlock(c store.Container, blockID string, blockPatch *model.BlockPatch, userID string) error {
+	if s.dbType == sqliteDBType {
+		return s.patchBlock(s.db, c, blockID, blockPatch, userID)
+	}
 	tx, txErr := s.db.BeginTx(context.Background(), nil)
 	if txErr != nil {
 		return txErr
@@ -317,6 +329,9 @@ func (s *SQLStore) PatchBlock(c store.Container, blockID string, blockPatch *mod
 }
 
 func (s *SQLStore) PatchBlocks(c store.Container, blockPatches *model.BlockPatchBatch, userID string) error {
+	if s.dbType == sqliteDBType {
+		return s.patchBlocks(s.db, c, blockPatches, userID)
+	}
 	tx, txErr := s.db.BeginTx(context.Background(), nil)
 	if txErr != nil {
 		return txErr

--- a/server/services/store/sqlstore/sqlstore.go
+++ b/server/services/store/sqlstore/sqlstore.go
@@ -70,7 +70,7 @@ func (s *SQLStore) DBHandle() *sql.DB {
 	return s.db
 }
 
-// DBType returns the DB driver used for the store
+// DBType returns the DB driver used for the store.
 func (s *SQLStore) DBType() string {
 	return s.dbType
 }

--- a/server/services/store/sqlstore/sqlstore.go
+++ b/server/services/store/sqlstore/sqlstore.go
@@ -70,6 +70,11 @@ func (s *SQLStore) DBHandle() *sql.DB {
 	return s.db
 }
 
+// DBType returns the DB driver used for the store
+func (s *SQLStore) DBType() string {
+	return s.dbType
+}
+
 func (s *SQLStore) getQueryBuilder(db sq.BaseRunner) sq.StatementBuilderType {
 	builder := sq.StatementBuilder
 	if s.dbType == postgresDBType || s.dbType == sqliteDBType {

--- a/server/services/store/store.go
+++ b/server/services/store/store.go
@@ -93,6 +93,8 @@ type Store interface {
 	RemoveDefaultTemplates(blocks []model.Block) error
 	GetDefaultTemplateBlocks() ([]model.Block, error)
 
+	DBType() string
+
 	IsErrNotFound(err error) bool
 }
 

--- a/server/services/store/storetests/blocks.go
+++ b/server/services/store/storetests/blocks.go
@@ -221,6 +221,7 @@ func testInsertBlocks(t *testing.T, store store.Store, container store.Container
 
 		newBlocks := []model.Block{validBlock, invalidBlock}
 
+		time.Sleep(1 * time.Millisecond)
 		err := store.InsertBlocks(container, newBlocks, "user-id-1")
 		require.Error(t, err)
 
@@ -381,6 +382,7 @@ func testPatchBlocks(t *testing.T, store store.Store, container store.Container)
 		blockIds := []string{"id-test", "id-test2"}
 		blockPatches := []model.BlockPatch{blockPatch, blockPatch2}
 
+		time.Sleep(1 * time.Millisecond)
 		err := store.PatchBlocks(container, &model.BlockPatchBatch{BlockIDs: blockIds, BlockPatches: blockPatches}, "user-id-1")
 		require.NoError(t, err)
 
@@ -394,6 +396,10 @@ func testPatchBlocks(t *testing.T, store store.Store, container store.Container)
 	})
 
 	t.Run("invalid block id, nothing updated existing blocks", func(t *testing.T) {
+		if store.DBType() == "sqlite3" {
+			t.Skip("No transactions support int sqlite")
+		}
+
 		title := "Another Title"
 		blockPatch := model.BlockPatch{
 			Title: &title,


### PR DESCRIPTION
We expect to prevent the locking problem detected by some users in the #2300
issue by removing the transactions while using the sqlite database.

Fixes #2300