### PR TITLE
Remove export archive from plugin header

### DIFF
--- a/server/api/archive.go
+++ b/server/api/archive.go
@@ -115,11 +115,6 @@ func (a *API) handleArchiveExportTeam(w http.ResponseWriter, r *http.Request) {
 		a.errorResponse(w, r.URL.Path, http.StatusNotImplemented, "not permitted in plugin mode", nil)
 	}
 
-	if a.MattermostAuth {
-		a.errorResponse(w, r.URL.Path, http.StatusNotImplemented, "", nil)
-		return
-	}
-
 	vars := mux.Vars(r)
 	teamID := vars["teamID"]
 

--- a/webapp/src/components/globalHeader/__snapshots__/globalHeaderSettingsMenu.test.tsx.snap
+++ b/webapp/src/components/globalHeader/__snapshots__/globalHeaderSettingsMenu.test.tsx.snap
@@ -218,29 +218,6 @@ exports[`components/sidebar/GlobalHeaderSettingsMenu imports menu open should ma
             </div>
             <div>
               <div
-                aria-label="Export archive"
-                class="MenuOption TextOption menu-option"
-                role="button"
-              >
-                <div
-                  class=""
-                >
-                  <div
-                    class="noicon"
-                  />
-                </div>
-                <div
-                  class="menu-name"
-                >
-                  Export archive
-                </div>
-                <div
-                  class="noicon"
-                />
-              </div>
-            </div>
-            <div>
-              <div
                 class="MenuOption SubMenuOption menu-option open-left"
                 id="lang"
               >
@@ -393,29 +370,6 @@ exports[`components/sidebar/GlobalHeaderSettingsMenu languages menu open should 
                 >
                   Import
                 </div>
-              </div>
-            </div>
-            <div>
-              <div
-                aria-label="Export archive"
-                class="MenuOption TextOption menu-option"
-                role="button"
-              >
-                <div
-                  class=""
-                >
-                  <div
-                    class="noicon"
-                  />
-                </div>
-                <div
-                  class="menu-name"
-                >
-                  Export archive
-                </div>
-                <div
-                  class="noicon"
-                />
               </div>
             </div>
             <div>
@@ -997,29 +951,6 @@ exports[`components/sidebar/GlobalHeaderSettingsMenu settings menu open should m
                 >
                   Import
                 </div>
-              </div>
-            </div>
-            <div>
-              <div
-                aria-label="Export archive"
-                class="MenuOption TextOption menu-option"
-                role="button"
-              >
-                <div
-                  class=""
-                >
-                  <div
-                    class="noicon"
-                  />
-                </div>
-                <div
-                  class="menu-name"
-                >
-                  Export archive
-                </div>
-                <div
-                  class="noicon"
-                />
               </div>
             </div>
             <div>

--- a/webapp/src/components/globalHeader/globalHeaderSettingsMenu.tsx
+++ b/webapp/src/components/globalHeader/globalHeaderSettingsMenu.tsx
@@ -72,16 +72,6 @@ const GlobalHeaderSettingsMenu = (props: Props) => {
                             ))
                         }
                     </Menu.SubMenu>
-                    <Menu.Text
-                        id='export'
-                        name={intl.formatMessage({id: 'Sidebar.export-archive', defaultMessage: 'Export archive'})}
-                        onClick={async () => {
-                            if (currentTeam) {
-                                TelemetryClient.trackEvent(TelemetryCategory, TelemetryActions.ExportArchive)
-                                Archiver.exportFullArchive(currentTeam.id)
-                            }
-                        }}
-                    />
                     <Menu.SubMenu
                         id='lang'
                         name={intl.formatMessage({id: 'Sidebar.set-language', defaultMessage: 'Set language'})}


### PR DESCRIPTION
#### Summary
Follow up to https://github.com/mattermost/focalboard/pull/2776 to remove the export archive option from plugin mode. A redundant check on the API has been removed as well as cleanup.

#### Ticket Link
Related to https://github.com/mattermost/focalboard/issues/2672
Fixes https://github.com/mattermost/focalboard/issues/2780
