### PR TITLE
Fix for #2430. Bypass Welcome screen for Personal Desktop.

### DIFF
--- a/server/api/api.go
+++ b/server/api/api.go
@@ -508,11 +508,6 @@ func (a *API) handleUpdateUserConfig(w http.ResponseWriter, r *http.Request) {
 	auditRec := a.makeAuditRecord(r, "updateUserConfig", audit.Fail)
 	defer a.audit.LogRecord(audit.LevelModify, auditRec)
 
-	// Ignore for single-user
-	if session.UserID == model.SingleUser {
-		return
-	}
-
 	// a user can update only own config
 	if userID != session.UserID {
 		http.Error(w, "Unauthorized", http.StatusUnauthorized)
@@ -1781,11 +1776,6 @@ func (a *API) handleOnboard(w http.ResponseWriter, r *http.Request) {
 	//       "$ref": "#/definitions/ErrorResponse"
 	ctx := r.Context()
 	session := ctx.Value(sessionContextKey).(*model.Session)
-
-	// Ignore for single-user
-	if session.UserID == model.SingleUser {
-		return
-	}
 
 	workspaceID, boardID, err := a.app.PrepareOnboardingTour(session.UserID)
 	if err != nil {

--- a/server/api/api.go
+++ b/server/api/api.go
@@ -508,6 +508,11 @@ func (a *API) handleUpdateUserConfig(w http.ResponseWriter, r *http.Request) {
 	auditRec := a.makeAuditRecord(r, "updateUserConfig", audit.Fail)
 	defer a.audit.LogRecord(audit.LevelModify, auditRec)
 
+	// Ignore for single-user
+	if session.UserID == model.SingleUser {
+		return
+	}
+
 	// a user can update only own config
 	if userID != session.UserID {
 		http.Error(w, "Unauthorized", http.StatusUnauthorized)
@@ -1776,6 +1781,11 @@ func (a *API) handleOnboard(w http.ResponseWriter, r *http.Request) {
 	//       "$ref": "#/definitions/ErrorResponse"
 	ctx := r.Context()
 	session := ctx.Value(sessionContextKey).(*model.Session)
+
+	// Ignore for single-user
+	if session.UserID == model.SingleUser {
+		return
+	}
 
 	workspaceID, boardID, err := a.app.PrepareOnboardingTour(session.UserID)
 	if err != nil {

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -102,7 +102,7 @@ const App = (props: Props): JSX.Element => {
     }
 
     const continueToWelcomeScreen = () => {
-        return loggedIn === true && !me?.props[UserPropPrefix + UserSettingKey.WelcomePageViewed]
+        return loggedIn === true && !(me?.props && me?.props[UserPropPrefix + UserSettingKey.WelcomePageViewed])
     }
 
     return (

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -102,7 +102,7 @@ const App = (props: Props): JSX.Element => {
     }
 
     const continueToWelcomeScreen = () => {
-        return Utils.isFocalboardPlugin() && loggedIn === true && !(me?.props && me?.props[UserPropPrefix + UserSettingKey.WelcomePageViewed])
+        return (me?.id !== 'single-user') && loggedIn === true && !(me?.props && me?.props[UserPropPrefix + UserSettingKey.WelcomePageViewed])
     }
 
     return (

--- a/webapp/src/app.tsx
+++ b/webapp/src/app.tsx
@@ -102,7 +102,7 @@ const App = (props: Props): JSX.Element => {
     }
 
     const continueToWelcomeScreen = () => {
-        return loggedIn === true && !(me?.props && me?.props[UserPropPrefix + UserSettingKey.WelcomePageViewed])
+        return Utils.isFocalboardPlugin() && loggedIn === true && !(me?.props && me?.props[UserPropPrefix + UserSettingKey.WelcomePageViewed])
     }
 
     return (

--- a/webapp/src/pages/welcome/welcomePage.tsx
+++ b/webapp/src/pages/welcome/welcomePage.tsx
@@ -86,7 +86,7 @@ const WelcomePage = () => {
         history.replace(newPath)
     }
 
-    if (me?.props[UserPropPrefix + UserSettingKey.WelcomePageViewed]) {
+    if (me?.props && me?.props[UserPropPrefix + UserSettingKey.WelcomePageViewed]) {
         goForward()
         return null
     }

--- a/webapp/src/store/users.ts
+++ b/webapp/src/store/users.ts
@@ -112,7 +112,7 @@ export const getOnboardingTourStarted = createSelector(
             return false
         }
 
-        return Boolean(me.props.focalboard_onboardingTourStarted)
+        return Boolean(me.props?.focalboard_onboardingTourStarted)
     },
 )
 
@@ -123,11 +123,11 @@ export const getOnboardingTourStep = createSelector(
             return ''
         }
 
-        return me.props.focalboard_onboardingTourStep
+        return me.props?.focalboard_onboardingTourStep
     },
 )
 
 export const getOnboardingTourCategory = createSelector(
     getMe,
-    (me): string => (me ? me.props.focalboard_tourCategory : ''),
+    (me): string => (me ? me.props?.focalboard_tourCategory : ''),
 )


### PR DESCRIPTION
#### Summary
This fixes for #2430:
* Avoid null ref errors
* Skip Welcome screen for Personal Desktop (single-user)
* No-op on the new config and onboard APIs for single-user mode

#### Ticket Link
#2430