### PR TITLE
Don't warn when  appears in card followed by text that is not a username

### DIFF
--- a/server/services/notify/notifymentions/mentions_backend.go
+++ b/server/services/notify/notifymentions/mentions_backend.go
@@ -115,6 +115,11 @@ func (b *Backend) BlockChanged(evt notify.BlockChangeEvent) error {
 			merr.Append(fmt.Errorf("cannot deliver notification for @%s: %w", username, err))
 		}
 
+		if userID == "" {
+			// was a `@` followed by something other than a username.
+			continue
+		}
+
 		b.logger.Debug("Mention notification delivered",
 			mlog.String("user", username),
 			mlog.Int("listener_count", len(listeners)),


### PR DESCRIPTION
#### Summary
When a `@` appeared in card text followed by something other than a username, an attempt was made to subscribe the non-user to the card.  This resulted in a warning emitted to the logs.  This PR corrects that.   e.g. a default template includes the phrase `to @mention teammates`



#### Ticket Link
NONE