### PR TITLE
GH-2369 - Fix duplicate templates

### DIFF
--- a/server/api/api.go
+++ b/server/api/api.go
@@ -73,7 +73,6 @@ func (a *API) RegisterRoutes(r *mux.Router) {
 
 	// Board APIs
 	apiv1.HandleFunc("/teams/{teamID}/boards", a.sessionRequired(a.handleGetBoards)).Methods("GET")
-	apiv1.HandleFunc("/teams/{teamID}/templates", a.sessionRequired(a.handleGetTemplates)).Methods("GET")
 	apiv1.HandleFunc("/teams/{teamID}/boards/search", a.sessionRequired(a.handleSearchBoards)).Methods("GET")
 	apiv1.HandleFunc("/teams/{teamID}/templates", a.sessionRequired(a.handleGetTemplates)).Methods("GET")
 	apiv1.HandleFunc("/boards", a.sessionRequired(a.handleCreateBoard)).Methods("POST")

--- a/server/services/store/sqlstore/migrate.go
+++ b/server/services/store/sqlstore/migrate.go
@@ -195,7 +195,7 @@ func (s *SQLStore) Migrate() error {
 
 	if err := s.runUniqueIDsMigration(); err != nil {
 		if s.isPlugin {
-			s.logger.Debug("Releasing cluster lock for Unique IDs migration1")
+			s.logger.Debug("Releasing cluster lock for Unique IDs migration")
 			mutex.Unlock()
 		}
 		return fmt.Errorf("error running unique IDs migration: %w", err)
@@ -207,22 +207,14 @@ func (s *SQLStore) Migrate() error {
 
 	if err := s.runCategoryUuidIdMigration(); err != nil {
 		if s.isPlugin {
-			s.logger.Debug("Releasing cluster lock for Unique IDs migration2")
+			s.logger.Debug("Releasing cluster lock for Unique IDs migration")
 			mutex.Unlock()
 		}
 		return fmt.Errorf("error running categoryID migration: %w", err)
 	}
 
-	// if err := s.runTemplatesToTeamsMigration(); err != nil {
-	// 	if s.isPlugin {
-	// 		s.logger.Debug("Releasing cluster lock for template to teams migration")
-	// 		mutex.Unlock()
-	// 	}
-	// 	return fmt.Errorf("error running template to teams migration: %w", err)
-	// }
-
 	if s.isPlugin {
-		s.logger.Debug("Releasing cluster lock for Unique IDs migration3")
+		s.logger.Debug("Releasing cluster lock for Unique IDs migration")
 		mutex.Unlock()
 	}
 

--- a/server/services/store/sqlstore/migrate.go
+++ b/server/services/store/sqlstore/migrate.go
@@ -195,7 +195,7 @@ func (s *SQLStore) Migrate() error {
 
 	if err := s.runUniqueIDsMigration(); err != nil {
 		if s.isPlugin {
-			s.logger.Debug("Releasing cluster lock for Unique IDs migration")
+			s.logger.Debug("Releasing cluster lock for Unique IDs migration1")
 			mutex.Unlock()
 		}
 		return fmt.Errorf("error running unique IDs migration: %w", err)
@@ -207,14 +207,22 @@ func (s *SQLStore) Migrate() error {
 
 	if err := s.runCategoryUuidIdMigration(); err != nil {
 		if s.isPlugin {
-			s.logger.Debug("Releasing cluster lock for Unique IDs migration")
+			s.logger.Debug("Releasing cluster lock for Unique IDs migration2")
 			mutex.Unlock()
 		}
 		return fmt.Errorf("error running categoryID migration: %w", err)
 	}
 
+	// if err := s.runTemplatesToTeamsMigration(); err != nil {
+	// 	if s.isPlugin {
+	// 		s.logger.Debug("Releasing cluster lock for template to teams migration")
+	// 		mutex.Unlock()
+	// 	}
+	// 	return fmt.Errorf("error running template to teams migration: %w", err)
+	// }
+
 	if s.isPlugin {
-		s.logger.Debug("Releasing cluster lock for Unique IDs migration")
+		s.logger.Debug("Releasing cluster lock for Unique IDs migration3")
 		mutex.Unlock()
 	}
 

--- a/webapp/src/octoClient.ts
+++ b/webapp/src/octoClient.ts
@@ -579,6 +579,11 @@ class OctoClient {
         return this.getBoardsWithPath(path)
     }
 
+    async getGlobalTemplates(): Promise<Board[]> {
+        const path = this.teamPath('0') + '/templates'
+        return this.getBoardsWithPath(path)
+    }
+
     // Boards
     // ToDo: .
     // - goal? make the interface show boards & blocks for boards

--- a/webapp/src/store/globalTemplates.ts
+++ b/webapp/src/store/globalTemplates.ts
@@ -3,7 +3,8 @@
 
 import {createSlice, createAsyncThunk} from '@reduxjs/toolkit'
 
-import {default as client, OctoClient} from '../octoClient'
+import {default as client} from '../octoClient'
+
 import {Board} from '../blocks/board'
 
 import {RootState} from './index'
@@ -13,8 +14,7 @@ import {RootState} from './index'
 export const fetchGlobalTemplates = createAsyncThunk(
     'globalTemplates/fetch',
     async () => {
-        const rootClient = new OctoClient(client.serverUrl, '0')
-        const templates = await rootClient.getTeamTemplates() // ToDo: pass team id?
+        const templates = await client.getGlobalTemplates() // ToDo: pass team id?
         return templates.sort((a, b) => a.title.localeCompare(b.title))
     },
 )


### PR DESCRIPTION
#### Summary
Custom Templates are duplicated because retrieving "Global Templates" actually retrieves the current team templates. So the team templates are duplicated.

This creates a specific call in OctoClient for retrieving Global Templates, defined here as teamID = 0.

#### Ticket Link

Fixes https://github.com/mattermost/focalboard/issues/2369

