### PR TITLE
[GH-2618] Gallery view should have top border

### DIFF
--- a/webapp/src/components/gallery/gallery.scss
+++ b/webapp/src/components/gallery/gallery.scss
@@ -2,6 +2,7 @@
     display: flex;
     flex-wrap: wrap;
     overflow: auto;
+    margin-top: 10px;
 
     .octo-gallery-new {
         border: 1px solid rgba(var(--center-channel-color-rgb), 0.09);


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Adds space to the top of gallery view so it is no longer up next to the header line.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Fixes: https://github.com/mattermost/focalboard/issues/2681

