### PR TITLE
Migration fix categories channel_id

### DIFF
--- a/server/services/store/sqlstore/migrations/000018_populate_categories.up.sql
+++ b/server/services/store/sqlstore/migrations/000018_populate_categories.up.sql
@@ -5,9 +5,7 @@ CREATE TABLE {{.prefix}}categories (
     name varchar(100) NOT NULL,
     user_id varchar(32) NOT NULL,
     team_id varchar(32) NOT NULL,
-    {{if not .sqlite}}
-      channel_id varchar(32) NOT NULL,
-    {{end}}
+    channel_id varchar(36) NOT NULL,
     create_at BIGINT,
     update_at BIGINT,
     delete_at BIGINT,

--- a/server/services/store/sqlstore/migrations/000019_populate_category_blocks.up.sql
+++ b/server/services/store/sqlstore/migrations/000019_populate_category_blocks.up.sql
@@ -28,7 +28,7 @@ CREATE TABLE {{.prefix}}category_blocks (
         AND {{.prefix}}boards.is_template = false
 ;
 
-    ALTER TABLE {{.prefix}}categories DROP COLUMN channel_id;
+    --ALTER TABLE {{.prefix}}categories DROP COLUMN channel_id;
 
     {{if .mysql}}
         ALTER TABLE {{.prefix}}category_blocks MODIFY id varchar(36);

--- a/server/services/store/sqlstore/migrations/000019_populate_category_blocks.up.sql
+++ b/server/services/store/sqlstore/migrations/000019_populate_category_blocks.up.sql
@@ -28,8 +28,6 @@ CREATE TABLE {{.prefix}}category_blocks (
         AND {{.prefix}}boards.is_template = false
 ;
 
-    --ALTER TABLE {{.prefix}}categories DROP COLUMN channel_id;
-
     {{if .mysql}}
         ALTER TABLE {{.prefix}}category_blocks MODIFY id varchar(36);
     {{end}}

--- a/server/services/store/sqlstore/migrations/000021_fix_categories.up.sql
+++ b/server/services/store/sqlstore/migrations/000021_fix_categories.up.sql
@@ -13,6 +13,6 @@ ALTER TABLE {{.prefix}}categories ALTER COLUMN id TYPE VARCHAR(36);
 ALTER TABLE {{.prefix}}categories ALTER COLUMN id SET NOT NULL;
 ALTER TABLE {{.prefix}}category_blocks ALTER COLUMN id TYPE VARCHAR(36);
 ALTER TABLE {{.prefix}}category_blocks ALTER COLUMN id SET NOT NULL;
-ALTER TABLE {{.prefix}}categories ALTER COLUMN channel_id TYPE VARCHAR(36);
-ALTER TABLE {{.prefix}}categories ALTER COLUMN channel_id DROP NOT NULL;
+--ALTER TABLE {{.prefix}}categories ALTER COLUMN channel_id TYPE VARCHAR(36);
+--ALTER TABLE {{.prefix}}categories ALTER COLUMN channel_id DROP NOT NULL;
 {{end}}

--- a/server/services/store/sqlstore/migrations/000021_fix_categories.up.sql
+++ b/server/services/store/sqlstore/migrations/000021_fix_categories.up.sql
@@ -13,6 +13,4 @@ ALTER TABLE {{.prefix}}categories ALTER COLUMN id TYPE VARCHAR(36);
 ALTER TABLE {{.prefix}}categories ALTER COLUMN id SET NOT NULL;
 ALTER TABLE {{.prefix}}category_blocks ALTER COLUMN id TYPE VARCHAR(36);
 ALTER TABLE {{.prefix}}category_blocks ALTER COLUMN id SET NOT NULL;
---ALTER TABLE {{.prefix}}categories ALTER COLUMN channel_id TYPE VARCHAR(36);
---ALTER TABLE {{.prefix}}categories ALTER COLUMN channel_id DROP NOT NULL;
 {{end}}


### PR DESCRIPTION
#### Summary
Fixes the missing `categories.channel_id` column.  This allows the plugin to launch with crashing, but may not fix all the migration issues.

#### Ticket Link
NONE