### PR TITLE
Revert in-memory unit tests for sqlite

### DIFF
--- a/server/integrationtests/board_test.go
+++ b/server/integrationtests/board_test.go
@@ -229,7 +229,9 @@ func TestCreateBoard(t *testing.T) {
 				Title: title,
 			}
 			board, resp := th.Client.CreateBoard(newBoard)
-			th.CheckBadRequest(resp)
+			// the request is unauthorized because the permission
+			// check fails on an empty teamID
+			th.CheckForbidden(resp)
 			require.Nil(t, board)
 
 			boards, err := th.Server.App().GetBoardsForUserAndTeam(user1.ID, teamID)

--- a/server/integrationtests/board_test.go
+++ b/server/integrationtests/board_test.go
@@ -229,8 +229,6 @@ func TestCreateBoard(t *testing.T) {
 				Title: title,
 			}
 			board, resp := th.Client.CreateBoard(newBoard)
-			// the request is unauthorized because the permission
-			// check fails on an empty teamID
 			th.CheckBadRequest(resp)
 			require.Nil(t, board)
 

--- a/server/integrationtests/board_test.go
+++ b/server/integrationtests/board_test.go
@@ -231,7 +231,7 @@ func TestCreateBoard(t *testing.T) {
 			board, resp := th.Client.CreateBoard(newBoard)
 			// the request is unauthorized because the permission
 			// check fails on an empty teamID
-			th.CheckForbidden(resp)
+			th.CheckBadRequest(resp)
 			require.Nil(t, board)
 
 			boards, err := th.Server.App().GetBoardsForUserAndTeam(user1.ID, teamID)

--- a/server/services/permissions/localpermissions/localpermissions.go
+++ b/server/services/permissions/localpermissions/localpermissions.go
@@ -27,7 +27,9 @@ func New(store permissions.Store, logger *mlog.Logger) *Service {
 }
 
 func (s *Service) HasPermissionToTeam(userID, teamID string, permission *mmModel.Permission) bool {
-	// Locally there is no team, so return true
+	if userID == "" || teamID == "" || permission == nil {
+		return false
+	}
 	return true
 }
 

--- a/server/services/store/sqlstore/util.go
+++ b/server/services/store/sqlstore/util.go
@@ -3,6 +3,7 @@ package sqlstore
 import (
 	"database/sql"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"strings"
 
@@ -33,7 +34,12 @@ func PrepareNewTestDatabase() (dbType string, connectionString string, err error
 	var rootUser string
 
 	if dbType == model.SqliteDBType {
-		connectionString = "file::memory:?cache=shared&_busy_timeout=5000"
+		file, err := ioutil.TempFile("", "fbtest_*.db")
+		if err != nil {
+			return "", "", err
+		}
+		connectionString = file.Name() + "?_busy_timeout=5000"
+		_ = file.Close()
 	} else if port := strings.TrimSpace(os.Getenv("FB_STORE_TEST_DOCKER_PORT")); port != "" {
 		// docker unit tests take priority over any DSN env vars
 		var template string


### PR DESCRIPTION
#### Summary
The `cache=shared` pragma required by in-memory sqlite database creates more opportunity for database locked errors.  Adding a 5 second wait/timeout helped but still resulted in flaky results.  Moving back to a file based unit test is safer since each test gets a completely new instance and is impervious to the timing of the previous close within the driver.

I'm hoping the memory caching that sqlite does, and the fact unit tests create very small databases, and the parallelization of the unit tests will result in CI jobs that are not much slower.  **Update: just under 2 minutes was added to CI job.**

The temporary database file is cleaned up on test teardown.

#### Ticket Link
NONE