### PR TITLE
Add readme for Mac and Win apps

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,6 +14,19 @@
             "cwd": "${workspaceFolder}"
         },
         {
+            "name": "Go: Launch Single-user Server",
+            "type": "go",
+            "request": "launch",
+            "mode": "debug",
+            "buildFlags": "-tags 'json1'",
+            "program": "${workspaceFolder}/server/main",
+            "cwd": "${workspaceFolder}",
+            "args": ["-single-user"],
+			"env": {
+				"FOCALBOARD_SINGLE_USER_TOKEN": "testtest"
+			}
+        },
+        {
             "name": "Go: Launch Windows App",
             "type": "go",
             "request": "launch",

--- a/Makefile
+++ b/Makefile
@@ -164,7 +164,8 @@ mac-app: server-mac webapp ## Build Mac application.
 	cp app-config.json mac/resources/config.json
 	cp -R webapp/pack mac/resources/pack
 	mkdir -p mac/temp
-	xcodebuild archive -workspace mac/Focalboard.xcworkspace -scheme Focalboard -archivePath mac/temp/focalboard.xcarchive CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED="NO" CODE_SIGNING_ALLOWED="NO"
+	xcodebuild archive -workspace mac/Focalboard.xcworkspace -scheme Focalboard -archivePath mac/temp/focalboard.xcarchive CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED="NO" CODE_SIGNING_ALLOWED="NO" \
+		|| { echo "xcodebuild failed, did you install the full Xcode and not just the CLI tools?"; exit 1; }
 	mkdir -p mac/dist
 	cp -R mac/temp/focalboard.xcarchive/Products/Applications/Focalboard.app mac/dist/
 	# xcodebuild -exportArchive -archivePath mac/temp/focalboard.xcarchive -exportPath mac/dist -exportOptionsPlist mac/export.plist

--- a/mac/README.md
+++ b/mac/README.md
@@ -1,0 +1,25 @@
+# Focalboard Mac Personal Desktop
+
+This folder contains the code for the Mac Personal Desktop. It packages a lightweight Swift Mac App with the Mac build of the server, and the webapp. The server is run in a single-user mode.
+
+## Debugging in Xcode
+
+Open `Focalboard.xcworkspace` in Xcode to debug it.
+
+To debug the client webapp:
+1. Run the Focalboard desktop app from Xcode
+2. Open Safari
+3. Enable Safari's [developer tools]
+4. Select the Focalboard app from the develop menu, under your computer's name
+
+### Testing the single-user server
+
+You can also run the server in single-user mode and connect to it via a browser:
+
+1. Run `FOCALBOARD_SINGLE_USER_TOKEN=testtest make watch-single-user`
+  * This runs the server with the `-single-user` flag
+  * Alternatively, select `Go: Launch Single-user Server` from VSCode's run and debug options
+2. Open a browser to `http://localhost:8000`
+3. Open the browser developer tools to Application \ Local Storage \ localhost:8000
+4. Set `focalboardSessionId` to `testtest`
+5. Navigate to `http://localhost:8000`

--- a/win-wpf/README.md
+++ b/win-wpf/README.md
@@ -1,0 +1,19 @@
+# Focalboard Windows Personal Desktop
+
+This folder contains the code for the Windows Personal Desktop. It packages a lightweight C# Windows App with the Windows build of the server, and the webapp. The server is run in a single-user mode.
+
+## Debugging in Visual Studio
+
+Open `Focalboard.sln` in Visual Studio to debug it.
+
+### Testing the single-user server
+
+You can also run the server in single-user mode and connect to it via a browser:
+
+1. Run `FOCALBOARD_SINGLE_USER_TOKEN=testtest make watch-single-user`
+  * This runs the server with the `-single-user` flag
+  * Alternatively, select `Go: Launch Single-user Server` from VSCode's run and debug options
+2. Open a browser to `http://localhost:8000`
+3. Open the browser developer tools to Application \ Local Storage \ localhost:8000
+4. Set `focalboardSessionId` to `testtest`
+5. Navigate to `http://localhost:8000`


### PR DESCRIPTION
#### Summary
Added a readme with tips on debugging the Mac and Windows app, plus running the server in single-user mode.

Also added a `Go: Launch Single-user Server` option to VSCode's launch.json.