### PR TITLE
GH-2551 - Update correct routes after welcome page

### DIFF
--- a/webapp/src/pages/welcome/welcomePage.tsx
+++ b/webapp/src/pages/welcome/welcomePage.tsx
@@ -49,7 +49,7 @@ const WelcomePage = () => {
             return
         }
 
-        history.replace(`/team/${currentTeam?.id}`)
+        history.replace('/')
     }
 
     const skipTour = async () => {

--- a/webapp/src/route.tsx
+++ b/webapp/src/route.tsx
@@ -27,7 +27,7 @@ type RouteProps = {
 
 function FBRoute(props: RouteProps) {
     const loggedIn = useAppSelector<boolean|null>(getLoggedIn)
-    const match = useRouteMatch<any>()
+    const match = useRouteMatch<any>({path: props.path})
     const me = useAppSelector<IUser|null>(getMe)
     const clientConfig = useAppSelector<ClientConfig>(getClientConfig)
 


### PR DESCRIPTION
#### Summary
Fixes issue with routing when user first logs in. They are redirected incorrectly to teamID - "undefined". 

This either routes them to back to home - `/boards` if originally routed just to `/boards`
Also fixes the match so that team it correctly pulled.

#### Ticket Link
  Fixes https://github.com/mattermost/focalboard/issues/2551

