### PR TITLE
Implement permissions specs for mentions.

### DIFF
--- a/mattermost-plugin/server/plugin.go
+++ b/mattermost-plugin/server/plugin.go
@@ -122,7 +122,9 @@ func (p *Plugin) OnActivate() error {
 	backendParams := notifyBackendParams{
 		cfg:         cfg,
 		client:      client,
+		store:       db,
 		permissions: permissionsService,
+		wsAdapter:   p.wsPluginAdapter,
 		serverRoot:  baseURL + "/boards",
 		logger:      logger,
 	}
@@ -135,7 +137,7 @@ func (p *Plugin) OnActivate() error {
 	}
 	notifyBackends = append(notifyBackends, mentionsBackend)
 
-	subscriptionsBackend, err2 := createSubscriptionsNotifyBackend(backendParams, db, p.wsPluginAdapter)
+	subscriptionsBackend, err2 := createSubscriptionsNotifyBackend(backendParams)
 	if err2 != nil {
 		return fmt.Errorf("error creating subscription notifications backend: %w", err2)
 	}
@@ -209,7 +211,7 @@ func (p *Plugin) createBoardsConfig(mmconfig mmModel.Config, baseURL string, ser
 	featureFlags := parseFeatureFlags(mmconfig.FeatureFlags.ToMap())
 
 	return &config.Configuration{
-		ServerRoot:               baseURL + "/plugins/focalboard",
+		ServerRoot:               baseURL,
 		Port:                     -1,
 		DBType:                   *mmconfig.SqlSettings.DriverName,
 		DBConfigString:           *mmconfig.SqlSettings.DataSource,

--- a/server/app/blocks.go
+++ b/server/app/blocks.go
@@ -358,7 +358,7 @@ func (a *App) notifyBlockChanged(action notify.Action, block *model.Block, oldBl
 
 	boardMember, _ := a.GetMemberForBoard(board.ID, modifiedByID)
 	if boardMember == nil {
-		// create guest board member
+		// create temporary guest board member
 		boardMember = &model.BoardMember{
 			BoardID: board.ID,
 			UserID:  modifiedByID,

--- a/server/app/blocks.go
+++ b/server/app/blocks.go
@@ -356,6 +356,15 @@ func (a *App) notifyBlockChanged(action notify.Action, block *model.Block, oldBl
 		return
 	}
 
+	boardMember, _ := a.GetMemberForBoard(board.ID, modifiedByID)
+	if boardMember == nil {
+		// create guest board member
+		boardMember = &model.BoardMember{
+			BoardID: board.ID,
+			UserID:  modifiedByID,
+		}
+	}
+
 	evt := notify.BlockChangeEvent{
 		Action:       action,
 		TeamID:       board.TeamID,
@@ -363,7 +372,7 @@ func (a *App) notifyBlockChanged(action notify.Action, block *model.Block, oldBl
 		Card:         card,
 		BlockChanged: block,
 		BlockOld:     oldBlock,
-		ModifiedByID: modifiedByID,
+		ModifiedBy:   boardMember,
 	}
 	a.notifications.BlockChanged(evt)
 }

--- a/server/app/boards.go
+++ b/server/app/boards.go
@@ -240,6 +240,10 @@ func (a *App) GetMembersForUser(userID string) ([]*model.BoardMember, error) {
 	return a.store.GetMembersForUser(userID)
 }
 
+func (a *App) GetMemberForBoard(boardID string, userID string) (*model.BoardMember, error) {
+	return a.store.GetMemberForBoard(boardID, userID)
+}
+
 func (a *App) AddMemberToBoard(member *model.BoardMember) (*model.BoardMember, error) {
 	board, err := a.store.GetBoard(member.BoardID)
 	if errors.Is(err, sql.ErrNoRows) {

--- a/server/services/notify/notifymentions/delivery.go
+++ b/server/services/notify/notifymentions/delivery.go
@@ -3,11 +3,17 @@
 
 package notifymentions
 
-import "github.com/mattermost/focalboard/server/services/notify"
+import (
+	"github.com/mattermost/focalboard/server/services/notify"
+
+	mm_model "github.com/mattermost/mattermost-server/v6/model"
+)
 
 // MentionDelivery provides an interface for delivering @mention notifications to other systems, such as
 // channels server via plugin API.
 // On success the user id of the user mentioned is returned.
 type MentionDelivery interface {
-	MentionDeliver(mentionUsername string, extract string, evt notify.BlockChangeEvent) (string, error)
+	MentionDeliver(mentionedUser *mm_model.User, extract string, evt notify.BlockChangeEvent) (string, error)
+	UserByUsername(mentionUsername string) (*mm_model.User, error)
+	IsErrNotFound(err error) bool
 }

--- a/server/services/notify/notifymentions/mentions_backend.go
+++ b/server/services/notify/notifymentions/mentions_backend.go
@@ -4,12 +4,14 @@
 package notifymentions
 
 import (
+	"errors"
 	"fmt"
 	"sync"
 
 	"github.com/mattermost/focalboard/server/model"
 	"github.com/mattermost/focalboard/server/services/notify"
 	"github.com/mattermost/focalboard/server/services/permissions"
+	"github.com/mattermost/focalboard/server/ws"
 	"github.com/wiggin77/merror"
 
 	"github.com/mattermost/mattermost-server/v6/shared/mlog"
@@ -19,25 +21,41 @@ const (
 	backendName = "notifyMentions"
 )
 
+var (
+	ErrMentionPermission = errors.New("mention not permitted")
+)
+
 type MentionListener interface {
 	OnMention(userID string, evt notify.BlockChangeEvent)
 }
 
+type BackendParams struct {
+	Store       Store
+	Permissions permissions.PermissionsService
+	Delivery    MentionDelivery
+	WSAdapter   ws.Adapter
+	Logger      *mlog.Logger
+}
+
 // Backend provides the notification backend for @mentions.
 type Backend struct {
-	delivery    MentionDelivery
+	store       Store
 	permissions permissions.PermissionsService
+	delivery    MentionDelivery
+	wsAdapter   ws.Adapter
 	logger      *mlog.Logger
 
 	mux       sync.RWMutex
 	listeners []MentionListener
 }
 
-func New(delivery MentionDelivery, permissions permissions.PermissionsService, logger *mlog.Logger) *Backend {
+func New(params BackendParams) *Backend {
 	return &Backend{
-		delivery:    delivery,
-		permissions: permissions,
-		logger:      logger,
+		store:       params.Store,
+		permissions: params.Permissions,
+		delivery:    params.Delivery,
+		wsAdapter:   params.WSAdapter,
+		logger:      params.Logger,
 	}
 }
 
@@ -110,7 +128,7 @@ func (b *Backend) BlockChanged(evt notify.BlockChangeEvent) error {
 
 		extract := extractText(evt.BlockChanged.Title, username, newLimits())
 
-		userID, err := b.delivery.MentionDeliver(username, extract, evt)
+		userID, err := b.deliverMentionNotification(username, extract, evt)
 		if err != nil {
 			merr.Append(fmt.Errorf("cannot deliver notification for @%s: %w", username, err))
 		}
@@ -140,4 +158,68 @@ func safeCallListener(listener MentionListener, userID string, evt notify.BlockC
 		}
 	}()
 	listener.OnMention(userID, evt)
+}
+
+func (b *Backend) deliverMentionNotification(username string, extract string, evt notify.BlockChangeEvent) (string, error) {
+	mentionedUser, err := b.delivery.UserByUsername(username)
+	if err != nil {
+		if b.delivery.IsErrNotFound(err) {
+			// not really an error; could just be someone typed "@sometext"
+			return "", nil
+		} else {
+			return "", fmt.Errorf("cannot lookup mentioned user: %w", err)
+		}
+	}
+
+	if evt.ModifiedBy == nil {
+		return "", fmt.Errorf("invalid user cannot mention: %w", ErrMentionPermission)
+	}
+
+	if evt.Board.Type == model.BoardTypeOpen {
+		// public board rules:
+		//    - admin, editor, commenter: can mention anyone on team (mentioned users are automatically added to board)
+		//    - guest: can mention board members
+		switch {
+		case evt.ModifiedBy.SchemeAdmin, evt.ModifiedBy.SchemeEditor, evt.ModifiedBy.SchemeCommenter:
+			if !b.permissions.HasPermissionToTeam(mentionedUser.Id, evt.TeamID, model.PermissionViewTeam) {
+				return "", fmt.Errorf("%s cannot mention non-team member %s : %w", evt.ModifiedBy.UserID, mentionedUser.Id, ErrMentionPermission)
+			}
+			// add mentioned user to board (if not already a member)
+			_, err := b.store.GetMemberForBoard(evt.Board.ID, mentionedUser.Id)
+			if b.store.IsErrNotFound(err) {
+				// currently all memberships are created as editors by default
+				newBoardMember := &model.BoardMember{
+					UserID:       mentionedUser.Id,
+					BoardID:      evt.Board.ID,
+					SchemeEditor: true,
+				}
+				if _, err := b.store.SaveMember(newBoardMember); err != nil {
+					return "", fmt.Errorf("cannot add mentioned user %s to board %s: %w", mentionedUser.Id, evt.Board.ID, err)
+				}
+			}
+		case evt.ModifiedBy.SchemeViewer:
+			// viewer should not have gotten this far since they cannot add text to a card
+			return "", fmt.Errorf("%s (viewer) cannot mention user %s: %w", evt.ModifiedBy.UserID, mentionedUser.Id, ErrMentionPermission)
+		default:
+			// this is a guest
+			if !b.permissions.HasPermissionToBoard(mentionedUser.Id, evt.Board.ID, model.PermissionViewBoard) {
+				return "", fmt.Errorf("%s cannot mention non-board member %s : %w", evt.ModifiedBy.UserID, mentionedUser.Id, ErrMentionPermission)
+			}
+		}
+	} else {
+		// private board rules:
+		//    - admin, editor, commenter, guest: can mention board members
+		switch {
+		case evt.ModifiedBy.SchemeViewer:
+			// viewer should not have gotten this far since they cannot add text to a card
+			return "", fmt.Errorf("%s (viewer) cannot mention user %s: %w", evt.ModifiedBy.UserID, mentionedUser.Id, ErrMentionPermission)
+		default:
+			// everyone else can mention board members
+			if !b.permissions.HasPermissionToBoard(mentionedUser.Id, evt.Board.ID, model.PermissionViewBoard) {
+				return "", fmt.Errorf("%s cannot mention non-board member %s : %w", evt.ModifiedBy.UserID, mentionedUser.Id, ErrMentionPermission)
+			}
+		}
+	}
+
+	return b.delivery.MentionDeliver(mentionedUser, extract, evt)
 }

--- a/server/services/notify/notifymentions/store.go
+++ b/server/services/notify/notifymentions/store.go
@@ -1,0 +1,16 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+package notifymentions
+
+import "github.com/mattermost/focalboard/server/model"
+
+type Store interface {
+	GetUserByID(userID string) (*model.User, error)
+
+	GetMemberForBoard(boardID, userID string) (*model.BoardMember, error)
+	SaveMember(bm *model.BoardMember) (*model.BoardMember, error)
+
+	CreateSubscription(sub *model.Subscription) (*model.Subscription, error)
+
+	IsErrNotFound(err error) bool
+}

--- a/server/services/notify/notifysubscriptions/store.go
+++ b/server/services/notify/notifysubscriptions/store.go
@@ -18,6 +18,7 @@ type Store interface {
 	GetUserByID(userID string) (*model.User, error)
 
 	GetMemberForBoard(boardID, userID string) (*model.BoardMember, error)
+	SaveMember(bm *model.BoardMember) (*model.BoardMember, error)
 
 	CreateSubscription(sub *model.Subscription) (*model.Subscription, error)
 	GetSubscribersForBlock(blockID string) ([]*model.Subscriber, error)

--- a/server/services/notify/notifysubscriptions/subscriptions_backend.go
+++ b/server/services/notify/notifysubscriptions/subscriptions_backend.go
@@ -183,31 +183,6 @@ func (b *Backend) OnMention(userID string, evt notify.BlockChangeEvent) {
 		return
 	}
 
-	// admin, editor, commenter can auto-add user to public board
-	if evt.Board.Type == model.BoardTypeOpen {
-		switch {
-		case evt.ModifiedBy.SchemeAdmin, evt.ModifiedBy.SchemeEditor, evt.ModifiedBy.SchemeCommenter:
-			// add mentionee to the board if not already a member
-			_, err := b.store.GetMemberForBoard(evt.Board.ID, userID)
-			if b.store.IsErrNotFound(err) {
-				// currently all memberships are created as editors by default
-				newBoardMember := &model.BoardMember{
-					UserID:       userID,
-					BoardID:      evt.Board.ID,
-					SchemeEditor: true,
-				}
-				if _, err := b.store.SaveMember(newBoardMember); err != nil {
-					b.logger.Debug("Cannot add mentioned user to board",
-						mlog.String("user_id", userID),
-						mlog.String("board_id", evt.Board.ID),
-						mlog.Err(err),
-					)
-					return
-				}
-			}
-		}
-	}
-
 	// user mentioned must be a board member to subscribe to card.
 	if !b.permissions.HasPermissionToBoard(userID, evt.Board.ID, model.PermissionViewBoard) {
 		b.logger.Debug("Not subscribing mentioned non-board member to card",

--- a/server/services/notify/plugindelivery/mention_deliver.go
+++ b/server/services/notify/plugindelivery/mention_deliver.go
@@ -4,75 +4,22 @@
 package plugindelivery
 
 import (
-	"errors"
 	"fmt"
 
-	"github.com/mattermost/focalboard/server/model"
 	"github.com/mattermost/focalboard/server/services/notify"
 	"github.com/mattermost/focalboard/server/utils"
 
 	mm_model "github.com/mattermost/mattermost-server/v6/model"
 )
 
-var (
-	ErrMentionPermission = errors.New("mention not permitted")
-)
-
-// MentionDeliver notifies a user they have been mentioned in a block.
-func (pd *PluginDelivery) MentionDeliver(mentionUsername string, extract string, evt notify.BlockChangeEvent) (string, error) {
-	user, err := userByUsername(pd.api, mentionUsername)
-	if err != nil {
-		if isErrNotFound(err) {
-			// not really an error; could just be someone typed "@sometext"
-			return "", nil
-		} else {
-			return "", fmt.Errorf("cannot lookup mentioned user: %w", err)
-		}
-	}
-
-	if evt.ModifiedBy == nil {
-		return "", fmt.Errorf("invalid user cannot mention: %w", ErrMentionPermission)
-	}
-
-	if evt.Board.Type == model.BoardTypeOpen {
-		// public board rules:
-		//    - admin, editor, commenter: can mention anyone on team
-		//    - guest: can mention board members
-		switch {
-		case evt.ModifiedBy.SchemeAdmin, evt.ModifiedBy.SchemeEditor, evt.ModifiedBy.SchemeCommenter:
-			if !pd.permissions.HasPermissionToTeam(user.Id, evt.TeamID, model.PermissionViewTeam) {
-				return "", fmt.Errorf("%s cannot mention non-team member %s : %w", evt.ModifiedBy.UserID, user.Id, ErrMentionPermission)
-			}
-		case evt.ModifiedBy.SchemeViewer:
-			// viewer should not have gotten this far since they cannot add text to a card
-			return "", fmt.Errorf("%s (viewer) cannot mention user %s: %w", evt.ModifiedBy.UserID, user.Id, ErrMentionPermission)
-		default:
-			// this is a guest
-			if !pd.permissions.HasPermissionToBoard(user.Id, evt.Board.ID, model.PermissionViewBoard) {
-				return "", fmt.Errorf("%s cannot mention non-board member %s : %w", evt.ModifiedBy.UserID, user.Id, ErrMentionPermission)
-			}
-		}
-	} else {
-		// private board rules:
-		//    - admin, editor, commenter, guest: can mention board members
-		switch {
-		case evt.ModifiedBy.SchemeViewer:
-			// viewer should not have gotten this far since they cannot add text to a card
-			return "", fmt.Errorf("%s (viewer) cannot mention user %s: %w", evt.ModifiedBy.UserID, user.Id, ErrMentionPermission)
-		default:
-			// everyone else can mention board members
-			if !pd.permissions.HasPermissionToBoard(user.Id, evt.Board.ID, model.PermissionViewBoard) {
-				return "", fmt.Errorf("%s cannot mention non-board member %s : %w", evt.ModifiedBy.UserID, user.Id, ErrMentionPermission)
-			}
-		}
-	}
-
+// MentionDeliver notifies a user they have been mentioned in a blockv ia the plugin API.
+func (pd *PluginDelivery) MentionDeliver(mentionedUser *mm_model.User, extract string, evt notify.BlockChangeEvent) (string, error) {
 	author, err := pd.api.GetUserByID(evt.ModifiedBy.UserID)
 	if err != nil {
 		return "", fmt.Errorf("cannot find user: %w", err)
 	}
 
-	channel, err := pd.api.GetDirectChannel(user.Id, pd.botID)
+	channel, err := pd.api.GetDirectChannel(mentionedUser.Id, pd.botID)
 	if err != nil {
 		return "", fmt.Errorf("cannot get direct channel: %w", err)
 	}
@@ -83,5 +30,5 @@ func (pd *PluginDelivery) MentionDeliver(mentionUsername string, extract string,
 		ChannelId: channel.Id,
 		Message:   formatMessage(author.Username, extract, evt.Card.Title, link, evt.BlockChanged),
 	}
-	return user.Id, pd.api.CreatePost(post)
+	return mentionedUser.Id, pd.api.CreatePost(post)
 }

--- a/server/services/notify/plugindelivery/plugin_delivery.go
+++ b/server/services/notify/plugindelivery/plugin_delivery.go
@@ -4,8 +4,6 @@
 package plugindelivery
 
 import (
-	"github.com/mattermost/focalboard/server/services/permissions"
-
 	mm_model "github.com/mattermost/mattermost-server/v6/model"
 )
 
@@ -39,17 +37,21 @@ type PluginAPI interface {
 
 // PluginDelivery provides ability to send notifications to direct message channels via Mattermost plugin API.
 type PluginDelivery struct {
-	botID       string
-	serverRoot  string
-	api         PluginAPI
-	permissions permissions.PermissionsService
+	botID      string
+	serverRoot string
+	api        PluginAPI
 }
 
-func New(botID string, serverRoot string, api PluginAPI, permissions permissions.PermissionsService) *PluginDelivery {
+func New(botID string, serverRoot string, api PluginAPI) *PluginDelivery {
 	return &PluginDelivery{
-		botID:       botID,
-		serverRoot:  serverRoot,
-		api:         api,
-		permissions: permissions,
+		botID:      botID,
+		serverRoot: serverRoot,
+		api:        api,
 	}
+}
+
+// IsErrNotFound returns true if `err` or one of its wrapped children are the `ErrNotFound`
+// as defined in the plugin API.
+func (pd *PluginDelivery) IsErrNotFound(err error) bool {
+	return pd.api.IsErrNotFound(err)
 }

--- a/server/services/notify/plugindelivery/user.go
+++ b/server/services/notify/plugindelivery/user.go
@@ -13,14 +13,14 @@ const (
 	usernameSpecialChars = ".-_ "
 )
 
-func userByUsername(api PluginAPI, username string) (*mm_model.User, error) {
+func (pd *PluginDelivery) UserByUsername(username string) (*mm_model.User, error) {
 	// check for usernames that might have trailing punctuation
 	var user *mm_model.User
 	var err error
 	ok := true
 	trimmed := username
 	for ok {
-		user, err = api.GetUserByUsername(trimmed)
+		user, err = pd.api.GetUserByUsername(trimmed)
 		if err != nil && !isErrNotFound(err) {
 			return nil, err
 		}

--- a/server/services/notify/plugindelivery/user_test.go
+++ b/server/services/notify/plugindelivery/user_test.go
@@ -43,7 +43,8 @@ var (
 )
 
 func Test_userByUsername(t *testing.T) {
-	delivery := newPlugAPIMock(mockUsers)
+	pluginAPI := newPlugAPIMock(mockUsers)
+	delivery := New("bot_id", "server_root", pluginAPI)
 
 	tests := []struct {
 		name    string
@@ -64,7 +65,7 @@ func Test_userByUsername(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := userByUsername(delivery, tt.uname)
+			got, err := delivery.UserByUsername(tt.uname)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("userByUsername() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/server/services/notify/service.go
+++ b/server/services/notify/service.go
@@ -27,7 +27,7 @@ type BlockChangeEvent struct {
 	Card         *model.Block
 	BlockChanged *model.Block
 	BlockOld     *model.Block
-	ModifiedByID string
+	ModifiedBy   *model.BoardMember
 }
 
 type SubscriptionChangeNotifier interface {

--- a/server/utils/callbackqueue.go
+++ b/server/utils/callbackqueue.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"context"
+	"runtime/debug"
 	"sync/atomic"
 	"time"
 
@@ -119,7 +120,11 @@ func (cn *CallbackQueue) exec(f CallbackFunc) {
 	// don't let a panic in the callback exit the thread.
 	defer func() {
 		if r := recover(); r != nil {
-			cn.logger.Error("CallbackQueue callback panic", mlog.String("name", cn.name), mlog.Any("panic", r))
+			cn.logger.Error("CallbackQueue callback panic",
+				mlog.String("name", cn.name),
+				mlog.Any("panic", r),
+				mlog.String("stack", string(debug.Stack())),
+			)
 		}
 	}()
 


### PR DESCRIPTION
#### Summary
This PR implements [permissions spec](https://docs.google.com/document/d/1HOnoB87WZojqplpB6XGbtKsLuqjG8h-8CbJpmWsRfM4/edit#bookmark=id.7k6tbu6a6odp) for mentions.

- public boards: admin, editor, commenter can mention team members and auto-add them to board; guests can mention board members
- private boards:  admin, editor, commenter, guest can mention board members
- viewers cannot mention


#### Ticket Link
https://community.mattermost.com/boards/workspace/qgsck6cts3fwpqwyjiupjm5cde/b4ctmm917q3rzdfi451qtuxjzcw/150d1464-6d59-4c39-810f-ee201439dbaf/ciu68wqtbp3nuxnrt9o6db86htr