### PR TITLE
GH-2759 - fix path to file api

### DIFF
--- a/webapp/src/octoClient.ts
+++ b/webapp/src/octoClient.ts
@@ -553,7 +553,7 @@ class OctoClient {
     }
 
     async getFileAsDataUrl(boardId: string, fileId: string): Promise<string> {
-        let path = '/files/teams/' + this.teamId + '/' + boardId + '/' + fileId
+        let path = '/api/v1/files/teams/' + this.teamId + '/' + boardId + '/' + fileId
         const readToken = Utils.getReadToken()
         if (readToken) {
             path += `?read_token=${readToken}`


### PR DESCRIPTION
#### Summary
Prior to permissions release, the `api/v1` was not included in the file upload path. This was fixed in the permission branch, but the octoclient was never updated. This PR updates the octoclient to include that in the path.

#### Ticket Link

  Fixes https://github.com/mattermost/focalboard/issues/2759

