### PR TITLE
GH-2712:Don't check team permission for GlobalTeamID

### DIFF
--- a/server/api/api.go
+++ b/server/api/api.go
@@ -2547,7 +2547,6 @@ func (a *API) handleDuplicateBoard(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-
 	if board.Type == model.BoardTypePrivate {
 		if !a.permissions.HasPermissionToBoard(userID, boardID, model.PermissionViewBoard) {
 			a.errorResponse(w, r.URL.Path, http.StatusForbidden, "", PermissionError{"access denied to board"})

--- a/server/api/api.go
+++ b/server/api/api.go
@@ -292,7 +292,7 @@ func (a *API) handleGetBlocks(w http.ResponseWriter, r *http.Request) {
 
 	if !a.hasValidReadTokenForBoard(r, boardID) {
 		if board.IsTemplate {
-			if !a.permissions.HasPermissionToTeam(userID, board.TeamID, model.PermissionViewTeam) {
+			if board.TeamID != model.GlobalTeamID && !a.permissions.HasPermissionToTeam(userID, board.TeamID, model.PermissionViewTeam) {
 				a.errorResponse(w, r.URL.Path, http.StatusForbidden, "", PermissionError{"access denied to board template"})
 				return
 			}
@@ -2179,7 +2179,7 @@ func (a *API) handleGetTemplates(w http.ResponseWriter, r *http.Request) {
 	teamID := mux.Vars(r)["teamID"]
 	userID := getUserID(r)
 
-	if teamID != "0" && !a.permissions.HasPermissionToTeam(userID, teamID, model.PermissionViewTeam) {
+	if teamID != model.GlobalTeamID && !a.permissions.HasPermissionToTeam(userID, teamID, model.PermissionViewTeam) {
 		a.errorResponse(w, r.URL.Path, http.StatusForbidden, "", PermissionError{"access denied to team"})
 		return
 	}
@@ -2855,8 +2855,8 @@ func (a *API) handleDuplicateBoard(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 		} else {
-			if !a.permissions.HasPermissionToTeam(userID, board.TeamID, model.PermissionViewTeam) {
-				a.errorResponse(w, r.URL.Path, http.StatusForbidden, "", PermissionError{"access denied to board"})
+			if board.TeamID != model.GlobalTeamID && !a.permissions.HasPermissionToTeam(userID, board.TeamID, model.PermissionViewTeam) {
+				a.errorResponse(w, r.URL.Path, http.StatusForbidden, "", PermissionError{"access denied to team"})
 				return
 			}
 		}

--- a/server/app/onboarding.go
+++ b/server/app/onboarding.go
@@ -46,14 +46,14 @@ func (a *App) PrepareOnboardingTour(userID string, teamID string) (string, strin
 }
 
 func (a *App) getOnboardingBoardID() (string, error) {
-	boards, err := a.store.GetTemplateBoards(GlobalTeamID, "")
+	boards, err := a.store.GetTemplateBoards(model.GlobalTeamID, "")
 	if err != nil {
 		return "", err
 	}
 
 	var onboardingBoardID string
 	for _, block := range boards {
-		if block.Title == WelcomeBoardTitle && block.TeamID == GlobalTeamID {
+		if block.Title == WelcomeBoardTitle && block.TeamID == model.GlobalTeamID {
 			onboardingBoardID = block.ID
 			break
 		}

--- a/server/app/onboarding.go
+++ b/server/app/onboarding.go
@@ -46,14 +46,14 @@ func (a *App) PrepareOnboardingTour(userID string, teamID string) (string, strin
 }
 
 func (a *App) getOnboardingBoardID() (string, error) {
-	boards, err := a.store.GetTemplateBoards(globalTeamID, "")
+	boards, err := a.store.GetTemplateBoards(GlobalTeamID, "")
 	if err != nil {
 		return "", err
 	}
 
 	var onboardingBoardID string
 	for _, block := range boards {
-		if block.Title == WelcomeBoardTitle && block.TeamID == globalTeamID {
+		if block.Title == WelcomeBoardTitle && block.TeamID == GlobalTeamID {
 			onboardingBoardID = block.ID
 			break
 		}

--- a/server/app/templates.go
+++ b/server/app/templates.go
@@ -13,7 +13,6 @@ import (
 
 const (
 	defaultTemplateVersion = 2
-	globalTeamID           = "0"
 )
 
 func (a *App) InitTemplates() error {
@@ -23,7 +22,7 @@ func (a *App) InitTemplates() error {
 
 // initializeTemplates imports default templates if the boards table is empty.
 func (a *App) initializeTemplates() (bool, error) {
-	boards, err := a.store.GetTemplateBoards(globalTeamID, "")
+	boards, err := a.store.GetTemplateBoards(model.GlobalTeamID, "")
 	if err != nil {
 		return false, fmt.Errorf("cannot initialize templates: %w", err)
 	}
@@ -49,13 +48,13 @@ func (a *App) initializeTemplates() (bool, error) {
 	r := bytes.NewReader(assets.DefaultTemplatesArchive)
 
 	opt := model.ImportArchiveOptions{
-		TeamID:        globalTeamID,
+		TeamID:        model.GlobalTeamID,
 		ModifiedBy:    "system",
 		BlockModifier: fixTemplateBlock,
 		BoardModifier: fixTemplateBoard,
 	}
 	if err = a.ImportArchive(r, opt); err != nil {
-		return false, fmt.Errorf("cannot initialize global templates for team %s: %w", globalTeamID, err)
+		return false, fmt.Errorf("cannot initialize global templates for team %s: %w", model.GlobalTeamID, err)
 	}
 	return true, nil
 }

--- a/server/app/templates_test.go
+++ b/server/app/templates_test.go
@@ -14,7 +14,7 @@ import (
 func TestApp_initializeTemplates(t *testing.T) {
 	board := &model.Board{
 		ID:              utils.NewID(utils.IDTypeBoard),
-		TeamID:          globalTeamID,
+		TeamID:          model.GlobalTeamID,
 		Type:            model.BoardTypeOpen,
 		Title:           "test board",
 		IsTemplate:      true,
@@ -43,7 +43,7 @@ func TestApp_initializeTemplates(t *testing.T) {
 		th, tearDown := SetupTestHelper(t)
 		defer tearDown()
 
-		th.Store.EXPECT().GetTemplateBoards(globalTeamID, "").Return([]*model.Board{}, nil)
+		th.Store.EXPECT().GetTemplateBoards(model.GlobalTeamID, "").Return([]*model.Board{}, nil)
 		th.Store.EXPECT().RemoveDefaultTemplates([]*model.Board{}).Return(nil)
 		th.Store.EXPECT().CreateBoardsAndBlocks(gomock.Any(), gomock.Any()).AnyTimes().Return(boardsAndBlocks, nil)
 		th.Store.EXPECT().GetMembersForBoard(board.ID).AnyTimes().Return([]*model.BoardMember{}, nil)
@@ -61,7 +61,7 @@ func TestApp_initializeTemplates(t *testing.T) {
 		th, tearDown := SetupTestHelper(t)
 		defer tearDown()
 
-		th.Store.EXPECT().GetTemplateBoards(globalTeamID, "").Return([]*model.Board{board}, nil)
+		th.Store.EXPECT().GetTemplateBoards(model.GlobalTeamID, "").Return([]*model.Board{board}, nil)
 
 		done, err := th.App.initializeTemplates()
 		require.NoError(t, err, "initializeTemplates should not error")

--- a/server/model/user.go
+++ b/server/model/user.go
@@ -6,7 +6,8 @@ import (
 )
 
 const (
-	SingleUser = "single-user"
+	SingleUser   = "single-user"
+	GlobalTeamID = "0"
 )
 
 // User is a user


### PR DESCRIPTION
#### Summary
Permission Checks for teamID = '0' fails for non admin users. 

When retrieving GlobalTemplates, don't check team permissions.

#### Ticket Link

  Fixes https://github.com/mattermost/focalboard/issues/2712


