### PR TITLE
Run make server-test-sqlite to run only against sqlite for that part of the job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
         path: ${{ github.workspace }}/dist/focalboard-server-linux-amd64.tar.gz
 
     - name: "Test server: sqlite"
-      run: make server-test
+      run: make server-test-sqlite
 
     - name: "Test server: mysql"
       run: make server-test-mysql


### PR DESCRIPTION
This is for speed up the tests, I'm not 100% sure if this has other implications. @wiggin77 can you confirm this is correct?.