### PR TITLE
Use the right single user ID on the WS implementation

### DIFF
--- a/server/ws/server.go
+++ b/server/ws/server.go
@@ -14,8 +14,6 @@ import (
 	"github.com/mattermost/mattermost-server/v6/shared/mlog"
 )
 
-const singleUserID = "single-user-id"
-
 func (wss *websocketSession) WriteJSON(v interface{}) error {
 	wss.mu.Lock()
 	defer wss.mu.Unlock()
@@ -224,7 +222,7 @@ func (ws *Server) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 			// if single user mode, check that the userID is valid and
 			// assume that the user has permission if so
 			if len(ws.singleUserToken) != 0 {
-				if wsSession.userID != singleUserID {
+				if wsSession.userID != model.SingleUser {
 					continue
 				}
 
@@ -426,7 +424,7 @@ func (ws *Server) removeListenerFromBlock(listener *websocketSession, blockID st
 func (ws *Server) getUserIDForToken(token string) string {
 	if len(ws.singleUserToken) > 0 {
 		if token == ws.singleUserToken {
-			return singleUserID
+			return model.SingleUser
 		} else {
 			return ""
 		}

--- a/server/ws/server_test.go
+++ b/server/ws/server_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/mattermost/focalboard/server/auth"
+	"github.com/mattermost/focalboard/server/model"
 
 	"github.com/mattermost/mattermost-server/v6/shared/mlog"
 
@@ -235,6 +236,6 @@ func TestGetUserIDForTokenInSingleUserMode(t *testing.T) {
 	})
 
 	t.Run("Should return the single user ID if the token is correct", func(t *testing.T) {
-		require.Equal(t, singleUserID, server.getUserIDForToken(singleUserToken))
+		require.Equal(t, model.SingleUser, server.getUserIDForToken(singleUserToken))
 	})
 }


### PR DESCRIPTION
#### Summary
The websockets implementation was using the wrong single user ID when deciding if a user was subscribed to a team, hence not sending the corresponding team updates to the interface.

#### Ticket Link
https://github.com/mattermost/focalboard/issues/2731
