### PR TITLE
Add coalesce to template version migration

### DIFF
--- a/server/services/store/sqlstore/migrations/000017_add_teams_and_boards.up.sql
+++ b/server/services/store/sqlstore/migrations/000017_add_teams_and_boards.up.sql
@@ -228,7 +228,7 @@ CREATE TABLE {{.prefix}}boards_history (
                  COALESCE(title, ''),
                  json_extract(fields, '$.description'),
                  json_extract(fields, '$.icon'), json_extract(fields, '$.showDescription'), json_extract(fields, '$.isTemplate'),
-                 json_extract(fields, '$.templateVer'),
+                 COALESCE(json_extract(fields, '$.templateVer'), 0),
                  '{}', json_extract(fields, '$.cardProperties'), json_extract(fields, '$.columnCalculations'), create_at,
                  update_at, delete_at
           FROM {{.prefix}}blocks
@@ -239,7 +239,7 @@ CREATE TABLE {{.prefix}}boards_history (
                  COALESCE(title, ''),
                  json_extract(fields, '$.description'),
                  json_extract(fields, '$.icon'), json_extract(fields, '$.showDescription'), json_extract(fields, '$.isTemplate'),
-                 json_extract(fields, '$.templateVer'),
+                 COALESCE(json_extract(fields, '$.templateVer'), 0),
                  '{}', json_extract(fields, '$.cardProperties'), json_extract(fields, '$.columnCalculations'), create_at,
                  update_at, delete_at
           FROM {{.prefix}}blocks_history


### PR DESCRIPTION
#### Summary
SQLite was not setting a default value on migrated templates for their version, causing the scanner to fail when getting `NULL`s for integer values.

#### Ticket Link
Fixes #2736

