### PR TITLE
✨ Fix Board and view remain selected in sidebar when adding board

### DIFF
--- a/webapp/src/components/sidebar/sidebar.tsx
+++ b/webapp/src/components/sidebar/sidebar.tsx
@@ -29,6 +29,7 @@ type Props = {
     activeViewId?: string
     isDashboard?: boolean
     onBoardTemplateSelectorOpen?: () => void
+    onBoardTemplateSelectorClose?: () => void
 }
 
 function getWindowDimensions() {
@@ -176,6 +177,7 @@ const Sidebar = (props: Props) => {
                             const nextBoardId = boards.length > 1 ? boards.find((o) => o.id !== board.id)?.id : undefined
                             return (
                                 <SidebarBoardItem
+                                    onBoardTemplateSelectorClose={props.onBoardTemplateSelectorClose}
                                     hideSidebar={hideSidebar}
                                     key={board.id}
                                     views={views}

--- a/webapp/src/components/sidebar/sidebarBoardItem.tsx
+++ b/webapp/src/components/sidebar/sidebarBoardItem.tsx
@@ -31,6 +31,7 @@ type Props = {
     activeViewId?: string
     nextBoardId?: string
     hideSidebar: () => void
+    onBoardTemplateSelectorClose?:() => void
 }
 
 const SidebarBoardItem = (props: Props) => {
@@ -110,11 +111,26 @@ const SidebarBoardItem = (props: Props) => {
     const displayTitle: string = board.title || intl.formatMessage({id: 'Sidebar.untitled-board', defaultMessage: '(Untitled Board)'})
     const boardViews = sortBoardViewsAlphabetically(views.filter((view) => view.parentId === board.id))
 
+    const handleView = (view:BoardView) => {
+        if (view.id === props.activeViewId && props.onBoardTemplateSelectorClose) {
+            props.onBoardTemplateSelectorClose()
+        } else {
+            showView(view.id, board.id)
+        }
+    }
+
+    const handleBoard = (boardId: string) => {
+        if (boardId === props.activeBoardId && props.onBoardTemplateSelectorClose) {
+            props.onBoardTemplateSelectorClose()
+        } else {
+            showBoard(boardId)
+        }
+    }
     return (
         <div className='SidebarBoardItem'>
             <div
                 className={`octo-sidebar-item ' ${collapsed ? 'collapsed' : 'expanded'} ${board.id === props.activeBoardId ? 'active' : ''}`}
-                onClick={() => showBoard(board.id)}
+                onClick={() => handleBoard(board.id)}
             >
                 <IconButton
                     icon={<DisclosureTriangle/>}
@@ -170,7 +186,7 @@ const SidebarBoardItem = (props: Props) => {
                 <div
                     key={view.id}
                     className={`octo-sidebar-item subitem ${view.id === props.activeViewId ? 'active' : ''}`}
-                    onClick={() => showView(view.id, board.id)}
+                    onClick={() => handleView(view)}
                 >
                     {iconForViewType(view.fields.viewType)}
                     <div

--- a/webapp/src/components/workspace.tsx
+++ b/webapp/src/components/workspace.tsx
@@ -130,6 +130,7 @@ const Workspace = (props: Props) => {
             {!props.readonly &&
                 <Sidebar
                     onBoardTemplateSelectorOpen={openBoardTemplateSelector}
+                    onBoardTemplateSelectorClose={closeBoardTemplateSelector}
                     activeBoardId={board?.id}
                     activeViewId={view?.id}
                 />


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
When you click on add board button and click on current selected view the add board page wont close , so implemented that functionality when you click on current view it will close the add board modal

#### Ticket Link
  Fixes https://github.com/mattermost/focalboard/issues/2331
  
  **Before**

https://user-images.githubusercontent.com/44333182/158739223-cc4ba2c1-c13b-4946-be36-f13280a838e7.mp4


 **After:** 

https://user-images.githubusercontent.com/44333182/158739170-efd7942f-2235-4960-9562-854e9afd6443.mp4





