### PR TITLE
GH-2745  Don't init default templates when unit testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,6 +115,8 @@ watch-server-test: modd-precheck ## Run server tests watching for changes
 
 server-test: server-test-sqlite server-test-mysql server-test-postgres ## Run server tests
 
+server-test-sqlite: export FB_UNIT_TESTING=1
+
 server-test-sqlite: templates-archive ## Run server tests using sqlite
 	cd server; go test -tags '$(BUILD_TAGS)' -race -v -count=1 -timeout=30m ./...
 

--- a/server/app/blocks.go
+++ b/server/app/blocks.go
@@ -344,7 +344,8 @@ func (a *App) GetBlocksForBoard(boardID string) ([]model.Block, error) {
 }
 
 func (a *App) notifyBlockChanged(action notify.Action, block *model.Block, oldBlock *model.Block, modifiedByID string) {
-	if a.notifications == nil {
+	// don't notify if notifications service disabled, or block change is generated via system user.
+	if a.notifications == nil || modifiedByID == model.SystemUserID {
 		return
 	}
 

--- a/server/app/templates.go
+++ b/server/app/templates.go
@@ -49,7 +49,7 @@ func (a *App) initializeTemplates() (bool, error) {
 
 	opt := model.ImportArchiveOptions{
 		TeamID:        model.GlobalTeamID,
-		ModifiedBy:    "system",
+		ModifiedBy:    model.SystemUserID,
 		BlockModifier: fixTemplateBlock,
 		BoardModifier: fixTemplateBoard,
 	}
@@ -69,7 +69,7 @@ func (a *App) isInitializationNeeded(boards []*model.Board) (bool, string) {
 	// look for any built-in template boards with the wrong version number (or no version #).
 	for _, board := range boards {
 		// if not built-in board...skip
-		if board.CreatedBy != "system" {
+		if board.CreatedBy != model.SystemUserID {
 			continue
 		}
 		if board.TemplateVersion < defaultTemplateVersion {

--- a/server/integrationtests/board_test.go
+++ b/server/integrationtests/board_test.go
@@ -1479,6 +1479,9 @@ func TestGetTemplates(t *testing.T) {
 		th := SetupTestHelper(t).InitBasic()
 		defer th.TearDown()
 
+		err := th.Server.App().InitTemplates()
+		require.NoError(t, err, "InitTemplates should not fail")
+
 		teamID := "my-team-id"
 		rBoards, resp := th.Client.GetTemplatesForTeam("0")
 		th.CheckOK(resp)

--- a/server/integrationtests/permissions_test.go
+++ b/server/integrationtests/permissions_test.go
@@ -259,6 +259,9 @@ func TestPermissionsGetTeamTemplates(t *testing.T) {
 	testData := setupData(t, th)
 	clients := setupClients(th)
 
+	err := th.Server.App().InitTemplates()
+	require.NoError(t, err, "InitTemplates should succeed")
+
 	builtInTemplateCount := 7
 
 	ttCases := []TestCase{
@@ -2074,6 +2077,9 @@ func TestPermissionsOnboard(t *testing.T) {
 	defer th.TearDown()
 	testData := setupData(t, th)
 	clients := setupClients(th)
+
+	err := th.Server.App().InitTemplates()
+	require.NoError(t, err, "InitTemplates should not fail")
 
 	ttCases := []TestCase{
 		{"/teams/test-team/onboard", methodPost, "", userAnon, http.StatusUnauthorized, 0},

--- a/server/model/user.go
+++ b/server/model/user.go
@@ -8,6 +8,7 @@ import (
 const (
 	SingleUser   = "single-user"
 	GlobalTeamID = "0"
+	SystemUserID = "system"
 )
 
 // User is a user

--- a/server/server/server.go
+++ b/server/server/server.go
@@ -130,14 +130,15 @@ func New(params Params) (*Server, error) {
 	}
 
 	appServices := app.Services{
-		Auth:          authenticator,
-		Store:         params.DBStore,
-		FilesBackend:  filesBackend,
-		Webhook:       webhookClient,
-		Metrics:       metricsService,
-		Notifications: notificationService,
-		Logger:        params.Logger,
-		Permissions:   params.PermissionsService,
+		Auth:             authenticator,
+		Store:            params.DBStore,
+		FilesBackend:     filesBackend,
+		Webhook:          webhookClient,
+		Metrics:          metricsService,
+		Notifications:    notificationService,
+		Logger:           params.Logger,
+		Permissions:      params.PermissionsService,
+		SkipTemplateInit: utils.IsRunningUnitTests(),
 	}
 	app := app.New(params.Cfg, wsAdapter, appServices)
 
@@ -202,11 +203,6 @@ func New(params Params) (*Server, error) {
 	}
 
 	server.initHandlers()
-
-	if err := app.InitTemplates(); err != nil {
-		params.Logger.Error("Unable initialize team templates", mlog.Err(err))
-		return nil, err
-	}
 
 	return &server, nil
 }

--- a/server/services/notify/notifymentions/mentions_backend.go
+++ b/server/services/notify/notifymentions/mentions_backend.go
@@ -115,6 +115,11 @@ func (b *Backend) BlockChanged(evt notify.BlockChangeEvent) error {
 			merr.Append(fmt.Errorf("cannot deliver notification for @%s: %w", username, err))
 		}
 
+		if userID == "" {
+			// was a `@` followed by something other than a username.
+			continue
+		}
+
 		b.logger.Debug("Mention notification delivered",
 			mlog.String("user", username),
 			mlog.Int("listener_count", len(listeners)),

--- a/server/services/store/sqlstore/templates.go
+++ b/server/services/store/sqlstore/templates.go
@@ -18,7 +18,7 @@ var (
 func (s *SQLStore) removeDefaultTemplates(db sq.BaseRunner, boards []*model.Board) error {
 	count := 0
 	for _, board := range boards {
-		if board.CreatedBy != "system" {
+		if board.CreatedBy != model.SystemUserID {
 			continue
 		}
 		// default template deletion does not need to go to blocks_history

--- a/server/utils/debug.go
+++ b/server/utils/debug.go
@@ -1,0 +1,20 @@
+package utils
+
+import (
+	"os"
+	"strings"
+)
+
+// IsRunningUnitTests returns true if this instance of FocalBoard is running unit or integration tests.
+func IsRunningUnitTests() bool {
+	testing := os.Getenv("FB_UNIT_TESTING")
+	if testing == "" {
+		return false
+	}
+
+	switch strings.ToLower(testing) {
+	case "1", "t", "y", "true", "yes":
+		return true
+	}
+	return false
+}


### PR DESCRIPTION
#### Summary
This PR speeds up unit testing (and integration testing) by selectively initializing default templates only for tests that need them.  Some log noise is also removed.

CI went from ~30 minutes to 14 minutes.

#### Ticket Link
fixes https://github.com/mattermost/focalboard/issues/2745
