### PR TITLE
[GH-2396] Fix scroll jump for kanban board

### DIFF
--- a/webapp/src/components/calculations/__snapshots__/options.test.tsx.snap
+++ b/webapp/src/components/calculations/__snapshots__/options.test.tsx.snap
@@ -10,18 +10,9 @@ exports[`components/calculations/Options should match snapshot 1`] = `
       aria-live="polite"
       aria-relevant="additions text"
       class="css-1f43avz-a11yText-A11yText"
-    >
-      <span
-        id="aria-selection"
-      />
-      <span
-        id="aria-context"
-      >
-          Select is focused , press Down to open the menu, 
-      </span>
-    </span>
+    />
     <div
-      class="CalculationOptions__control CalculationOptions__control--is-focused css-1s59geg-Control"
+      class="CalculationOptions__control css-1s59geg-Control"
     >
       <div
         class="CalculationOptions__value-container CalculationOptions__value-container--has-value css-1mxrbau-ValueContainer"
@@ -45,7 +36,7 @@ exports[`components/calculations/Options should match snapshot 1`] = `
       >
         <div
           aria-hidden="true"
-          class="CalculationOptions__indicator CalculationOptions__clear-indicator css-13eygzs-indicatorContainer"
+          class="CalculationOptions__indicator CalculationOptions__clear-indicator css-tpaeio-indicatorContainer"
         >
           <svg
             aria-hidden="true"
@@ -65,7 +56,7 @@ exports[`components/calculations/Options should match snapshot 1`] = `
         />
         <div
           aria-hidden="true"
-          class="CalculationOptions__indicator CalculationOptions__dropdown-indicator css-1f9iddu-indicatorContainer"
+          class="CalculationOptions__indicator CalculationOptions__dropdown-indicator css-wpsttr-indicatorContainer"
         >
           <i
             class="CompassIcon icon-chevron-up ChevronUpIcon"
@@ -92,18 +83,9 @@ exports[`components/calculations/Options should match snapshot menu open 1`] = `
       aria-live="polite"
       aria-relevant="additions text"
       class="css-1f43avz-a11yText-A11yText"
-    >
-      <span
-        id="aria-selection"
-      />
-      <span
-        id="aria-context"
-      >
-         2 results available. Use Up and Down to choose options, press Enter to select the currently focused option, press Escape to exit the menu, press Tab to select the option and exit the menu.
-      </span>
-    </span>
+    />
     <div
-      class="CalculationOptions__control CalculationOptions__control--is-focused CalculationOptions__control--menu-is-open css-1s59geg-Control"
+      class="CalculationOptions__control CalculationOptions__control--menu-is-open css-1s59geg-Control"
     >
       <div
         class="CalculationOptions__value-container CalculationOptions__value-container--has-value css-1mxrbau-ValueContainer"
@@ -127,7 +109,7 @@ exports[`components/calculations/Options should match snapshot menu open 1`] = `
       >
         <div
           aria-hidden="true"
-          class="CalculationOptions__indicator CalculationOptions__clear-indicator css-13eygzs-indicatorContainer"
+          class="CalculationOptions__indicator CalculationOptions__clear-indicator css-tpaeio-indicatorContainer"
         >
           <svg
             aria-hidden="true"
@@ -147,7 +129,7 @@ exports[`components/calculations/Options should match snapshot menu open 1`] = `
         />
         <div
           aria-hidden="true"
-          class="CalculationOptions__indicator CalculationOptions__dropdown-indicator css-1f9iddu-indicatorContainer"
+          class="CalculationOptions__indicator CalculationOptions__dropdown-indicator css-wpsttr-indicatorContainer"
         >
           <i
             class="CompassIcon icon-chevron-up ChevronUpIcon"

--- a/webapp/src/components/calculations/options.tsx
+++ b/webapp/src/components/calculations/options.tsx
@@ -191,7 +191,7 @@ const CalculationOptions = (props: BaseCalculationOptionProps): JSX.Element => {
             isSearchable={false}
             components={{DropdownIndicator, ...(props.components || {})}}
             defaultMenuIsOpen={props.menuOpen}
-            autoFocus={true}
+            autoFocus={false}
             formatOptionLabel={(option: Option, meta) => {
                 return meta.context === 'menu' ? optionLabelString(option, intl) : optionDisplayNameString(option, intl)
             }}

--- a/webapp/src/components/kanban/__snapshots__/kanban.test.tsx.snap
+++ b/webapp/src/components/kanban/__snapshots__/kanban.test.tsx.snap
@@ -336,18 +336,9 @@ exports[`src/component/kanban/kanban return kanban and click on KanbanCalculatio
               aria-live="polite"
               aria-relevant="additions text"
               class="css-1f43avz-a11yText-A11yText"
-            >
-              <span
-                id="aria-selection"
-              />
-              <span
-                id="aria-context"
-              >
-                 7 results available. Use Up and Down to choose options, press Enter to select the currently focused option, press Escape to exit the menu, press Tab to select the option and exit the menu.
-              </span>
-            </span>
+            />
             <div
-              class="CalculationOptions__control CalculationOptions__control--is-focused CalculationOptions__control--menu-is-open css-1s59geg-Control"
+              class="CalculationOptions__control CalculationOptions__control--menu-is-open css-1s59geg-Control"
             >
               <div
                 class="CalculationOptions__value-container CalculationOptions__value-container--has-value css-1mxrbau-ValueContainer"
@@ -371,7 +362,7 @@ exports[`src/component/kanban/kanban return kanban and click on KanbanCalculatio
               >
                 <div
                   aria-hidden="true"
-                  class="CalculationOptions__indicator CalculationOptions__clear-indicator css-13eygzs-indicatorContainer"
+                  class="CalculationOptions__indicator CalculationOptions__clear-indicator css-tpaeio-indicatorContainer"
                 >
                   <svg
                     aria-hidden="true"
@@ -391,7 +382,7 @@ exports[`src/component/kanban/kanban return kanban and click on KanbanCalculatio
                 />
                 <div
                   aria-hidden="true"
-                  class="CalculationOptions__indicator CalculationOptions__dropdown-indicator css-1f9iddu-indicatorContainer"
+                  class="CalculationOptions__indicator CalculationOptions__dropdown-indicator css-wpsttr-indicatorContainer"
                 >
                   <i
                     class="CompassIcon icon-chevron-up ChevronUpIcon"

--- a/webapp/src/components/kanban/calculation/__snapshots__/calculation.test.tsx.snap
+++ b/webapp/src/components/kanban/calculation/__snapshots__/calculation.test.tsx.snap
@@ -40,18 +40,9 @@ exports[`components/kanban/calculation/KanbanCalculation calculations menu open 
         aria-live="polite"
         aria-relevant="additions text"
         class="css-1f43avz-a11yText-A11yText"
-      >
-        <span
-          id="aria-selection"
-        />
-        <span
-          id="aria-context"
-        >
-           7 results available. Use Up and Down to choose options, press Enter to select the currently focused option, press Escape to exit the menu, press Tab to select the option and exit the menu.
-        </span>
-      </span>
+      />
       <div
-        class="CalculationOptions__control CalculationOptions__control--is-focused CalculationOptions__control--menu-is-open css-1s59geg-Control"
+        class="CalculationOptions__control CalculationOptions__control--menu-is-open css-1s59geg-Control"
       >
         <div
           class="CalculationOptions__value-container CalculationOptions__value-container--has-value css-1mxrbau-ValueContainer"
@@ -75,7 +66,7 @@ exports[`components/kanban/calculation/KanbanCalculation calculations menu open 
         >
           <div
             aria-hidden="true"
-            class="CalculationOptions__indicator CalculationOptions__clear-indicator css-13eygzs-indicatorContainer"
+            class="CalculationOptions__indicator CalculationOptions__clear-indicator css-tpaeio-indicatorContainer"
           >
             <svg
               aria-hidden="true"
@@ -95,7 +86,7 @@ exports[`components/kanban/calculation/KanbanCalculation calculations menu open 
           />
           <div
             aria-hidden="true"
-            class="CalculationOptions__indicator CalculationOptions__dropdown-indicator css-1f9iddu-indicatorContainer"
+            class="CalculationOptions__indicator CalculationOptions__dropdown-indicator css-wpsttr-indicatorContainer"
           >
             <i
               class="CompassIcon icon-chevron-up ChevronUpIcon"

--- a/webapp/src/components/kanban/calculation/__snapshots__/calculationOptions.test.tsx.snap
+++ b/webapp/src/components/kanban/calculation/__snapshots__/calculationOptions.test.tsx.snap
@@ -10,18 +10,9 @@ exports[`components/kanban/calculations/KanbanCalculationOptions base case 1`] =
       aria-live="polite"
       aria-relevant="additions text"
       class="css-1f43avz-a11yText-A11yText"
-    >
-      <span
-        id="aria-selection"
-      />
-      <span
-        id="aria-context"
-      >
-          Select is focused , press Down to open the menu, 
-      </span>
-    </span>
+    />
     <div
-      class="CalculationOptions__control CalculationOptions__control--is-focused css-1s59geg-Control"
+      class="CalculationOptions__control css-1s59geg-Control"
     >
       <div
         class="CalculationOptions__value-container CalculationOptions__value-container--has-value css-1mxrbau-ValueContainer"
@@ -45,7 +36,7 @@ exports[`components/kanban/calculations/KanbanCalculationOptions base case 1`] =
       >
         <div
           aria-hidden="true"
-          class="CalculationOptions__indicator CalculationOptions__clear-indicator css-13eygzs-indicatorContainer"
+          class="CalculationOptions__indicator CalculationOptions__clear-indicator css-tpaeio-indicatorContainer"
         >
           <svg
             aria-hidden="true"
@@ -65,7 +56,7 @@ exports[`components/kanban/calculations/KanbanCalculationOptions base case 1`] =
         />
         <div
           aria-hidden="true"
-          class="CalculationOptions__indicator CalculationOptions__dropdown-indicator css-1f9iddu-indicatorContainer"
+          class="CalculationOptions__indicator CalculationOptions__dropdown-indicator css-wpsttr-indicatorContainer"
         >
           <i
             class="CompassIcon icon-chevron-up ChevronUpIcon"
@@ -92,18 +83,9 @@ exports[`components/kanban/calculations/KanbanCalculationOptions with menu open 
       aria-live="polite"
       aria-relevant="additions text"
       class="css-1f43avz-a11yText-A11yText"
-    >
-      <span
-        id="aria-selection"
-      />
-      <span
-        id="aria-context"
-      >
-         7 results available. Use Up and Down to choose options, press Enter to select the currently focused option, press Escape to exit the menu, press Tab to select the option and exit the menu.
-      </span>
-    </span>
+    />
     <div
-      class="CalculationOptions__control CalculationOptions__control--is-focused CalculationOptions__control--menu-is-open css-1s59geg-Control"
+      class="CalculationOptions__control CalculationOptions__control--menu-is-open css-1s59geg-Control"
     >
       <div
         class="CalculationOptions__value-container CalculationOptions__value-container--has-value css-1mxrbau-ValueContainer"
@@ -127,7 +109,7 @@ exports[`components/kanban/calculations/KanbanCalculationOptions with menu open 
       >
         <div
           aria-hidden="true"
-          class="CalculationOptions__indicator CalculationOptions__clear-indicator css-13eygzs-indicatorContainer"
+          class="CalculationOptions__indicator CalculationOptions__clear-indicator css-tpaeio-indicatorContainer"
         >
           <svg
             aria-hidden="true"
@@ -147,7 +129,7 @@ exports[`components/kanban/calculations/KanbanCalculationOptions with menu open 
         />
         <div
           aria-hidden="true"
-          class="CalculationOptions__indicator CalculationOptions__dropdown-indicator css-1f9iddu-indicatorContainer"
+          class="CalculationOptions__indicator CalculationOptions__dropdown-indicator css-wpsttr-indicatorContainer"
         >
           <i
             class="CompassIcon icon-chevron-up ChevronUpIcon"
@@ -256,18 +238,9 @@ exports[`components/kanban/calculations/KanbanCalculationOptions with submenu op
       aria-live="polite"
       aria-relevant="additions text"
       class="css-1f43avz-a11yText-A11yText"
-    >
-      <span
-        id="aria-selection"
-      />
-      <span
-        id="aria-context"
-      >
-         7 results available. Use Up and Down to choose options, press Enter to select the currently focused option, press Escape to exit the menu, press Tab to select the option and exit the menu.
-      </span>
-    </span>
+    />
     <div
-      class="CalculationOptions__control CalculationOptions__control--is-focused CalculationOptions__control--menu-is-open css-1s59geg-Control"
+      class="CalculationOptions__control CalculationOptions__control--menu-is-open css-1s59geg-Control"
     >
       <div
         class="CalculationOptions__value-container CalculationOptions__value-container--has-value css-1mxrbau-ValueContainer"
@@ -291,7 +264,7 @@ exports[`components/kanban/calculations/KanbanCalculationOptions with submenu op
       >
         <div
           aria-hidden="true"
-          class="CalculationOptions__indicator CalculationOptions__clear-indicator css-13eygzs-indicatorContainer"
+          class="CalculationOptions__indicator CalculationOptions__clear-indicator css-tpaeio-indicatorContainer"
         >
           <svg
             aria-hidden="true"
@@ -311,7 +284,7 @@ exports[`components/kanban/calculations/KanbanCalculationOptions with submenu op
         />
         <div
           aria-hidden="true"
-          class="CalculationOptions__indicator CalculationOptions__dropdown-indicator css-1f9iddu-indicatorContainer"
+          class="CalculationOptions__indicator CalculationOptions__dropdown-indicator css-wpsttr-indicatorContainer"
         >
           <i
             class="CompassIcon icon-chevron-up ChevronUpIcon"

--- a/webapp/src/components/kanban/kanban.tsx
+++ b/webapp/src/components/kanban/kanban.tsx
@@ -40,6 +40,10 @@ type Props = {
     showCard: (cardId?: string) => void
 }
 
+const ScrollingComponent = withScrolling('div')
+const hStrength = createHorizontalStrength(Utils.isMobile() ? 60 : 250)
+const vStrength = createVerticalStrength(Utils.isMobile() ? 60 : 250)
+
 const Kanban = (props: Props) => {
     const {board, activeView, cards, groupByProperty, visibleGroups, hiddenGroups} = props
 
@@ -190,10 +194,6 @@ const Kanban = (props: Props) => {
         newShowOptions.set(templateId, show)
         setShowCalculationsMenu(newShowOptions)
     }
-
-    const ScrollingComponent = withScrolling('div')
-    const hStrength = createHorizontalStrength(Utils.isMobile() ? 60 : 250)
-    const vStrength = createVerticalStrength(Utils.isMobile() ? 60 : 250)
 
     return (
         <ScrollingComponent


### PR DESCRIPTION
#### Summary
Fixed bug with scroll jumping when the card is opened:
  - avoid remounting of `ScrollingComponent` for each render of `Kanban` component
  - property `autoFocus` set to false for `CalculationOptions` because it triggers `blur` event for the button in Jest tests and closes the menu
  - snapshots for tests with `CalculationOptions` updated

#### Ticket Link
Fixes #2396 
