### PR TITLE
Avoided using UUID() as function param for MySQL migration

### DIFF
--- a/server/services/store/sqlstore/migrations/000018_populate_categories.up.sql
+++ b/server/services/store/sqlstore/migrations/000018_populate_categories.up.sql
@@ -26,7 +26,7 @@ CREATE TABLE {{.prefix}}categories (
             REPLACE(uuid_in(md5(random()::text || clock_timestamp()::text)::cstring)::varchar, '-', ''),
         {{ end }}
         {{ if .mysql }}
-            REPLACE(UUID(), '-', ''),
+            UUID(),
         {{ end }}
         COALESCE(nullif(c.DisplayName, ''), 'Direct Message') as category_name,
         cm.UserId,

--- a/server/services/store/sqlstore/migrations/000019_populate_category_blocks.up.sql
+++ b/server/services/store/sqlstore/migrations/000019_populate_category_blocks.up.sql
@@ -16,7 +16,7 @@ CREATE TABLE {{.prefix}}category_blocks (
             REPLACE(uuid_in(md5(random()::text || clock_timestamp()::text)::cstring)::varchar, '-', ''),
         {{ end }}
         {{ if .mysql }}
-            REPLACE(UUID(), '-', ''),
+            UUID(),
         {{ end }}
         {{.prefix}}categories.user_id,
         {{.prefix}}categories.id,


### PR DESCRIPTION
Fixes #2773

@sbishel @wiggin77 This is the quickest and cleanest fix IMO. The data migration anyways updates the IDs to our standard UUID format, so it doesn't really matter what we use in the SQL migration as long as its a varchar.

Tested on both MySQL v5.7 and v8.