### PR TITLE
Fix #2589. Maintain cardProperty order on patch

### DIFF
--- a/server/model/board.go
+++ b/server/model/board.go
@@ -223,7 +223,8 @@ func (p *BoardPatch) Patch(board *Board) *Board {
 	}
 
 	if len(p.UpdatedCardProperties) != 0 || len(p.DeletedCardProperties) != 0 {
-		// first we accumulate all properties indexed by ID
+		// first we accumulate all properties indexed by, and maintain their order
+		keyOrder := []string{}
 		cardPropertyMap := map[string]map[string]interface{}{}
 		for _, prop := range board.CardProperties {
 			id, ok := prop["id"].(string)
@@ -233,6 +234,7 @@ func (p *BoardPatch) Patch(board *Board) *Board {
 			}
 
 			cardPropertyMap[id] = prop
+			keyOrder = append(keyOrder, id)
 		}
 
 		// if there are properties marked for removal, we delete them
@@ -249,13 +251,20 @@ func (p *BoardPatch) Patch(board *Board) *Board {
 				continue
 			}
 
+			_, exists := cardPropertyMap[id]
+			if !exists {
+				keyOrder = append(keyOrder, id)
+			}
 			cardPropertyMap[id] = newprop
 		}
 
 		// and finally we flatten and save the updated properties
 		newCardProperties := []map[string]interface{}{}
-		for _, p := range cardPropertyMap {
-			newCardProperties = append(newCardProperties, p)
+		for _, key := range keyOrder {
+			p, exists := cardPropertyMap[key]
+			if exists {
+				newCardProperties = append(newCardProperties, p)
+			}
 		}
 
 		board.CardProperties = newCardProperties


### PR DESCRIPTION
#### Summary
Maintain the order of existing card properties on a patch. The order is used for display.

#### Ticket Link
#2589