### PR TITLE
GH-2667: Update apis to return 501 if not available for plugin

### DIFF
--- a/server/api/api.go
+++ b/server/api/api.go
@@ -1798,6 +1798,9 @@ func (a *API) handlePostTeamRegenerateSignupToken(w http.ResponseWriter, r *http
 	//     description: internal error
 	//     schema:
 	//       "$ref": "#/definitions/ErrorResponse"
+	if a.MattermostAuth {
+		a.errorResponse(w, r.URL.Path, http.StatusNotImplemented, "not permitted in plugin mode", nil)
+	}
 
 	team, err := a.app.GetRootTeam()
 	if err != nil {

--- a/server/api/archive.go
+++ b/server/api/archive.go
@@ -103,6 +103,9 @@ func (a *API) handleArchiveExportTeam(w http.ResponseWriter, r *http.Request) {
 	//     description: internal error
 	//     schema:
 	//       "$ref": "#/definitions/ErrorResponse"
+	if a.MattermostAuth {
+		a.errorResponse(w, r.URL.Path, http.StatusNotImplemented, "not permitted in plugin mode", nil)
+	}
 
 	vars := mux.Vars(r)
 	teamID := vars["teamID"]

--- a/server/api/auth.go
+++ b/server/api/auth.go
@@ -166,6 +166,9 @@ func (a *API) handleLogin(w http.ResponseWriter, r *http.Request) {
 	//     description: internal error
 	//     schema:
 	//       "$ref": "#/definitions/ErrorResponse"
+	if a.MattermostAuth {
+		a.errorResponse(w, r.URL.Path, http.StatusNotImplemented, "not permitted in plugin mode", nil)
+	}
 
 	if len(a.singleUserToken) > 0 {
 		// Not permitted in single-user mode
@@ -228,6 +231,9 @@ func (a *API) handleLogout(w http.ResponseWriter, r *http.Request) {
 	//     description: internal error
 	//     schema:
 	//       "$ref": "#/definitions/ErrorResponse"
+	if a.MattermostAuth {
+		a.errorResponse(w, r.URL.Path, http.StatusNotImplemented, "not permitted in plugin mode", nil)
+	}
 
 	if len(a.singleUserToken) > 0 {
 		// Not permitted in single-user mode
@@ -278,6 +284,9 @@ func (a *API) handleRegister(w http.ResponseWriter, r *http.Request) {
 	//     description: internal error
 	//     schema:
 	//       "$ref": "#/definitions/ErrorResponse"
+	if a.MattermostAuth {
+		a.errorResponse(w, r.URL.Path, http.StatusNotImplemented, "not permitted in plugin mode", nil)
+	}
 
 	if len(a.singleUserToken) > 0 {
 		// Not permitted in single-user mode
@@ -377,6 +386,9 @@ func (a *API) handleChangePassword(w http.ResponseWriter, r *http.Request) {
 	//     description: internal error
 	//     schema:
 	//       "$ref": "#/definitions/ErrorResponse"
+	if a.MattermostAuth {
+		a.errorResponse(w, r.URL.Path, http.StatusNotImplemented, "not permitted in plugin mode", nil)
+	}
 
 	if len(a.singleUserToken) > 0 {
 		// Not permitted in single-user mode


### PR DESCRIPTION
#### Summary
Returns a 501 for those apis that should not be called when running as a plugin.

#### Ticket Link

  Fixes https://github.com/mattermost/focalboard/issues/2667
  Fixes https://mattermost.atlassian.net/browse/MM-40553

