### PR TITLE
GH-2534: Don't show error page for Personal Server when not logged in

### DIFF
--- a/webapp/cypress/integration/loginActions.ts
+++ b/webapp/cypress/integration/loginActions.ts
@@ -8,10 +8,8 @@ describe('Login actions', () => {
 
     it('Can perform login/register actions', () => {
         // Redirects to login page
-        cy.log('**Redirects to error then login page**')
+        cy.log('**Redirects to login page (except plugin mode) **')
         cy.visit('/')
-        cy.location('pathname').should('eq', '/error')
-        cy.get('button').contains('Log in').click()
         cy.location('pathname').should('eq', '/login')
         cy.get('.LoginPage').contains('Log in')
         cy.get('#login-username').should('exist')
@@ -40,7 +38,7 @@ describe('Login actions', () => {
         // User should not be logged in automatically
         cy.log('**User should not be logged in automatically**')
         cy.visit('/')
-        cy.location('pathname').should('eq', '/error')
+        cy.location('pathname').should('eq', '/login')
 
         // Can log in registered user
         cy.log('**Can log in registered user**')

--- a/webapp/src/pages/errorPage.tsx
+++ b/webapp/src/pages/errorPage.tsx
@@ -10,6 +10,7 @@ import Button from '../widgets/buttons/button'
 import './errorPage.scss'
 
 import {errorDefFromId, ErrorId} from '../errors'
+import {Utils} from '../utils'
 
 const ErrorPage = () => {
     const history = useHistory()
@@ -44,6 +45,10 @@ const ErrorPage = () => {
             </Button>
         )
     })
+
+    if (!Utils.isFocalboardPlugin() && errid === ErrorId.NotLoggedIn) {
+        handleButtonClick(errorDef.button1Redirect)
+    }
 
     return (
         <div className='ErrorPage'>


### PR DESCRIPTION
#### Summary
This PR ensure the error page is not displayed for personal server or desktop when not logged in.  User is redirected to the login page instead.

#### Ticket Link
fixes https://github.com/mattermost/focalboard/issues/2534