### PR TITLE
GH-2257: Don't display template page if readonly and access revoked

### DIFF
--- a/webapp/src/pages/boardPage.tsx
+++ b/webapp/src/pages/boardPage.tsx
@@ -349,9 +349,16 @@ const BoardPage = (props: Props): JSX.Element => {
                 <div className='error'>
                     {intl.formatMessage({id: 'BoardPage.syncFailed', defaultMessage: 'Board may be deleted or access revoked.'})}
                 </div>}
-            <Workspace
-                readonly={props.readonly || false}
-            />
+
+            {
+
+                // Don't display Templates page
+                // if readonly mode and no board defined.
+                (!props.readonly || board !== undefined) &&
+                <Workspace
+                    readonly={props.readonly || false}
+                />
+            }
         </div>
     )
 }


### PR DESCRIPTION
#### Summary
Don't display the workspace if there is no board and it is a read-only view.

The original desired fix was to redirect to the error page. Unfortunately, that wasn't going to work without redesigning the page, as the first time through the board is not yet defined and a redirect causes no boards to display.


#### Ticket Link

  Fixes https://github.com/mattermost/focalboard/issues/2457

![Screen Shot 2022-03-08 at 2 53 42 PM](https://user-images.githubusercontent.com/12704875/157350862-4e15c5e4-8306-4539-816e-409ba60c4734.png)
