### PR TITLE
GH-2258 - set min-height on empty date to allow click

### DIFF
--- a/webapp/src/components/properties/dateRange/dateRange.scss
+++ b/webapp/src/components/properties/dateRange/dateRange.scss
@@ -38,6 +38,7 @@
     }
 
     &.empty .Button {
+        min-height: 24px;
         color: rgba(var(--center-channel-color-rgb), 0.4);
         padding: 0 3px;
     }


### PR DESCRIPTION
#### Summary
Not sure if this was regression or if it was ever fixed completely earlier. We may have still been displaying "empty" in the cell in which case the issue would not be present. 

The issue now is with empty date range cells. If you fill in a Data Range via the card view, you can edit the date in the table view. However, if there is no cell data the button height is 0px and cannot be clicked. 

This PR sets the button within a data range to have a minimum width, allowing it to be clicked.

#### Ticket Link

  Fixes https://github.com/mattermost/focalboard/issues/2258


