### PR TITLE
GH-2443  - Fix broken Follow button

### DIFF
--- a/server/app/boards.go
+++ b/server/app/boards.go
@@ -69,6 +69,21 @@ func (a *App) GetBoardMetadata(boardID string) (*model.Board, *model.BoardMetada
 	return board, &boardMetadata, nil
 }
 
+// getBoardForBlock returns the board that owns the specified block.
+func (a *App) getBoardForBlock(blockID string) (*model.Board, error) {
+	block, err := a.GetBlockByID(blockID)
+	if err != nil {
+		return nil, fmt.Errorf("cannot get block %s: %w", blockID, err)
+	}
+
+	board, err := a.GetBoard(block.BoardID)
+	if err != nil {
+		return nil, fmt.Errorf("cannot get board %s: %w", block.BoardID, err)
+	}
+
+	return board, nil
+}
+
 func (a *App) getBoardHistory(boardID string, latest bool) (*model.Board, error) {
 	opts := model.QueryBlockHistoryOptions{
 		Limit:      1,

--- a/server/app/subscriptions.go
+++ b/server/app/subscriptions.go
@@ -3,6 +3,8 @@ package app
 import (
 	"github.com/mattermost/focalboard/server/model"
 	"github.com/mattermost/focalboard/server/utils"
+
+	"github.com/mattermost/mattermost-server/v6/shared/mlog"
 )
 
 func (a *App) CreateSubscription(sub *model.Subscription) (*model.Subscription, error) {
@@ -37,5 +39,15 @@ func (a *App) notifySubscriptionChanged(subscription *model.Subscription) {
 	if a.notifications == nil {
 		return
 	}
-	a.notifications.BroadcastSubscriptionChange(subscription)
+
+	board, err := a.getBoardForBlock(subscription.BlockID)
+	if err != nil {
+		a.logger.Error("Error notifying subscription change",
+			mlog.String("subscriber_id", subscription.SubscriberID),
+			mlog.String("block_id", subscription.BlockID),
+			mlog.Err(err),
+		)
+	}
+
+	a.notifications.BroadcastSubscriptionChange(board.TeamID, subscription)
 }

--- a/server/services/notify/notifysubscriptions/subscriptions_backend.go
+++ b/server/services/notify/notifysubscriptions/subscriptions_backend.go
@@ -205,7 +205,7 @@ func (b *Backend) OnMention(userID string, evt notify.BlockChangeEvent) {
 }
 
 // BroadcastSubscriptionChange sends a websocket message with details of the changed subscription to all
-// connected users in the workspace.
-func (b *Backend) BroadcastSubscriptionChange(workspaceID string, subscription *model.Subscription) {
-	b.wsAdapter.BroadcastSubscriptionChange(workspaceID, subscription)
+// connected users in the team.
+func (b *Backend) BroadcastSubscriptionChange(teamID string, subscription *model.Subscription) {
+	b.wsAdapter.BroadcastSubscriptionChange(teamID, subscription)
 }

--- a/server/services/notify/service.go
+++ b/server/services/notify/service.go
@@ -31,7 +31,7 @@ type BlockChangeEvent struct {
 }
 
 type SubscriptionChangeNotifier interface {
-	BroadcastSubscriptionChange(subscription *model.Subscription)
+	BroadcastSubscriptionChange(teamID string, subscription *model.Subscription)
 }
 
 // Backend provides an interface for sending notifications.
@@ -113,7 +113,7 @@ func (s *Service) BlockChanged(evt BlockChangeEvent) {
 
 // BroadcastSubscriptionChange sends a websocket message with details of the changed subscription to all
 // connected users in the workspace.
-func (s *Service) BroadcastSubscriptionChange(subscription *model.Subscription) {
+func (s *Service) BroadcastSubscriptionChange(teamID string, subscription *model.Subscription) {
 	s.mux.RLock()
 	backends := make([]Backend, len(s.backends))
 	copy(backends, s.backends)
@@ -125,7 +125,7 @@ func (s *Service) BroadcastSubscriptionChange(subscription *model.Subscription) 
 				mlog.String("block_id", subscription.BlockID),
 				mlog.String("subscriber_id", subscription.SubscriberID),
 			)
-			scn.BroadcastSubscriptionChange(subscription)
+			scn.BroadcastSubscriptionChange(teamID, subscription)
 		}
 	}
 }

--- a/webapp/src/octoClient.ts
+++ b/webapp/src/octoClient.ts
@@ -350,7 +350,6 @@ class OctoClient {
 
     async followBlock(blockId: string, blockType: string, userId: string): Promise<Response> {
         const body: Subscription = {
-            teamId: this.teamId,
             blockType,
             blockId,
             subscriberType: 'user',

--- a/webapp/src/pages/boardPage/websocketConnection.tsx
+++ b/webapp/src/pages/boardPage/websocketConnection.tsx
@@ -109,12 +109,12 @@ const WebsocketConnection = (props: Props) => {
         wsClient.addOnReconnect(() => dispatch(props.loadAction(props.boardId)))
         wsClient.addOnStateChange(updateWebsocketState)
         wsClient.setOnFollowBlock((_: WSClient, subscription: Subscription): void => {
-            if (subscription.subscriberId === me?.id && subscription.teamId === props.teamId) {
+            if (subscription.subscriberId === me?.id) {
                 dispatch(followBlock(subscription))
             }
         })
         wsClient.setOnUnfollowBlock((_: WSClient, subscription: Subscription): void => {
-            if (subscription.subscriberId === me?.id && subscription.teamId === props.teamId) {
+            if (subscription.subscriberId === me?.id) {
                 dispatch(unfollowBlock(subscription))
             }
         })

--- a/webapp/src/wsclient.ts
+++ b/webapp/src/wsclient.ts
@@ -51,7 +51,6 @@ type WSSubscriptionMsg = {
 
 export interface Subscription {
     blockId: string
-    teamId: string
     subscriberId: string
     blockType: string
     subscriberType: string


### PR DESCRIPTION
#### Summary
This PR fixes the Follow button which was broken during the Permissions branch merge and refactor of boards page.
- websocket events for subscription changes were not being sent
- webapp was filtering out websocket events based on undefined teamID.

#### Ticket Link
fixes https://github.com/mattermost/focalboard/issues/2443

