### PR TITLE
Gh 2507 fix make swagger

### DIFF
--- a/server/api/api.go
+++ b/server/api/api.go
@@ -746,7 +746,7 @@ func (a *API) handleUpdateUserConfig(w http.ResponseWriter, r *http.Request) {
 	//   default:
 	//     description: internal error
 	//     schema:
-	//       "$ref": "#/definitions/ErrorResponse
+	//       "$ref": "#/definitions/ErrorResponse"
 
 	requestBody, err := ioutil.ReadAll(r.Body)
 	if err != nil {

--- a/server/api/archive.go
+++ b/server/api/archive.go
@@ -25,7 +25,7 @@ func (a *API) handleArchiveExportBoard(w http.ResponseWriter, r *http.Request) {
 	// parameters:
 	// - name: boardID
 	//   in: path
-	//   description: Id of board to to export
+	//   description: Id of board to export
 	//   required: true
 	//   type: string
 	// security:
@@ -85,9 +85,9 @@ func (a *API) handleArchiveExportTeam(w http.ResponseWriter, r *http.Request) {
 	// produces:
 	// - application/json
 	// parameters:
-	// - name: boardID
+	// - name: teamID
 	//   in: path
-	//   description: Id of board to to export
+	//   description: Id of team
 	//   required: true
 	//   type: string
 	// security:

--- a/server/model/user.go
+++ b/server/model/user.go
@@ -57,6 +57,8 @@ type User struct {
 	IsBot bool `json:"is_bot"`
 }
 
+// UserPropPatch is a user property patch
+// swagger:model
 type UserPropPatch struct {
 	// The user prop updated fields
 	// required: false

--- a/server/swagger/swagger.yml
+++ b/server/swagger/swagger.yml
@@ -5,6 +5,10 @@ definitions:
   Block:
     description: Block is the basic data unit
     properties:
+      boardId:
+        description: The board id that the block belongs to
+        type: string
+        x-go-name: BoardID
       createAt:
         description: The creation time
         format: int64
@@ -37,10 +41,6 @@ definitions:
         description: The id for this block's parent block. Empty for root blocks
         type: string
         x-go-name: ParentID
-      boardId:
-        description: The id for this board that this block belongs to
-        type: string
-        x-go-name: BoardID
       schema:
         description: The schema version of this block
         format: int64
@@ -57,25 +57,24 @@ definitions:
         format: int64
         type: integer
         x-go-name: UpdateAt
-      workspaceId:
-        description: The workspace id that the block belongs to
-        type: string
-        x-go-name: WorkspaceID
     required:
     - id
-    - rootId
     - createdBy
     - modifiedBy
     - schema
     - type
     - createAt
     - updateAt
-    - workspaceId
+    - boardId
     type: object
     x-go-package: github.com/mattermost/focalboard/server/model
   BlockPatch:
     description: BlockPatch is a patch for modify blocks
     properties:
+      boardId:
+        description: The board id that the block belongs to
+        type: string
+        x-go-name: BoardID
       deletedFields:
         description: The block removed fields
         items:
@@ -86,10 +85,6 @@ definitions:
         description: The id for this block's parent block. Empty for root blocks
         type: string
         x-go-name: ParentID
-      boardId:
-        description: The id for this board that this block belongs to
-        type: string
-        x-go-name: BoardID
       schema:
         description: The schema version of this block
         format: int64
@@ -105,23 +100,6 @@ definitions:
         additionalProperties:
           type: object
         description: The block updated fields
-        type: object
-        x-go-name: UpdatedFields
-    type: object
-    x-go-package: github.com/mattermost/focalboard/server/model
-  UserPropPatch:
-    description: UserConfigPatch is a patch for user config
-    properties:
-      deletedFields:
-        description: The config fields removed
-        items:
-          type: string
-        type: array
-        x-go-name: DeletedFields
-      updatedFields:
-        additionalProperties:
-          type: object
-        description: The updated config
         type: object
         x-go-name: UpdatedFields
     type: object
@@ -147,6 +125,224 @@ definitions:
     title: BlockType represents a block type.
     type: string
     x-go-package: github.com/mattermost/focalboard/server/model
+  Board:
+    description: Board groups a set of blocks and its layout
+    properties:
+      cardProperties:
+        description: The properties of the board cards
+        items:
+          additionalProperties:
+            type: object
+          type: object
+        type: array
+        x-go-name: CardProperties
+      channelId:
+        description: The ID of the channel that the board was created from
+        type: string
+        x-go-name: ChannelID
+      columnCalculations:
+        additionalProperties:
+          type: object
+        description: The calculations on the board's cards
+        type: object
+        x-go-name: ColumnCalculations
+      createAt:
+        description: The creation time
+        format: int64
+        type: integer
+        x-go-name: CreateAt
+      createdBy:
+        description: The ID of the user that created the board
+        type: string
+        x-go-name: CreatedBy
+      deleteAt:
+        description: The deleted time. Set to indicate this block is deleted
+        format: int64
+        type: integer
+        x-go-name: DeleteAt
+      description:
+        description: The description of the board
+        type: string
+        x-go-name: Description
+      icon:
+        description: The icon of the board
+        type: string
+        x-go-name: Icon
+      id:
+        description: The ID for the board
+        type: string
+        x-go-name: ID
+      isTemplate:
+        description: Marks the template boards
+        type: boolean
+        x-go-name: IsTemplate
+      modifiedBy:
+        description: The ID of the last user that updated the board
+        type: string
+        x-go-name: ModifiedBy
+      properties:
+        additionalProperties:
+          type: object
+        description: The properties of the board
+        type: object
+        x-go-name: Properties
+      showDescription:
+        description: Indicates if the board shows the description on the interface
+        type: boolean
+        x-go-name: ShowDescription
+      teamId:
+        description: The ID of the team that the board belongs to
+        type: string
+        x-go-name: TeamID
+      templateVersion:
+        description: Marks the template boards
+        format: int64
+        type: integer
+        x-go-name: TemplateVersion
+      title:
+        description: The title of the board
+        type: string
+        x-go-name: Title
+      type:
+        $ref: '#/definitions/BoardType'
+      updateAt:
+        description: The last modified time
+        format: int64
+        type: integer
+        x-go-name: UpdateAt
+    required:
+    - id
+    - teamId
+    - createdBy
+    - modifiedBy
+    - type
+    - createAt
+    - updateAt
+    type: object
+    x-go-package: github.com/mattermost/focalboard/server/model
+  BoardMember:
+    description: BoardMember stores the information of the membership of a user on a board
+    properties:
+      boardId:
+        description: The ID of the board
+        type: string
+        x-go-name: BoardID
+      roles:
+        description: The independent roles of the user on the board
+        type: string
+        x-go-name: Roles
+      schemeAdmin:
+        description: Marks the user as an admin of the board
+        type: boolean
+        x-go-name: SchemeAdmin
+      schemeCommenter:
+        description: Marks the user as an commenter of the board
+        type: boolean
+        x-go-name: SchemeCommenter
+      schemeEditor:
+        description: Marks the user as an editor of the board
+        type: boolean
+        x-go-name: SchemeEditor
+      schemeViewer:
+        description: Marks the user as an viewer of the board
+        type: boolean
+        x-go-name: SchemeViewer
+      userId:
+        description: The ID of the user
+        type: string
+        x-go-name: UserID
+    required:
+    - boardId
+    - userId
+    - schemeAdmin
+    - schemeEditor
+    - schemeCommenter
+    - schemeViewer
+    type: object
+    x-go-package: github.com/mattermost/focalboard/server/model
+  BoardPatch:
+    description: BoardPatch is a patch for modify boards
+    properties:
+      deletedCardProperties:
+        description: The board removed card properties
+        items:
+          type: string
+        type: array
+        x-go-name: DeletedCardProperties
+      deletedColumnCalculations:
+        description: The board deleted column calculations
+        items:
+          type: string
+        type: array
+        x-go-name: DeletedColumnCalculations
+      deletedProperties:
+        description: The board removed properties
+        items:
+          type: string
+        type: array
+        x-go-name: DeletedProperties
+      description:
+        description: The description of the board
+        type: string
+        x-go-name: Description
+      icon:
+        description: The icon of the board
+        type: string
+        x-go-name: Icon
+      showDescription:
+        description: Indicates if the board shows the description on the interface
+        type: boolean
+        x-go-name: ShowDescription
+      title:
+        description: The title of the board
+        type: string
+        x-go-name: Title
+      type:
+        $ref: '#/definitions/BoardType'
+      updatedCardProperties:
+        description: The board updated card properties
+        items:
+          additionalProperties:
+            type: object
+          type: object
+        type: array
+        x-go-name: UpdatedCardProperties
+      updatedColumnCalculations:
+        additionalProperties:
+          type: object
+        description: The board updated column calculations
+        type: object
+        x-go-name: UpdatedColumnCalculations
+      updatedProperties:
+        additionalProperties:
+          type: object
+        description: The board updated properties
+        type: object
+        x-go-name: UpdatedProperties
+    type: object
+    x-go-package: github.com/mattermost/focalboard/server/model
+  BoardType:
+    type: string
+    x-go-package: github.com/mattermost/focalboard/server/model
+  BoardsAndBlocks:
+    description: |-
+      BoardsAndBlocks is used to operate over boards and blocks at the
+      same time
+    properties:
+      blocks:
+        description: The blocks
+        items:
+          $ref: '#/definitions/Block'
+        type: array
+        x-go-name: Blocks
+      boards:
+        description: The boards
+        items:
+          $ref: '#/definitions/Board'
+        type: array
+        x-go-name: Boards
+    type: object
+    x-go-package: github.com/mattermost/focalboard/server/model
   ChangePasswordRequest:
     description: ChangePasswordRequest is a user password change request
     properties:
@@ -163,6 +359,28 @@ definitions:
     - newPassword
     type: object
     x-go-package: github.com/mattermost/focalboard/server/api
+  DeleteBoardsAndBlocks:
+    description: |-
+      DeleteBoardsAndBlocks is used to list the boards and blocks to
+      delete on a request
+    properties:
+      blocks:
+        description: The blocks
+        items:
+          type: string
+        type: array
+        x-go-name: Blocks
+      boards:
+        description: The boards
+        items:
+          type: string
+        type: array
+        x-go-name: Boards
+    required:
+    - boards
+    - blocks
+    type: object
+    x-go-package: github.com/mattermost/focalboard/server/model
   ErrorResponse:
     description: ErrorResponse is an error response
     properties:
@@ -248,16 +466,47 @@ definitions:
         format: int64
         type: integer
         x-go-name: NotifyAt
-      workspace_id:
-        description: WorkspaceID is id of workspace the block belongs to
-        type: string
-        x-go-name: WorkspaceID
     required:
     - block_type
     - block_id
-    - workspace_id
     - create_at
     - notify_at
+    type: object
+    x-go-package: github.com/mattermost/focalboard/server/model
+  PatchBoardsAndBlocks:
+    description: |-
+      PatchBoardsAndBlocks is used to patch multiple boards and blocks on
+      a single request
+    properties:
+      blockIDs:
+        description: The block IDs to patch
+        items:
+          type: string
+        type: array
+        x-go-name: BlockIDs
+      blockPatches:
+        description: The block patches
+        items:
+          $ref: '#/definitions/BlockPatch'
+        type: array
+        x-go-name: BlockPatches
+      boardIDs:
+        description: The board IDs to patch
+        items:
+          type: string
+        type: array
+        x-go-name: BoardIDs
+      boardPatches:
+        description: The board patches
+        items:
+          $ref: '#/definitions/BoardPatch'
+        type: array
+        x-go-name: BoardPatches
+    required:
+    - boardIDs
+    - boardPatches
+    - blockIDs
+    - blockPatches
     type: object
     x-go-package: github.com/mattermost/focalboard/server/model
   RegisterRequest:
@@ -319,8 +568,7 @@ definitions:
     type: object
     x-go-package: github.com/mattermost/focalboard/server/model
   Subscriber:
-    description: Subscriber is an entity (e.g. user, channel) that can subscribe to
-      events from boards, cards, etc
+    description: Subscriber is an entity (e.g. user, channel) that can subscribe to events from boards, cards, etc
     properties:
       notified_at:
         description: NotifiedAt is the timestamp this subscriber was last notified
@@ -355,14 +603,12 @@ definitions:
         type: integer
         x-go-name: CreateAt
       deleteAt:
-        description: DeleteAt is the timestamp this subscription was deleted, or zero
-          if not deleted
+        description: DeleteAt is the timestamp this subscription was deleted, or zero if not deleted
         format: int64
         type: integer
         x-go-name: DeleteAt
       notifiedAt:
-        description: NotifiedAt is the timestamp of the last notification sent for
-          this subscription
+        description: NotifiedAt is the timestamp of the last notification sent for this subscription
         format: int64
         type: integer
         x-go-name: NotifiedAt
@@ -372,20 +618,52 @@ definitions:
         x-go-name: SubscriberID
       subscriberType:
         $ref: '#/definitions/SubscriberType'
-      workspaceId:
-        description: WorkspaceID is id of the workspace the block belongs to
-        type: string
-        x-go-name: WorkspaceID
     required:
     - blockType
     - blockId
-    - workspaceId
     - subscriberType
     - subscriberId
     - notifiedAt
     - createAt
     - deleteAt
     title: Subscription is a subscription to a board, card, etc, for a user or channel.
+    type: object
+    x-go-package: github.com/mattermost/focalboard/server/model
+  Team:
+    description: Team is information global to a team
+    properties:
+      id:
+        description: ID of the team
+        type: string
+        x-go-name: ID
+      modifiedBy:
+        description: ID of user who last modified this
+        type: string
+        x-go-name: ModifiedBy
+      settings:
+        additionalProperties:
+          type: object
+        description: Team settings
+        type: object
+        x-go-name: Settings
+      signupToken:
+        description: Token required to register new users
+        type: string
+        x-go-name: SignupToken
+      title:
+        description: Title of the team
+        type: string
+        x-go-name: Title
+      updateAt:
+        description: Updated time
+        format: int64
+        type: integer
+        x-go-name: UpdateAt
+    required:
+    - id
+    - signupToken
+    - modifiedBy
+    - updateAt
     type: object
     x-go-package: github.com/mattermost/focalboard/server/model
   User:
@@ -434,74 +712,23 @@ definitions:
     - is_bot
     type: object
     x-go-package: github.com/mattermost/focalboard/server/model
-  UserWorkspace:
-    description: |-
-      UserWorkspace is a summary of a single association between
-      a user and a workspace
+  UserPropPatch:
+    description: UserPropPatch is a user property patch
     properties:
-      boardCount:
-        description: Number of boards in the workspace
-        format: int64
-        type: integer
-        x-go-name: BoardCount
-      id:
-        description: ID of the workspace
-        type: string
-        x-go-name: ID
-      title:
-        description: Title of the workspace
-        type: string
-        x-go-name: Title
-    required:
-    - id
-    type: object
-    x-go-package: github.com/mattermost/focalboard/server/model
-  Workspace:
-    description: Workspace is information global to a workspace
-    properties:
-      id:
-        description: ID of the workspace
-        type: string
-        x-go-name: ID
-      modifiedBy:
-        description: ID of user who last modified this
-        type: string
-        x-go-name: ModifiedBy
-      settings:
+      deletedFields:
+        description: The user prop removed fields
+        items:
+          type: string
+        type: array
+        x-go-name: DeletedFields
+      updatedFields:
         additionalProperties:
-          type: object
-        description: Workspace settings
+          type: string
+        description: The user prop updated fields
         type: object
-        x-go-name: Settings
-      signupToken:
-        description: Token required to register new users
-        type: string
-        x-go-name: SignupToken
-      title:
-        description: Title of the workspace
-        type: string
-        x-go-name: Title
-      updateAt:
-        description: Updated time
-        format: int64
-        type: integer
-        x-go-name: UpdateAt
-    required:
-    - id
-    - signupToken
-    - modifiedBy
-    - updateAt
+        x-go-name: UpdatedFields
     type: object
     x-go-package: github.com/mattermost/focalboard/server/model
-  OnboardingResponse:
-    description: OnboardResponse contains basic data required by the client to complete the onboarding
-    properties:
-      workspaceID:
-        description: the workspace to send to user to, to start the onboarding tour
-        type: string
-      boardID:
-        description: the board to send to user to, to start the onboarding tour
-        type: string
 host: localhost
 info:
   contact:
@@ -515,6 +742,613 @@ info:
   title: Focalboard Server
   version: 1.0.0
 paths:
+  /api/v1/boards:
+    post:
+      description: Creates a new board
+      operationId: createBoard
+      parameters:
+      - description: the board to create
+        in: body
+        name: Body
+        required: true
+        schema:
+          $ref: '#/definitions/Board'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: success
+          schema:
+            $ref: '#/definitions/Board'
+        default:
+          description: internal error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+      security:
+      - BearerAuth: []
+  /api/v1/boards-and-blocks:
+    delete:
+      description: Deletes boards and blocks
+      operationId: deleteBoardsAndBlocks
+      parameters:
+      - description: the boards and blocks to delete
+        in: body
+        name: Body
+        required: true
+        schema:
+          $ref: '#/definitions/DeleteBoardsAndBlocks'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: success
+        default:
+          description: internal error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+      security:
+      - BearerAuth: []
+    patch:
+      description: Patches a set of related boards and blocks
+      operationId: patchBoardsAndBlocks
+      parameters:
+      - description: the patches for the boards and blocks
+        in: body
+        name: Body
+        required: true
+        schema:
+          $ref: '#/definitions/PatchBoardsAndBlocks'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: success
+          schema:
+            $ref: '#/definitions/BoardsAndBlocks'
+        default:
+          description: internal error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+      security:
+      - BearerAuth: []
+    post:
+      description: Creates new boards and blocks
+      operationId: insertBoardsAndBlocks
+      parameters:
+      - description: the boards and blocks to create
+        in: body
+        name: Body
+        required: true
+        schema:
+          $ref: '#/definitions/BoardsAndBlocks'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: success
+          schema:
+            $ref: '#/definitions/BoardsAndBlocks'
+        default:
+          description: internal error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+      security:
+      - BearerAuth: []
+  /api/v1/boards/{boardID}:
+    delete:
+      description: Removes a board
+      operationId: deleteBoard
+      parameters:
+      - description: Board ID
+        in: path
+        name: boardID
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: success
+        default:
+          description: internal error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+      security:
+      - BearerAuth: []
+    get:
+      description: Returns a board
+      operationId: getBoard
+      parameters:
+      - description: Board ID
+        in: path
+        name: boardID
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: success
+          schema:
+            $ref: '#/definitions/Board'
+        default:
+          description: internal error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+      security:
+      - BearerAuth: []
+    patch:
+      description: Partially updates a board
+      operationId: patchBoard
+      parameters:
+      - description: Board ID
+        in: path
+        name: boardID
+        required: true
+        type: string
+      - description: board patch to apply
+        in: body
+        name: Body
+        required: true
+        schema:
+          $ref: '#/definitions/BoardPatch'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: success
+          schema:
+            $ref: '#/definitions/Board'
+        default:
+          description: internal error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+      security:
+      - BearerAuth: []
+  /api/v1/boards/{boardID}/archive/export:
+    get:
+      operationId: archiveExportBoard
+      parameters:
+      - description: Id of board to export
+        in: path
+        name: boardID
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: success
+        default:
+          description: internal error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Exports an archive of all blocks for one boards.
+  /api/v1/boards/{boardID}/archive/import:
+    post:
+      consumes:
+      - multipart/form-data
+      operationId: archiveImport
+      parameters:
+      - description: Workspace ID
+        in: path
+        name: boardID
+        required: true
+        type: string
+      - description: archive file to import
+        in: formData
+        name: file
+        required: true
+        type: file
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: success
+        default:
+          description: internal error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Import an archive of boards.
+  /api/v1/boards/{boardID}/blocks:
+    get:
+      description: Returns blocks
+      operationId: getBlocks
+      parameters:
+      - description: Board ID
+        in: path
+        name: boardID
+        required: true
+        type: string
+      - description: ID of parent block, omit to specify all blocks
+        in: query
+        name: parent_id
+        type: string
+      - description: Type of blocks to return, omit to specify all types
+        in: query
+        name: type
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: success
+          schema:
+            items:
+              $ref: '#/definitions/Block'
+            type: array
+        default:
+          description: internal error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+      security:
+      - BearerAuth: []
+    post:
+      description: |-
+        Insert blocks. The specified IDs will only be used to link
+        blocks with existing ones, the rest will be replaced by server
+        generated IDs
+      operationId: updateBlocks
+      parameters:
+      - description: Board ID
+        in: path
+        name: boardID
+        required: true
+        type: string
+      - description: array of blocks to insert or update
+        in: body
+        name: Body
+        required: true
+        schema:
+          items:
+            $ref: '#/definitions/Block'
+          type: array
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: success
+          schema:
+            items:
+              $ref: '#/definitions/Block'
+            type: array
+        default:
+          description: internal error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+      security:
+      - BearerAuth: []
+  /api/v1/boards/{boardID}/blocks/:
+    patch:
+      description: Partially updates batch of blocks
+      operationId: patchBlocks
+      parameters:
+      - description: Workspace ID
+        in: path
+        name: boardID
+        required: true
+        type: string
+      - description: block Ids and block patches to apply
+        in: body
+        name: Body
+        required: true
+        schema:
+          $ref: '#/definitions/BlockPatchBatch'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: success
+        default:
+          description: internal error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+      security:
+      - BearerAuth: []
+  /api/v1/boards/{boardID}/blocks/{blockID}:
+    delete:
+      description: Deletes a block
+      operationId: deleteBlock
+      parameters:
+      - description: Board ID
+        in: path
+        name: boardID
+        required: true
+        type: string
+      - description: ID of block to delete
+        in: path
+        name: blockID
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: success
+        default:
+          description: internal error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+      security:
+      - BearerAuth: []
+    patch:
+      description: Partially updates a block
+      operationId: patchBlock
+      parameters:
+      - description: Board ID
+        in: path
+        name: boardID
+        required: true
+        type: string
+      - description: ID of block to patch
+        in: path
+        name: blockID
+        required: true
+        type: string
+      - description: block patch to apply
+        in: body
+        name: Body
+        required: true
+        schema:
+          $ref: '#/definitions/BlockPatch'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: success
+        default:
+          description: internal error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+      security:
+      - BearerAuth: []
+  /api/v1/boards/{boardID}/blocks/{blockID}/duplicate:
+    post:
+      description: Returns the new created blocks
+      operationId: duplicateBlock
+      parameters:
+      - description: Board ID
+        in: path
+        name: boardID
+        required: true
+        type: string
+      - description: Block ID
+        in: path
+        name: blockID
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: success
+          schema:
+            items:
+              $ref: '#/definitions/Block'
+            type: array
+        default:
+          description: internal error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+      security:
+      - BearerAuth: []
+  /api/v1/boards/{boardID}/blocks/{blockID}/subtree:
+    get:
+      description: Returns the blocks of a subtree
+      operationId: getSubTree
+      parameters:
+      - description: Board ID
+        in: path
+        name: boardID
+        required: true
+        type: string
+      - description: The ID of the root block of the subtree
+        in: path
+        name: blockID
+        required: true
+        type: string
+      - description: The number of levels to return. 2 or 3. Defaults to 2.
+        in: query
+        maximum: 3
+        minimum: 2
+        name: l
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: success
+          schema:
+            items:
+              $ref: '#/definitions/Block'
+            type: array
+        default:
+          description: internal error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+      security:
+      - BearerAuth: []
+  /api/v1/boards/{boardID}/blocks/export:
+    get:
+      description: Returns all blocks of a board
+      operationId: exportBlocks
+      parameters:
+      - description: Board ID
+        in: path
+        name: boardID
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: success
+          schema:
+            items:
+              $ref: '#/definitions/Block'
+            type: array
+        default:
+          description: internal error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+      security:
+      - BearerAuth: []
+  /api/v1/boards/{boardID}/blocks/import:
+    post:
+      description: Import blocks on a given board
+      operationId: importBlocks
+      parameters:
+      - description: Board ID
+        in: path
+        name: boardID
+        required: true
+        type: string
+      - description: array of blocks to import
+        in: body
+        name: Body
+        required: true
+        schema:
+          items:
+            $ref: '#/definitions/Block'
+          type: array
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: success
+        default:
+          description: internal error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+      security:
+      - BearerAuth: []
+  /api/v1/boards/{boardID}/duplicate:
+    post:
+      description: Returns the new created board and all the blocks
+      operationId: duplicateBoard
+      parameters:
+      - description: Board ID
+        in: path
+        name: boardID
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: success
+          schema:
+            $ref: '#/definitions/BoardsAndBlocks'
+        default:
+          description: internal error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+      security:
+      - BearerAuth: []
+  /api/v1/boards/{boardID}/members:
+    get:
+      description: Returns the members of the board
+      operationId: getMembersForBoard
+      parameters:
+      - description: Board ID
+        in: path
+        name: boardID
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: success
+          schema:
+            items:
+              $ref: '#/definitions/BoardMember'
+            type: array
+        default:
+          description: internal error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+      security:
+      - BearerAuth: []
+  /api/v1/boards/{boardID}/members/{userID}:
+    delete:
+      description: Deletes a member from a board
+      operationId: deleteMember
+      parameters:
+      - description: Board ID
+        in: path
+        name: boardID
+        required: true
+        type: string
+      - description: User ID
+        in: path
+        name: userID
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: success
+        default:
+          description: internal error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+      security:
+      - BearerAuth: []
+  /api/v1/boards/{boardID}/sharing:
+    get:
+      description: Returns sharing information for a board
+      operationId: getSharing
+      parameters:
+      - description: Board ID
+        in: path
+        name: boardID
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: success
+          schema:
+            $ref: '#/definitions/Sharing'
+        default:
+          description: internal error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+      security:
+      - BearerAuth: []
+    post:
+      description: Sets sharing information for a board
+      operationId: postSharing
+      parameters:
+      - description: Board ID
+        in: path
+        name: boardID
+        required: true
+        type: string
+      - description: sharing information for a root block
+        in: body
+        name: Body
+        required: true
+        schema:
+          $ref: '#/definitions/Sharing'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: success
+        default:
+          description: internal error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+      security:
+      - BearerAuth: []
   /api/v1/login:
     post:
       description: Login user
@@ -578,6 +1412,336 @@ paths:
           description: internal error
           schema:
             $ref: '#/definitions/ErrorResponse'
+  /api/v1/subscriptions:
+    post:
+      operationId: createSubscription
+      parameters:
+      - description: subscription definition
+        in: body
+        name: Body
+        required: true
+        schema:
+          $ref: '#/definitions/Subscription'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: success
+          schema:
+            $ref: '#/definitions/User'
+        default:
+          description: internal error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Creates a subscription to a block for a user. The user will receive change notifications for the block.
+  /api/v1/subscriptions/{blockID}/{subscriberID}:
+    delete:
+      operationId: deleteSubscription
+      parameters:
+      - description: Block ID
+        in: path
+        name: blockID
+        required: true
+        type: string
+      - description: Subscriber ID
+        in: path
+        name: subscriberID
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: success
+        default:
+          description: internal error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Deletes a subscription a user has for a a block. The user will no longer receive change notifications for the block.
+  /api/v1/subscriptions/{subscriberID}:
+    get:
+      operationId: getSubscriptions
+      parameters:
+      - description: Subscriber ID
+        in: path
+        name: subscriberID
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: success
+          schema:
+            items:
+              $ref: '#/definitions/User'
+            type: array
+        default:
+          description: internal error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Gets subscriptions for a user.
+  /api/v1/team/{teamID}/onboard:
+    post:
+      operationId: onboard
+      parameters:
+      - description: Team ID
+        in: path
+        name: teamID
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: success
+          schema:
+            $ref: '#/definitions/OnboardingResponse'
+        default:
+          description: internal error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Onboards a user on Boards.
+  /api/v1/teams:
+    get:
+      description: Returns information of all the teams
+      operationId: getTeams
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: success
+          schema:
+            items:
+              $ref: '#/definitions/Team'
+            type: array
+        default:
+          description: internal error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+      security:
+      - BearerAuth: []
+  /api/v1/teams/{teamID}:
+    get:
+      description: Returns information of the root team
+      operationId: getTeam
+      parameters:
+      - description: Team ID
+        in: path
+        name: teamID
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: success
+          schema:
+            $ref: '#/definitions/Team'
+        default:
+          description: internal error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+      security:
+      - BearerAuth: []
+  /api/v1/teams/{teamID}/archive/export:
+    get:
+      operationId: archiveExportTeam
+      parameters:
+      - description: Id of team
+        in: path
+        name: teamID
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: success
+        default:
+          description: internal error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Exports an archive of all blocks for all the boards in a team.
+  /api/v1/teams/{teamID}/boards:
+    get:
+      description: Returns team boards
+      operationId: getBoards
+      parameters:
+      - description: Team ID
+        in: path
+        name: teamID
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: success
+          schema:
+            items:
+              $ref: '#/definitions/Board'
+            type: array
+        default:
+          description: internal error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+      security:
+      - BearerAuth: []
+  /api/v1/teams/{teamID}/boards/{boardID}/files:
+    post:
+      consumes:
+      - multipart/form-data
+      description: Upload a binary file, attached to a root block
+      operationId: uploadFile
+      parameters:
+      - description: ID of the team
+        in: path
+        name: teamID
+        required: true
+        type: string
+      - description: Board ID
+        in: path
+        name: boardID
+        required: true
+        type: string
+      - description: The file to upload
+        in: formData
+        name: uploaded file
+        type: file
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: success
+          schema:
+            $ref: '#/definitions/FileUploadResponse'
+        default:
+          description: internal error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+      security:
+      - BearerAuth: []
+  /api/v1/teams/{teamID}/boards/search:
+    get:
+      description: Returns the boards that match with a search term
+      operationId: searchBoards
+      parameters:
+      - description: Board ID
+        in: path
+        name: boardID
+        required: true
+        type: string
+      - description: Team ID
+        in: path
+        name: teamID
+        required: true
+        type: string
+      - description: The search term. Must have at least one character
+        in: query
+        name: q
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: success
+          schema:
+            items:
+              $ref: '#/definitions/Board'
+            type: array
+        default:
+          description: internal error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+      security:
+      - BearerAuth: []
+  /api/v1/teams/{teamID}/regenerate_signup_token:
+    post:
+      description: Regenerates the signup token for the root team
+      operationId: regenerateSignupToken
+      parameters:
+      - description: Team ID
+        in: path
+        name: teamID
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: success
+        default:
+          description: internal error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+      security:
+      - BearerAuth: []
+  /api/v1/teams/{teamID}/templates:
+    get:
+      description: Returns team templates
+      operationId: getTemplates
+      parameters:
+      - description: Team ID
+        in: path
+        name: teamID
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: success
+          schema:
+            items:
+              $ref: '#/definitions/Board'
+            type: array
+        default:
+          description: internal error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+      security:
+      - BearerAuth: []
+  /api/v1/teams/{teamID}/users:
+    get:
+      description: Returns team users
+      operationId: getTeamUsers
+      parameters:
+      - description: Team ID
+        in: path
+        name: teamID
+        required: true
+        type: string
+      - description: string to filter users list
+        in: query
+        name: search
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: success
+          schema:
+            items:
+              $ref: '#/definitions/User'
+            type: array
+        default:
+          description: internal error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+      security:
+      - BearerAuth: []
   /api/v1/users/{userID}:
     get:
       description: Returns a user
@@ -632,6 +1796,33 @@ paths:
             $ref: '#/definitions/ErrorResponse'
       security:
       - BearerAuth: []
+  /api/v1/users/{userID}/config:
+    patch:
+      description: Updates user config
+      operationId: updateUserConfig
+      parameters:
+      - description: User ID
+        in: path
+        name: userID
+        required: true
+        type: string
+      - description: User config patch to apply
+        in: body
+        name: Body
+        required: true
+        schema:
+          $ref: '#/definitions/UserPropPatch'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: success
+        default:
+          description: internal error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+      security:
+      - BearerAuth: []
   /api/v1/users/me:
     get:
       description: Returns the currently logged-in user
@@ -649,169 +1840,17 @@ paths:
             $ref: '#/definitions/ErrorResponse'
       security:
       - BearerAuth: []
-  /api/v1/workspaces/{workspaceID}:
-    get:
-      description: Returns information of the root workspace
-      operationId: getWorkspace
-      parameters:
-      - description: Workspace ID
-        in: path
-        name: workspaceID
-        required: true
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: success
-          schema:
-            $ref: '#/definitions/Workspace'
-        default:
-          description: internal error
-          schema:
-            $ref: '#/definitions/ErrorResponse'
-      security:
-      - BearerAuth: []
-  /api/v1/workspaces/{workspaceID}/{rootID}/files:
+  /api/v1/workspaces/{workspaceID}/blocks/{blockID}/undelete:
     post:
-      consumes:
-      - multipart/form-data
-      description: Upload a binary file, attached to a root block
-      operationId: uploadFile
+      description: Undeletes a block
+      operationId: undeleteBlock
       parameters:
       - description: Workspace ID
         in: path
         name: workspaceID
         required: true
         type: string
-      - description: ID of the root block
-        in: path
-        name: rootID
-        required: true
-        type: string
-      - description: The file to upload
-        in: formData
-        name: uploaded file
-        type: file
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: success
-          schema:
-            $ref: '#/definitions/FileUploadResponse'
-        default:
-          description: internal error
-          schema:
-            $ref: '#/definitions/ErrorResponse'
-      security:
-      - BearerAuth: []
-  /api/v1/workspaces/{workspaceID}/blocks:
-    get:
-      description: Returns blocks
-      operationId: getBlocks
-      parameters:
-      - description: Workspace ID
-        in: path
-        name: workspaceID
-        required: true
-        type: string
-      - description: ID of parent block, omit to specify all blocks
-        in: query
-        name: parent_id
-        type: string
-      - description: Type of blocks to return, omit to specify all types
-        in: query
-        name: type
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: success
-          schema:
-            items:
-              $ref: '#/definitions/Block'
-            type: array
-        default:
-          description: internal error
-          schema:
-            $ref: '#/definitions/ErrorResponse'
-      security:
-      - BearerAuth: []
-    post:
-      description: |-
-        Insert blocks. The specified IDs will only be used to link
-        blocks with existing ones, the rest will be replaced by server
-        generated IDs
-      operationId: updateBlocks
-      parameters:
-      - description: Workspace ID
-        in: path
-        name: workspaceID
-        required: true
-        type: string
-      - description: array of blocks to insert or update
-        in: body
-        name: Body
-        required: true
-        schema:
-          items:
-            $ref: '#/definitions/Block'
-          type: array
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: success
-          schema:
-            items:
-              $ref: '#/definitions/Block'
-            type: array
-        default:
-          description: internal error
-          schema:
-            $ref: '#/definitions/ErrorResponse'
-      security:
-      - BearerAuth: []
-  /api/v1/workspaces/{workspaceID}/blocks/:
-    patch:
-      description: Partially updates batch of blocks
-      operationId: patchBlocks
-      parameters:
-      - description: Workspace ID
-        in: path
-        name: workspaceID
-        required: true
-        type: string
-      - description: block Ids and block patches to apply
-        in: body
-        name: Body
-        required: true
-        schema:
-          $ref: '#/definitions/BlockPatchBatch'
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: success
-        default:
-          description: internal error
-          schema:
-            $ref: '#/definitions/ErrorResponse'
-      security:
-      - BearerAuth: []
-  /api/v1/workspaces/{workspaceID}/blocks/{blockID}:
-    delete:
-      description: Deletes a block
-      operationId: deleteBlock
-      parameters:
-      - description: Workspace ID
-        in: path
-        name: workspaceID
-        required: true
-        type: string
-      - description: ID of block to delete
+      - description: ID of block to undelete
         in: path
         name: blockID
         required: true
@@ -827,332 +1866,14 @@ paths:
             $ref: '#/definitions/ErrorResponse'
       security:
       - BearerAuth: []
-    patch:
-      description: Partially updates a block
-      operationId: patchBlock
-      parameters:
-      - description: Workspace ID
-        in: path
-        name: workspaceID
-        required: true
-        type: string
-      - description: ID of block to patch
-        in: path
-        name: blockID
-        required: true
-        type: string
-      - description: block patch to apply
-        in: body
-        name: Body
-        required: true
-        schema:
-          $ref: '#/definitions/BlockPatch'
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: success
-        default:
-          description: internal error
-          schema:
-            $ref: '#/definitions/ErrorResponse'
-      security:
-      - BearerAuth: []
-  /api/v1/workspaces/{workspaceID}/blocks/{blockID}/subtree:
-    get:
-      description: Returns the blocks of a subtree
-      operationId: getSubTree
-      parameters:
-      - description: Workspace ID
-        in: path
-        name: workspaceID
-        required: true
-        type: string
-      - description: The ID of the root block of the subtree
-        in: path
-        name: blockID
-        required: true
-        type: string
-      - description: The number of levels to return. 2 or 3. Defaults to 2.
-        in: query
-        maximum: 3
-        minimum: 2
-        name: l
-        type: integer
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: success
-          schema:
-            items:
-              $ref: '#/definitions/Block'
-            type: array
-        default:
-          description: internal error
-          schema:
-            $ref: '#/definitions/ErrorResponse'
-      security:
-      - BearerAuth: []
-  /api/v1/workspaces/{workspaceID}/blocks/export:
-    get:
-      description: Returns all blocks
-      operationId: exportBlocks
-      parameters:
-      - description: Workspace ID
-        in: path
-        name: workspaceID
-        required: true
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: success
-          schema:
-            items:
-              $ref: '#/definitions/Block'
-            type: array
-        default:
-          description: internal error
-          schema:
-            $ref: '#/definitions/ErrorResponse'
-      security:
-      - BearerAuth: []
-  /api/v1/workspaces/{workspaceID}/blocks/import:
-    post:
-      description: Import blocks
-      operationId: importBlocks
-      parameters:
-      - description: Workspace ID
-        in: path
-        name: workspaceID
-        required: true
-        type: string
-      - description: array of blocks to import
-        in: body
-        name: Body
-        required: true
-        schema:
-          items:
-            $ref: '#/definitions/Block'
-          type: array
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: success
-        default:
-          description: internal error
-          schema:
-            $ref: '#/definitions/ErrorResponse'
-      security:
-      - BearerAuth: []
-  /api/v1/workspaces/{workspaceID}/regenerate_signup_token:
-    post:
-      description: Regenerates the signup token for the root workspace
-      operationId: regenerateSignupToken
-      parameters:
-      - description: Workspace ID
-        in: path
-        name: workspaceID
-        required: true
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: success
-        default:
-          description: internal error
-          schema:
-            $ref: '#/definitions/ErrorResponse'
-      security:
-      - BearerAuth: []
-  /api/v1/workspaces/{workspaceID}/sharing/{rootID}:
-    get:
-      description: Returns sharing information for a root block
-      operationId: getSharing
-      parameters:
-      - description: Workspace ID
-        in: path
-        name: workspaceID
-        required: true
-        type: string
-      - description: ID of the root block
-        in: path
-        name: rootID
-        required: true
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: success
-          schema:
-            $ref: '#/definitions/Sharing'
-        default:
-          description: internal error
-          schema:
-            $ref: '#/definitions/ErrorResponse'
-      security:
-      - BearerAuth: []
-    post:
-      description: Sets sharing information for a root block
-      operationId: postSharing
-      parameters:
-      - description: Workspace ID
-        in: path
-        name: workspaceID
-        required: true
-        type: string
-      - description: ID of the root block
-        in: path
-        name: rootID
-        required: true
-        type: string
-      - description: sharing information for a root block
-        in: body
-        name: Body
-        required: true
-        schema:
-          $ref: '#/definitions/Sharing'
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: success
-        default:
-          description: internal error
-          schema:
-            $ref: '#/definitions/ErrorResponse'
-      security:
-      - BearerAuth: []
-  /api/v1/workspaces/{workspaceID}/subscriptions:
-    post:
-      operationId: createSubscription
-      parameters:
-      - description: Workspace ID
-        in: path
-        name: workspaceID
-        required: true
-        type: string
-      - description: subscription definition
-        in: body
-        name: Body
-        required: true
-        schema:
-          $ref: '#/definitions/Subscription'
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: success
-          schema:
-            $ref: '#/definitions/User'
-        default:
-          description: internal error
-          schema:
-            $ref: '#/definitions/ErrorResponse'
-      security:
-      - BearerAuth: []
-      summary: Creates a subscription to a block for a user. The user will receive
-        change notifications for the block.
-  /api/v1/workspaces/{workspaceID}/subscriptions/{blockID}/{subscriberID}:
-    delete:
-      operationId: deleteSubscription
-      parameters:
-      - description: Workspace ID
-        in: path
-        name: workspaceID
-        required: true
-        type: string
-      - description: Block ID
-        in: path
-        name: blockID
-        required: true
-        type: string
-      - description: Subscriber ID
-        in: path
-        name: subscriberID
-        required: true
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: success
-        default:
-          description: internal error
-          schema:
-            $ref: '#/definitions/ErrorResponse'
-      security:
-      - BearerAuth: []
-      summary: Deletes a subscription a user has for a a block. The user will no longer
-        receive change notifications for the block.
-  /api/v1/workspaces/{workspaceID}/subscriptions/{subscriberID}:
-    get:
-      operationId: getSubscriptions
-      parameters:
-      - description: Workspace ID
-        in: path
-        name: workspaceID
-        required: true
-        type: string
-      - description: Subscriber ID
-        in: path
-        name: subscriberID
-        required: true
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: success
-          schema:
-            items:
-              $ref: '#/definitions/User'
-            type: array
-        default:
-          description: internal error
-          schema:
-            $ref: '#/definitions/ErrorResponse'
-      security:
-      - BearerAuth: []
-      summary: Gets subscriptions for a user.
-  /api/v1/workspaces/{workspaceID}/users:
-    get:
-      description: Returns workspace users
-      operationId: getWorkspaceUsers
-      parameters:
-      - description: Workspace ID
-        in: path
-        name: workspaceID
-        required: true
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: success
-          schema:
-            items:
-              $ref: '#/definitions/User'
-            type: array
-        default:
-          description: internal error
-          schema:
-            $ref: '#/definitions/ErrorResponse'
-      security:
-      - BearerAuth: []
-  /workspaces/{workspaceID}/{rootID}/{fileID}:
+  /boards/{boardID}/{rootID}/{fileID}:
     get:
       description: Returns the contents of an uploaded file
       operationId: getFile
       parameters:
-      - description: Workspace ID
+      - description: Board ID
         in: path
-        name: workspaceID
+        name: boardID
         required: true
         type: string
       - description: ID of the root block
@@ -1169,9 +1890,73 @@ paths:
       - application/json
       - image/jpg
       - image/png
+      - image/gif
       responses:
         "200":
           description: success
+        default:
+          description: internal error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+      security:
+      - BearerAuth: []
+  /boards/{boardID}/members:
+    post:
+      description: Adds a new member to a board
+      operationId: addMember
+      parameters:
+      - description: Board ID
+        in: path
+        name: boardID
+        required: true
+        type: string
+      - description: membership to replace the current one with
+        in: body
+        name: Body
+        required: true
+        schema:
+          $ref: '#/definitions/BoardMember'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: success
+          schema:
+            $ref: '#/definitions/BoardMember'
+        default:
+          description: internal error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+      security:
+      - BearerAuth: []
+  /boards/{boardID}/members/{userID}:
+    put:
+      description: Updates a board member
+      operationId: updateMember
+      parameters:
+      - description: Board ID
+        in: path
+        name: boardID
+        required: true
+        type: string
+      - description: User ID
+        in: path
+        name: userID
+        required: true
+        type: string
+      - description: membership to replace the current one with
+        in: body
+        name: Body
+        required: true
+        schema:
+          $ref: '#/definitions/BoardMember'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: success
+          schema:
+            $ref: '#/definitions/BoardMember'
         default:
           description: internal error
           schema:
@@ -1185,8 +1970,7 @@ schemes:
 - https
 securityDefinitions:
   BearerAuth:
-    description: 'Pass session token using Bearer authentication, e.g. set header
-      "Authorization: Bearer <session token>"'
+    description: 'Pass session token using Bearer authentication, e.g. set header "Authorization: Bearer <session token>"'
     in: header
     name: Authorization
     type: apiKey


### PR DESCRIPTION
#### Summary
Fixed broken comments and added missing ones. `make swagger` works again now. A few notes and follow-ups:
* The Swagger documentation is currently incomplete - e.g. output schema of Onboard is missing (as one example)
* The Swagger docs are likely out of date  on main
* I did not check in the large index.html change with this, as we will likely need to update again, and not sure if there's a better alternative to checking in the generated docs.
* What's a better process to keep the API docs in sync?

#### Ticket Link
#2507