### PR TITLE
GH2575 - Focus title when card is created

### DIFF
--- a/webapp/cypress/integration/createBoard.ts
+++ b/webapp/cypress/integration/createBoard.ts
@@ -72,7 +72,12 @@ describe('Create and delete board / card', () => {
         cy.log('**Create card**')
         cy.get('.ViewHeader').contains('New').click()
         cy.get('.CardDetail').should('exist')
-
+        
+        //Check title has focus when card is created
+        cy.log('**Check title has focus when card is created**')
+        cy.get('.CardDetail .EditableArea.title').
+            should('have.focus')
+        
         // Change card title
         cy.log('**Change card title**')
         // eslint-disable-next-line cypress/no-unnecessary-waiting

--- a/webapp/src/components/markdownEditorInput/markdownEditorInput.tsx
+++ b/webapp/src/components/markdownEditorInput/markdownEditorInput.tsx
@@ -126,6 +126,10 @@ const MarkdownEditorInput = (props: Props): ReactElement => {
 
     const onEditorStateChange = useCallback((newEditorState: EditorState) => {
         const newText = newEditorState.getCurrentContent().getPlainText()
+        const text = editorState.getCurrentContent().getPlainText()
+
+        if(text === newText) return
+
         onChange && onChange(newText)
         setEditorState(newEditorState)
     }, [onChange])


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

I fixed the issue that the title is not focused when a card is created.
It seems that `markdownEditorInput` used in `CardDetatilContents` triggered a problem.
`onChange` event from `Editor` component is triggered even when the component is mounted.
It re-renders the component, so the `title` component loses the focus.

I added a guard to `onEditorStateChange` function, so the logic will not be executed when an old state is equal to a new state. 
I added a cypress test to check if it works.


https://user-images.githubusercontent.com/59413880/163104968-60f84558-a694-4fc6-9b42-76cd886ba4e0.mov




#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

Closes #2575 

