### PR TITLE
Updated SQL migration to insert board memberships for templates

### DIFF
--- a/server/services/store/sqlstore/migrations/000017_add_teams_and_boards.up.sql
+++ b/server/services/store/sqlstore/migrations/000017_add_teams_and_boards.up.sql
@@ -366,13 +366,11 @@ CREATE INDEX idx_boardmembers_user_id ON {{.prefix}}board_members(user_id);
 INSERT INTO {{.prefix}}board_members (
     SELECT B.Id, CM.UserId, CM.Roles, (CM.UserId=B.created_by) OR CM.SchemeAdmin, CM.SchemeUser, FALSE, CM.SchemeGuest
     FROM {{.prefix}}boards AS B
-    INNER JOIN ChannelMembers as CM ON CM.ChannelId=B.channel_id
-    WHERE NOT B.is_template
+    INNER JOIN ChannelMembers as CM ON CM.ChannelId=B.channel_id;
 );
 {{else}}
 {{- /* if we're in personal server or desktop, create memberships for everyone */ -}}
 INSERT INTO {{.prefix}}board_members
      SELECT B.id, U.id, '', B.created_by=U.id, TRUE, FALSE, FALSE
-       FROM {{.prefix}}boards AS B, {{.prefix}}users AS U
-       WHERE NOT B.is_template;
+       FROM {{.prefix}}boards AS B, {{.prefix}}users AS U;
 {{end}}


### PR DESCRIPTION
#### Summary
To maintain access contron on templates, we need to add entries into `board_members` table during the migration from workspace to teams. Currently, it was not being done for templates. This PR removes that condition and allows adding board memberships for templates. A later PR that will fix the entire issue in #2370 will need this work as a base.

#### Ticket Link
Completes data migration part of https://github.com/mattermost/focalboard/issues/2370, not the whole issue.

