### PR TITLE
fix: hide 'Copy link' for `single-user` installs

### DIFF
--- a/webapp/src/components/cardDialog.tsx
+++ b/webapp/src/components/cardDialog.tsx
@@ -119,21 +119,23 @@ const CardDialog = (props: Props): JSX.Element => {
                     onClick={handleDeleteButtonOnClick}
                 />
             </BoardPermissionGate>
-            <Menu.Text
-                icon={<LinkIcon/>}
-                id='copy'
-                name={intl.formatMessage({id: 'CardDialog.copyLink', defaultMessage: 'Copy link'})}
-                onClick={() => {
-                    let cardLink = window.location.href
+            {me?.id !== "single-user" &&
+                <Menu.Text
+                    icon={<LinkIcon/>}
+                    id='copy'
+                    name={intl.formatMessage({id: 'CardDialog.copyLink', defaultMessage: 'Copy link'})}
+                    onClick={() => {
+                        let cardLink = window.location.href
 
-                    if (!cardLink.includes(props.cardId)) {
-                        cardLink += `/${props.cardId}`
-                    }
+                        if (!cardLink.includes(props.cardId)) {
+                            cardLink += `/${props.cardId}`
+                        }
 
-                    Utils.copyTextToClipboard(cardLink)
-                    sendFlashMessage({content: intl.formatMessage({id: 'CardDialog.copiedLink', defaultMessage: 'Copied!'}), severity: 'high'})
-                }}
-            />
+                        Utils.copyTextToClipboard(cardLink)
+                        sendFlashMessage({content: intl.formatMessage({id: 'CardDialog.copiedLink', defaultMessage: 'Copied!'}), severity: 'high'})
+                    }}
+                />
+            }
             {!isTemplate &&
                 <BoardPermissionGate permissions={[Permission.ManageBoardProperties]}>
                     <Menu.Text

--- a/webapp/src/components/cardDialog.tsx
+++ b/webapp/src/components/cardDialog.tsx
@@ -119,7 +119,7 @@ const CardDialog = (props: Props): JSX.Element => {
                     onClick={handleDeleteButtonOnClick}
                 />
             </BoardPermissionGate>
-            {me?.id !== "single-user" &&
+            {me?.id !== 'single-user' &&
                 <Menu.Text
                     icon={<LinkIcon/>}
                     id='copy'

--- a/webapp/src/components/gallery/gallery.test.tsx
+++ b/webapp/src/components/gallery/gallery.test.tsx
@@ -58,6 +58,12 @@ describe('src/components/gallery/Gallery', () => {
         comments: {
             comments: {},
         },
+        users: {
+            me: {
+                id: 'user_id_1',
+                props: {},
+            },
+        }
     }
     const store = mockStateStore([], state)
     beforeEach(() => {

--- a/webapp/src/components/gallery/galleryCard.test.tsx
+++ b/webapp/src/components/gallery/galleryCard.test.tsx
@@ -85,6 +85,12 @@ describe('src/components/gallery/GalleryCard', () => {
                     comments: {},
                     commentsByCard: {},
                 },
+                users: {
+                    me: {
+                        id: 'user_id_1',
+                        props: {},
+                    },
+                },
             }
             store = mockStateStore([], state)
         })
@@ -264,6 +270,12 @@ describe('src/components/gallery/GalleryCard', () => {
                         [board.id]: {userId: 'user_id_1', schemeAdmin: true},
                     },
                 },
+                users: {
+                    me: {
+                        id: 'user_id_1',
+                        props: {},
+                    },
+                },
             }
             store = mockStateStore([], state)
         })
@@ -330,6 +342,12 @@ describe('src/components/gallery/GalleryCard', () => {
                         [board.id]: {userId: 'user_id_1', schemeAdmin: true},
                     },
                 },
+                users: {
+                    me: {
+                        id: 'user_id_1',
+                        props: {},
+                    },
+                },
             }
             store = mockStateStore([], state)
         })
@@ -389,6 +407,12 @@ describe('src/components/gallery/GalleryCard', () => {
                     templates: [],
                     myBoardMemberships: {
                         [board.id]: {userId: 'user_id_1', schemeAdmin: true},
+                    },
+                },
+                users: {
+                    me: {
+                        id: 'user_id_1',
+                        props: {},
                     },
                 },
             }
@@ -469,6 +493,12 @@ describe('src/components/gallery/GalleryCard', () => {
                     templates: [],
                     myBoardMemberships: {
                         [board.id]: {userId: 'user_id_1', schemeAdmin: true},
+                    },
+                },
+                users: {
+                    me: {
+                        id: 'user_id_1',
+                        props: {},
                     },
                 },
             }

--- a/webapp/src/components/gallery/galleryCard.tsx
+++ b/webapp/src/components/gallery/galleryCard.tsx
@@ -102,7 +102,7 @@ const GalleryCard = (props: Props) => {
                                 }}
                             />
                         </BoardPermissionGate>
-                        {me?.id !== "single-user" &&
+                        {me?.id !== 'single-user' &&
                             <Menu.Text
                                 icon={<LinkIcon/>}
                                 id='copy'

--- a/webapp/src/components/gallery/galleryCard.tsx
+++ b/webapp/src/components/gallery/galleryCard.tsx
@@ -8,6 +8,8 @@ import {Card} from '../../blocks/card'
 import {ContentBlock} from '../../blocks/contentBlock'
 import {useSortable} from '../../hooks/sortable'
 import mutator from '../../mutator'
+import {IUser} from '../../user'
+import {getMe} from '../../store/users'
 import {getCardContents} from '../../store/contents'
 import {useAppSelector} from '../../store/hooks'
 import TelemetryClient, {TelemetryActions, TelemetryCategory} from '../../telemetry/telemetryClient'
@@ -49,6 +51,7 @@ const GalleryCard = (props: Props) => {
     const intl = useIntl()
     const [isDragging, isOver, cardRef] = useSortable('card', card, props.isManualSort && !props.readonly, props.onDrop)
     const contents = useAppSelector(getCardContents(card.id))
+    const me = useAppSelector<IUser|null>(getMe)
 
     const visiblePropertyTemplates = props.visiblePropertyTemplates || []
 
@@ -99,21 +102,23 @@ const GalleryCard = (props: Props) => {
                                 }}
                             />
                         </BoardPermissionGate>
-                        <Menu.Text
-                            icon={<LinkIcon/>}
-                            id='copy'
-                            name={intl.formatMessage({id: 'GalleryCard.copyLink', defaultMessage: 'Copy link'})}
-                            onClick={() => {
-                                let cardLink = window.location.href
+                        {me?.id !== "single-user" &&
+                            <Menu.Text
+                                icon={<LinkIcon/>}
+                                id='copy'
+                                name={intl.formatMessage({id: 'GalleryCard.copyLink', defaultMessage: 'Copy link'})}
+                                onClick={() => {
+                                    let cardLink = window.location.href
 
-                                if (!cardLink.includes(card.id)) {
-                                    cardLink += `/${card.id}`
-                                }
+                                    if (!cardLink.includes(card.id)) {
+                                        cardLink += `/${card.id}`
+                                    }
 
-                                Utils.copyTextToClipboard(cardLink)
-                                sendFlashMessage({content: intl.formatMessage({id: 'GalleryCard.copiedLink', defaultMessage: 'Copied!'}), severity: 'high'})
-                            }}
-                        />
+                                    Utils.copyTextToClipboard(cardLink)
+                                    sendFlashMessage({content: intl.formatMessage({id: 'GalleryCard.copiedLink', defaultMessage: 'Copied!'}), severity: 'high'})
+                                }}
+                            />
+                        }
                     </Menu>
                 </MenuWrapper>
             }

--- a/webapp/src/components/kanban/kanbanCard.tsx
+++ b/webapp/src/components/kanban/kanbanCard.tsx
@@ -21,6 +21,9 @@ import Tooltip from '../../widgets/tooltip'
 import {Permission} from '../../constants'
 import {sendFlashMessage} from '../flashMessages'
 import PropertyValueElement from '../propertyValueElement'
+import {IUser} from '../../user'
+import {getMe} from '../../store/users'
+import {useAppSelector} from '../../store/hooks'
 
 import BoardPermissionGate from '../permissions/boardPermissionGate'
 
@@ -51,6 +54,7 @@ const KanbanCard = (props: Props) => {
     const [isDragging, isOver, cardRef] = useSortable('card', card, !props.readonly, props.onDrop)
     const visiblePropertyTemplates = props.visiblePropertyTemplates || []
     const match = useRouteMatch<{boardId: string, viewId: string, cardId?: string}>()
+    const me = useAppSelector<IUser|null>(getMe)
     let className = props.isSelected ? 'KanbanCard selected' : 'KanbanCard'
     if (props.isManualSort && isOver) {
         className += ' dragover'
@@ -142,21 +146,23 @@ const KanbanCard = (props: Props) => {
                                 }}
                             />
                         </BoardPermissionGate>
-                        <Menu.Text
-                            icon={<LinkIcon/>}
-                            id='copy'
-                            name={intl.formatMessage({id: 'KanbanCard.copyLink', defaultMessage: 'Copy link'})}
-                            onClick={() => {
-                                let cardLink = window.location.href
+                        {me?.id !== "single-user" &&
+                            <Menu.Text
+                                icon={<LinkIcon/>}
+                                id='copy'
+                                name={intl.formatMessage({id: 'KanbanCard.copyLink', defaultMessage: 'Copy link'})}
+                                onClick={() => {
+                                    let cardLink = window.location.href
 
-                                if (!cardLink.includes(card.id)) {
-                                    cardLink += `/${card.id}`
-                                }
+                                    if (!cardLink.includes(card.id)) {
+                                        cardLink += `/${card.id}`
+                                    }
 
-                                Utils.copyTextToClipboard(cardLink)
-                                sendFlashMessage({content: intl.formatMessage({id: 'KanbanCard.copiedLink', defaultMessage: 'Copied!'}), severity: 'high'})
-                            }}
-                        />
+                                    Utils.copyTextToClipboard(cardLink)
+                                    sendFlashMessage({content: intl.formatMessage({id: 'KanbanCard.copiedLink', defaultMessage: 'Copied!'}), severity: 'high'})
+                                }}
+                            />
+                        }
                     </Menu>
                 </MenuWrapper>
                 }

--- a/webapp/src/components/kanban/kanbanCard.tsx
+++ b/webapp/src/components/kanban/kanbanCard.tsx
@@ -146,7 +146,7 @@ const KanbanCard = (props: Props) => {
                                 }}
                             />
                         </BoardPermissionGate>
-                        {me?.id !== "single-user" &&
+                        {me?.id !== 'single-user' &&
                             <Menu.Text
                                 icon={<LinkIcon/>}
                                 id='copy'


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

Hides instances of the `Copy link` button for `single-user` installs e.g. Personal Desktop.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

closes #2337 

