### PR TITLE
Update focalboard endpoints to v2 namespace

### DIFF
--- a/experiments/webext/src/utils/networking.ts
+++ b/experiments/webext/src/utils/networking.ts
@@ -10,7 +10,7 @@ declare global {
 }
 
 async function request(method: string, host: string, resource: string, body: any, token: string | null) {
-  const response = await fetch(`${host}/api/v1/${resource}`, {
+  const response = await fetch(`${host}/api/v2/${resource}`, {
     'credentials': 'include',
     'headers': {
       'Accept': 'application/json',

--- a/server/admin-scripts/reset-password.sh
+++ b/server/admin-scripts/reset-password.sh
@@ -5,4 +5,4 @@ if [[ $# < 2 ]] ; then
     exit 1
 fi
 
-curl --unix-socket /var/tmp/focalboard_local.socket http://localhost/api/v1/admin/users/$1/password -X POST -H 'Content-Type: application/json' -d '{ "password": "'$2'" }'
+curl --unix-socket /var/tmp/focalboard_local.socket http://localhost/api/v2/admin/users/$1/password -X POST -H 'Content-Type: application/json' -d '{ "password": "'$2'" }'

--- a/server/api/api.go
+++ b/server/api/api.go
@@ -68,94 +68,94 @@ func NewAPI(app *app.App, singleUserToken string, authService string, permission
 }
 
 func (a *API) RegisterRoutes(r *mux.Router) {
-	apiv1 := r.PathPrefix("/api/v1").Subrouter()
-	apiv1.Use(a.panicHandler)
-	apiv1.Use(a.requireCSRFToken)
+	apiv2 := r.PathPrefix("/api/v2").Subrouter()
+	apiv2.Use(a.panicHandler)
+	apiv2.Use(a.requireCSRFToken)
 
 	// Board APIs
-	apiv1.HandleFunc("/teams/{teamID}/boards", a.sessionRequired(a.handleGetBoards)).Methods("GET")
-	apiv1.HandleFunc("/teams/{teamID}/boards/search", a.sessionRequired(a.handleSearchBoards)).Methods("GET")
-	apiv1.HandleFunc("/teams/{teamID}/templates", a.sessionRequired(a.handleGetTemplates)).Methods("GET")
-	apiv1.HandleFunc("/boards", a.sessionRequired(a.handleCreateBoard)).Methods("POST")
-	apiv1.HandleFunc("/boards/{boardID}", a.attachSession(a.handleGetBoard, false)).Methods("GET")
-	apiv1.HandleFunc("/boards/{boardID}", a.sessionRequired(a.handlePatchBoard)).Methods("PATCH")
-	apiv1.HandleFunc("/boards/{boardID}", a.sessionRequired(a.handleDeleteBoard)).Methods("DELETE")
-	apiv1.HandleFunc("/boards/{boardID}/duplicate", a.sessionRequired(a.handleDuplicateBoard)).Methods("POST")
-	apiv1.HandleFunc("/boards/{boardID}/undelete", a.sessionRequired(a.handleUndeleteBoard)).Methods("POST")
-	apiv1.HandleFunc("/boards/{boardID}/blocks", a.attachSession(a.handleGetBlocks, false)).Methods("GET")
-	apiv1.HandleFunc("/boards/{boardID}/blocks", a.sessionRequired(a.handlePostBlocks)).Methods("POST")
-	apiv1.HandleFunc("/boards/{boardID}/blocks", a.sessionRequired(a.handlePatchBlocks)).Methods("PATCH")
-	apiv1.HandleFunc("/boards/{boardID}/blocks/{blockID}", a.sessionRequired(a.handleDeleteBlock)).Methods("DELETE")
-	apiv1.HandleFunc("/boards/{boardID}/blocks/{blockID}", a.sessionRequired(a.handlePatchBlock)).Methods("PATCH")
-	apiv1.HandleFunc("/boards/{boardID}/blocks/{blockID}/undelete", a.sessionRequired(a.handleUndeleteBlock)).Methods("POST")
-	apiv1.HandleFunc("/boards/{boardID}/blocks/{blockID}/duplicate", a.sessionRequired(a.handleDuplicateBlock)).Methods("POST")
-	apiv1.HandleFunc("/boards/{boardID}/metadata", a.sessionRequired(a.handleGetBoardMetadata)).Methods("GET")
+	apiv2.HandleFunc("/teams/{teamID}/boards", a.sessionRequired(a.handleGetBoards)).Methods("GET")
+	apiv2.HandleFunc("/teams/{teamID}/boards/search", a.sessionRequired(a.handleSearchBoards)).Methods("GET")
+	apiv2.HandleFunc("/teams/{teamID}/templates", a.sessionRequired(a.handleGetTemplates)).Methods("GET")
+	apiv2.HandleFunc("/boards", a.sessionRequired(a.handleCreateBoard)).Methods("POST")
+	apiv2.HandleFunc("/boards/{boardID}", a.attachSession(a.handleGetBoard, false)).Methods("GET")
+	apiv2.HandleFunc("/boards/{boardID}", a.sessionRequired(a.handlePatchBoard)).Methods("PATCH")
+	apiv2.HandleFunc("/boards/{boardID}", a.sessionRequired(a.handleDeleteBoard)).Methods("DELETE")
+	apiv2.HandleFunc("/boards/{boardID}/duplicate", a.sessionRequired(a.handleDuplicateBoard)).Methods("POST")
+	apiv2.HandleFunc("/boards/{boardID}/undelete", a.sessionRequired(a.handleUndeleteBoard)).Methods("POST")
+	apiv2.HandleFunc("/boards/{boardID}/blocks", a.attachSession(a.handleGetBlocks, false)).Methods("GET")
+	apiv2.HandleFunc("/boards/{boardID}/blocks", a.sessionRequired(a.handlePostBlocks)).Methods("POST")
+	apiv2.HandleFunc("/boards/{boardID}/blocks", a.sessionRequired(a.handlePatchBlocks)).Methods("PATCH")
+	apiv2.HandleFunc("/boards/{boardID}/blocks/{blockID}", a.sessionRequired(a.handleDeleteBlock)).Methods("DELETE")
+	apiv2.HandleFunc("/boards/{boardID}/blocks/{blockID}", a.sessionRequired(a.handlePatchBlock)).Methods("PATCH")
+	apiv2.HandleFunc("/boards/{boardID}/blocks/{blockID}/undelete", a.sessionRequired(a.handleUndeleteBlock)).Methods("POST")
+	apiv2.HandleFunc("/boards/{boardID}/blocks/{blockID}/duplicate", a.sessionRequired(a.handleDuplicateBlock)).Methods("POST")
+	apiv2.HandleFunc("/boards/{boardID}/metadata", a.sessionRequired(a.handleGetBoardMetadata)).Methods("GET")
 
 	// Member APIs
-	apiv1.HandleFunc("/boards/{boardID}/members", a.sessionRequired(a.handleGetMembersForBoard)).Methods("GET")
-	apiv1.HandleFunc("/boards/{boardID}/members", a.sessionRequired(a.handleAddMember)).Methods("POST")
-	apiv1.HandleFunc("/boards/{boardID}/members/{userID}", a.sessionRequired(a.handleUpdateMember)).Methods("PUT")
-	apiv1.HandleFunc("/boards/{boardID}/members/{userID}", a.sessionRequired(a.handleDeleteMember)).Methods("DELETE")
-	apiv1.HandleFunc("/boards/{boardID}/join", a.sessionRequired(a.handleJoinBoard)).Methods("POST")
-	apiv1.HandleFunc("/boards/{boardID}/leave", a.sessionRequired(a.handleLeaveBoard)).Methods("POST")
+	apiv2.HandleFunc("/boards/{boardID}/members", a.sessionRequired(a.handleGetMembersForBoard)).Methods("GET")
+	apiv2.HandleFunc("/boards/{boardID}/members", a.sessionRequired(a.handleAddMember)).Methods("POST")
+	apiv2.HandleFunc("/boards/{boardID}/members/{userID}", a.sessionRequired(a.handleUpdateMember)).Methods("PUT")
+	apiv2.HandleFunc("/boards/{boardID}/members/{userID}", a.sessionRequired(a.handleDeleteMember)).Methods("DELETE")
+	apiv2.HandleFunc("/boards/{boardID}/join", a.sessionRequired(a.handleJoinBoard)).Methods("POST")
+	apiv2.HandleFunc("/boards/{boardID}/leave", a.sessionRequired(a.handleLeaveBoard)).Methods("POST")
 
 	// Sharing APIs
-	apiv1.HandleFunc("/boards/{boardID}/sharing", a.sessionRequired(a.handlePostSharing)).Methods("POST")
-	apiv1.HandleFunc("/boards/{boardID}/sharing", a.sessionRequired(a.handleGetSharing)).Methods("GET")
+	apiv2.HandleFunc("/boards/{boardID}/sharing", a.sessionRequired(a.handlePostSharing)).Methods("POST")
+	apiv2.HandleFunc("/boards/{boardID}/sharing", a.sessionRequired(a.handleGetSharing)).Methods("GET")
 
 	// Team APIs
-	apiv1.HandleFunc("/teams", a.sessionRequired(a.handleGetTeams)).Methods("GET")
-	apiv1.HandleFunc("/teams/{teamID}", a.sessionRequired(a.handleGetTeam)).Methods("GET")
-	apiv1.HandleFunc("/teams/{teamID}/regenerate_signup_token", a.sessionRequired(a.handlePostTeamRegenerateSignupToken)).Methods("POST")
-	apiv1.HandleFunc("/teams/{teamID}/users", a.sessionRequired(a.handleGetTeamUsers)).Methods("GET")
-	apiv1.HandleFunc("/teams/{teamID}/archive/export", a.sessionRequired(a.handleArchiveExportTeam)).Methods("GET")
-	apiv1.HandleFunc("/teams/{teamID}/{boardID}/files", a.sessionRequired(a.handleUploadFile)).Methods("POST")
+	apiv2.HandleFunc("/teams", a.sessionRequired(a.handleGetTeams)).Methods("GET")
+	apiv2.HandleFunc("/teams/{teamID}", a.sessionRequired(a.handleGetTeam)).Methods("GET")
+	apiv2.HandleFunc("/teams/{teamID}/regenerate_signup_token", a.sessionRequired(a.handlePostTeamRegenerateSignupToken)).Methods("POST")
+	apiv2.HandleFunc("/teams/{teamID}/users", a.sessionRequired(a.handleGetTeamUsers)).Methods("GET")
+	apiv2.HandleFunc("/teams/{teamID}/archive/export", a.sessionRequired(a.handleArchiveExportTeam)).Methods("GET")
+	apiv2.HandleFunc("/teams/{teamID}/{boardID}/files", a.sessionRequired(a.handleUploadFile)).Methods("POST")
 
 	// User APIs
-	apiv1.HandleFunc("/users/me", a.sessionRequired(a.handleGetMe)).Methods("GET")
-	apiv1.HandleFunc("/users/me/memberships", a.sessionRequired(a.handleGetMyMemberships)).Methods("GET")
-	apiv1.HandleFunc("/users/{userID}", a.sessionRequired(a.handleGetUser)).Methods("GET")
-	apiv1.HandleFunc("/users/{userID}/changepassword", a.sessionRequired(a.handleChangePassword)).Methods("POST")
-	apiv1.HandleFunc("/users/{userID}/config", a.sessionRequired(a.handleUpdateUserConfig)).Methods(http.MethodPut)
+	apiv2.HandleFunc("/users/me", a.sessionRequired(a.handleGetMe)).Methods("GET")
+	apiv2.HandleFunc("/users/me/memberships", a.sessionRequired(a.handleGetMyMemberships)).Methods("GET")
+	apiv2.HandleFunc("/users/{userID}", a.sessionRequired(a.handleGetUser)).Methods("GET")
+	apiv2.HandleFunc("/users/{userID}/changepassword", a.sessionRequired(a.handleChangePassword)).Methods("POST")
+	apiv2.HandleFunc("/users/{userID}/config", a.sessionRequired(a.handleUpdateUserConfig)).Methods(http.MethodPut)
 
 	// BoardsAndBlocks APIs
-	apiv1.HandleFunc("/boards-and-blocks", a.sessionRequired(a.handleCreateBoardsAndBlocks)).Methods("POST")
-	apiv1.HandleFunc("/boards-and-blocks", a.sessionRequired(a.handlePatchBoardsAndBlocks)).Methods("PATCH")
-	apiv1.HandleFunc("/boards-and-blocks", a.sessionRequired(a.handleDeleteBoardsAndBlocks)).Methods("DELETE")
+	apiv2.HandleFunc("/boards-and-blocks", a.sessionRequired(a.handleCreateBoardsAndBlocks)).Methods("POST")
+	apiv2.HandleFunc("/boards-and-blocks", a.sessionRequired(a.handlePatchBoardsAndBlocks)).Methods("PATCH")
+	apiv2.HandleFunc("/boards-and-blocks", a.sessionRequired(a.handleDeleteBoardsAndBlocks)).Methods("DELETE")
 
 	// Auth APIs
-	apiv1.HandleFunc("/login", a.handleLogin).Methods("POST")
-	apiv1.HandleFunc("/logout", a.sessionRequired(a.handleLogout)).Methods("POST")
-	apiv1.HandleFunc("/register", a.handleRegister).Methods("POST")
-	apiv1.HandleFunc("/clientConfig", a.getClientConfig).Methods("GET")
+	apiv2.HandleFunc("/login", a.handleLogin).Methods("POST")
+	apiv2.HandleFunc("/logout", a.sessionRequired(a.handleLogout)).Methods("POST")
+	apiv2.HandleFunc("/register", a.handleRegister).Methods("POST")
+	apiv2.HandleFunc("/clientConfig", a.getClientConfig).Methods("GET")
 
 	// Category APIs
-	apiv1.HandleFunc("/teams/{teamID}/categories", a.sessionRequired(a.handleCreateCategory)).Methods(http.MethodPost)
-	apiv1.HandleFunc("/teams/{teamID}/categories/{categoryID}", a.sessionRequired(a.handleUpdateCategory)).Methods(http.MethodPut)
-	apiv1.HandleFunc("/teams/{teamID}/categories/{categoryID}", a.sessionRequired(a.handleDeleteCategory)).Methods(http.MethodDelete)
+	apiv2.HandleFunc("/teams/{teamID}/categories", a.sessionRequired(a.handleCreateCategory)).Methods(http.MethodPost)
+	apiv2.HandleFunc("/teams/{teamID}/categories/{categoryID}", a.sessionRequired(a.handleUpdateCategory)).Methods(http.MethodPut)
+	apiv2.HandleFunc("/teams/{teamID}/categories/{categoryID}", a.sessionRequired(a.handleDeleteCategory)).Methods(http.MethodDelete)
 
 	// Category Block APIs
-	apiv1.HandleFunc("/teams/{teamID}/categories", a.sessionRequired(a.handleGetUserCategoryBlocks)).Methods(http.MethodGet)
-	apiv1.HandleFunc("/teams/{teamID}/categories/{categoryID}/blocks/{blockID}", a.sessionRequired(a.handleUpdateCategoryBlock)).Methods(http.MethodPost)
+	apiv2.HandleFunc("/teams/{teamID}/categories", a.sessionRequired(a.handleGetUserCategoryBlocks)).Methods(http.MethodGet)
+	apiv2.HandleFunc("/teams/{teamID}/categories/{categoryID}/blocks/{blockID}", a.sessionRequired(a.handleUpdateCategoryBlock)).Methods(http.MethodPost)
 
 	// Get Files API
-	apiv1.HandleFunc("/files/teams/{teamID}/{boardID}/{filename}", a.attachSession(a.handleServeFile, false)).Methods("GET")
+	apiv2.HandleFunc("/files/teams/{teamID}/{boardID}/{filename}", a.attachSession(a.handleServeFile, false)).Methods("GET")
 
 	// Subscriptions
-	apiv1.HandleFunc("/subscriptions", a.sessionRequired(a.handleCreateSubscription)).Methods("POST")
-	apiv1.HandleFunc("/subscriptions/{blockID}/{subscriberID}", a.sessionRequired(a.handleDeleteSubscription)).Methods("DELETE")
-	apiv1.HandleFunc("/subscriptions/{subscriberID}", a.sessionRequired(a.handleGetSubscriptions)).Methods("GET")
+	apiv2.HandleFunc("/subscriptions", a.sessionRequired(a.handleCreateSubscription)).Methods("POST")
+	apiv2.HandleFunc("/subscriptions/{blockID}/{subscriberID}", a.sessionRequired(a.handleDeleteSubscription)).Methods("DELETE")
+	apiv2.HandleFunc("/subscriptions/{subscriberID}", a.sessionRequired(a.handleGetSubscriptions)).Methods("GET")
 
 	// onboarding tour endpoints
-	apiv1.HandleFunc("/teams/{teamID}/onboard", a.sessionRequired(a.handleOnboard)).Methods(http.MethodPost)
+	apiv2.HandleFunc("/teams/{teamID}/onboard", a.sessionRequired(a.handleOnboard)).Methods(http.MethodPost)
 
 	// archives
-	apiv1.HandleFunc("/boards/{boardID}/archive/export", a.sessionRequired(a.handleArchiveExportBoard)).Methods("GET")
-	apiv1.HandleFunc("/teams/{teamID}/archive/import", a.sessionRequired(a.handleArchiveImport)).Methods("POST")
+	apiv2.HandleFunc("/boards/{boardID}/archive/export", a.sessionRequired(a.handleArchiveExportBoard)).Methods("GET")
+	apiv2.HandleFunc("/teams/{teamID}/archive/import", a.sessionRequired(a.handleArchiveImport)).Methods("POST")
 }
 
 func (a *API) RegisterAdminRoutes(r *mux.Router) {
-	r.HandleFunc("/api/v1/admin/users/{username}/password", a.adminRequired(a.handleAdminSetPassword)).Methods("POST")
+	r.HandleFunc("/api/v2/admin/users/{username}/password", a.adminRequired(a.handleAdminSetPassword)).Methods("POST")
 }
 
 func getUserID(r *http.Request) string {
@@ -230,7 +230,7 @@ func (a *API) hasValidReadTokenForBoard(r *http.Request, boardID string) bool {
 }
 
 func (a *API) handleGetBlocks(w http.ResponseWriter, r *http.Request) {
-	// swagger:operation GET /api/v1/boards/{boardID}/blocks getBlocks
+	// swagger:operation GET /boards/{boardID}/blocks getBlocks
 	//
 	// Returns blocks
 	//
@@ -591,7 +591,7 @@ func (a *API) handleUpdateCategoryBlock(w http.ResponseWriter, r *http.Request) 
 }
 
 func (a *API) handlePostBlocks(w http.ResponseWriter, r *http.Request) {
-	// swagger:operation POST /api/v1/boards/{boardID}/blocks updateBlocks
+	// swagger:operation POST /boards/{boardID}/blocks updateBlocks
 	//
 	// Insert blocks. The specified IDs will only be used to link
 	// blocks with existing ones, the rest will be replaced by server
@@ -719,7 +719,7 @@ func (a *API) handlePostBlocks(w http.ResponseWriter, r *http.Request) {
 }
 
 func (a *API) handleUpdateUserConfig(w http.ResponseWriter, r *http.Request) {
-	// swagger:operation PATCH /api/v1/users/{userID}/config updateUserConfig
+	// swagger:operation PATCH /users/{userID}/config updateUserConfig
 	//
 	// Updates user config
 	//
@@ -793,7 +793,7 @@ func (a *API) handleUpdateUserConfig(w http.ResponseWriter, r *http.Request) {
 }
 
 func (a *API) handleGetUser(w http.ResponseWriter, r *http.Request) {
-	// swagger:operation GET /api/v1/users/{userID} getUser
+	// swagger:operation GET /users/{userID} getUser
 	//
 	// Returns a user
 	//
@@ -842,7 +842,7 @@ func (a *API) handleGetUser(w http.ResponseWriter, r *http.Request) {
 }
 
 func (a *API) handleGetMe(w http.ResponseWriter, r *http.Request) {
-	// swagger:operation GET /api/v1/users/me getMe
+	// swagger:operation GET /users/me getMe
 	//
 	// Returns the currently logged-in user
 	//
@@ -899,7 +899,7 @@ func (a *API) handleGetMe(w http.ResponseWriter, r *http.Request) {
 }
 
 func (a *API) handleGetMyMemberships(w http.ResponseWriter, r *http.Request) {
-	// swagger:operation GET /api/v1/users/me/memberships getMyMemberships
+	// swagger:operation GET /users/me/memberships getMyMemberships
 	//
 	// Returns the currently users board memberships
 	//
@@ -944,7 +944,7 @@ func (a *API) handleGetMyMemberships(w http.ResponseWriter, r *http.Request) {
 }
 
 func (a *API) handleDeleteBlock(w http.ResponseWriter, r *http.Request) {
-	// swagger:operation DELETE /api/v1/boards/{boardID}/blocks/{blockID} deleteBlock
+	// swagger:operation DELETE /boards/{boardID}/blocks/{blockID} deleteBlock
 	//
 	// Deletes a block
 	//
@@ -1012,7 +1012,7 @@ func (a *API) handleDeleteBlock(w http.ResponseWriter, r *http.Request) {
 }
 
 func (a *API) handleUndeleteBlock(w http.ResponseWriter, r *http.Request) {
-	// swagger:operation POST /api/v1/boards/{boardID}/blocks/{blockID}/undelete undeleteBlock
+	// swagger:operation POST /boards/{boardID}/blocks/{blockID}/undelete undeleteBlock
 	//
 	// Undeletes a block
 	//
@@ -1105,7 +1105,7 @@ func (a *API) handleUndeleteBlock(w http.ResponseWriter, r *http.Request) {
 }
 
 func (a *API) handleUndeleteBoard(w http.ResponseWriter, r *http.Request) {
-	// swagger:operation POST /api/v1/boards/{boardID}/undelete undeleteBoard
+	// swagger:operation POST /boards/{boardID}/undelete undeleteBoard
 	//
 	// Undeletes a board
 	//
@@ -1157,7 +1157,7 @@ func (a *API) handleUndeleteBoard(w http.ResponseWriter, r *http.Request) {
 }
 
 func (a *API) handlePatchBlock(w http.ResponseWriter, r *http.Request) {
-	// swagger:operation PATCH /api/v1/boards/{boardID}/blocks/{blockID} patchBlock
+	// swagger:operation PATCH /boards/{boardID}/blocks/{blockID} patchBlock
 	//
 	// Partially updates a block
 	//
@@ -1244,7 +1244,7 @@ func (a *API) handlePatchBlock(w http.ResponseWriter, r *http.Request) {
 }
 
 func (a *API) handlePatchBlocks(w http.ResponseWriter, r *http.Request) {
-	// swagger:operation PATCH /api/v1/boards/{boardID}/blocks/ patchBlocks
+	// swagger:operation PATCH /boards/{boardID}/blocks/ patchBlocks
 	//
 	// Partially updates batch of blocks
 	//
@@ -1327,7 +1327,7 @@ func (a *API) handlePatchBlocks(w http.ResponseWriter, r *http.Request) {
 // Sharing
 
 func (a *API) handleGetSharing(w http.ResponseWriter, r *http.Request) {
-	// swagger:operation GET /api/v1/boards/{boardID}/sharing getSharing
+	// swagger:operation GET /boards/{boardID}/sharing getSharing
 	//
 	// Returns sharing information for a board
 	//
@@ -1396,7 +1396,7 @@ func (a *API) handleGetSharing(w http.ResponseWriter, r *http.Request) {
 }
 
 func (a *API) handlePostSharing(w http.ResponseWriter, r *http.Request) {
-	// swagger:operation POST /api/v1/boards/{boardID}/sharing postSharing
+	// swagger:operation POST /boards/{boardID}/sharing postSharing
 	//
 	// Sets sharing information for a board
 	//
@@ -1491,7 +1491,7 @@ func (a *API) handlePostSharing(w http.ResponseWriter, r *http.Request) {
 // Team
 
 func (a *API) handleGetTeams(w http.ResponseWriter, r *http.Request) {
-	// swagger:operation GET /api/v1/teams getTeams
+	// swagger:operation GET /teams getTeams
 	//
 	// Returns information of all the teams
 	//
@@ -1534,7 +1534,7 @@ func (a *API) handleGetTeams(w http.ResponseWriter, r *http.Request) {
 }
 
 func (a *API) handleGetTeam(w http.ResponseWriter, r *http.Request) {
-	// swagger:operation GET /api/v1/teams/{teamID} getTeam
+	// swagger:operation GET /teams/{teamID} getTeam
 	//
 	// Returns information of the root team
 	//
@@ -1603,7 +1603,7 @@ func (a *API) handleGetTeam(w http.ResponseWriter, r *http.Request) {
 }
 
 func (a *API) handlePostTeamRegenerateSignupToken(w http.ResponseWriter, r *http.Request) {
-	// swagger:operation POST /api/v1/teams/{teamID}/regenerate_signup_token regenerateSignupToken
+	// swagger:operation POST /teams/{teamID}/regenerate_signup_token regenerateSignupToken
 	//
 	// Regenerates the signup token for the root team
 	//
@@ -1654,7 +1654,7 @@ func (a *API) handlePostTeamRegenerateSignupToken(w http.ResponseWriter, r *http
 // File upload
 
 func (a *API) handleServeFile(w http.ResponseWriter, r *http.Request) {
-	// swagger:operation GET "api/v1/files/teams/{teamID}/{boardID}/{filename} getFile
+	// swagger:operation GET "api/v2/files/teams/{teamID}/{boardID}/{filename} getFile
 	//
 	// Returns the contents of an uploaded file
 	//
@@ -1765,7 +1765,7 @@ func FileUploadResponseFromJSON(data io.Reader) (*FileUploadResponse, error) {
 }
 
 func (a *API) handleUploadFile(w http.ResponseWriter, r *http.Request) {
-	// swagger:operation POST /api/v1/teams/{teamID}/boards/{boardID}/files uploadFile
+	// swagger:operation POST /teams/{teamID}/boards/{boardID}/files uploadFile
 	//
 	// Upload a binary file, attached to a root block
 	//
@@ -1866,7 +1866,7 @@ func (a *API) handleUploadFile(w http.ResponseWriter, r *http.Request) {
 }
 
 func (a *API) handleGetTeamUsers(w http.ResponseWriter, r *http.Request) {
-	// swagger:operation GET /api/v1/teams/{teamID}/users getTeamUsers
+	// swagger:operation GET /teams/{teamID}/users getTeamUsers
 	//
 	// Returns team users
 	//
@@ -1931,7 +1931,7 @@ func (a *API) handleGetTeamUsers(w http.ResponseWriter, r *http.Request) {
 }
 
 func (a *API) handleGetBoards(w http.ResponseWriter, r *http.Request) {
-	// swagger:operation GET /api/v1/teams/{teamID}/boards getBoards
+	// swagger:operation GET /teams/{teamID}/boards getBoards
 	//
 	// Returns team boards
 	//
@@ -1996,7 +1996,7 @@ func (a *API) handleGetBoards(w http.ResponseWriter, r *http.Request) {
 }
 
 func (a *API) handleGetTemplates(w http.ResponseWriter, r *http.Request) {
-	// swagger:operation GET /api/v1/teams/{teamID}/templates getTemplates
+	// swagger:operation GET /teams/{teamID}/templates getTemplates
 	//
 	// Returns team templates
 	//
@@ -2072,7 +2072,7 @@ func (a *API) handleGetTemplates(w http.ResponseWriter, r *http.Request) {
 // subscriptions
 
 func (a *API) handleCreateSubscription(w http.ResponseWriter, r *http.Request) {
-	// swagger:operation POST /api/v1/subscriptions createSubscription
+	// swagger:operation POST /subscriptions createSubscription
 	//
 	// Creates a subscription to a block for a user. The user will receive change notifications for the block.
 	//
@@ -2159,7 +2159,7 @@ func (a *API) handleCreateSubscription(w http.ResponseWriter, r *http.Request) {
 }
 
 func (a *API) handleDeleteSubscription(w http.ResponseWriter, r *http.Request) {
-	// swagger:operation DELETE /api/v1/subscriptions/{blockID}/{subscriberID} deleteSubscription
+	// swagger:operation DELETE /subscriptions/{blockID}/{subscriberID} deleteSubscription
 	//
 	// Deletes a subscription a user has for a a block. The user will no longer receive change notifications for the block.
 	//
@@ -2221,7 +2221,7 @@ func (a *API) handleDeleteSubscription(w http.ResponseWriter, r *http.Request) {
 }
 
 func (a *API) handleGetSubscriptions(w http.ResponseWriter, r *http.Request) {
-	// swagger:operation GET /api/v1/subscriptions/{subscriberID} getSubscriptions
+	// swagger:operation GET /subscriptions/{subscriberID} getSubscriptions
 	//
 	// Gets subscriptions for a user.
 	//
@@ -2286,7 +2286,7 @@ func (a *API) handleGetSubscriptions(w http.ResponseWriter, r *http.Request) {
 }
 
 func (a *API) handleCreateBoard(w http.ResponseWriter, r *http.Request) {
-	// swagger:operation POST /api/v1/boards createBoard
+	// swagger:operation POST /boards createBoard
 	//
 	// Creates a new board
 	//
@@ -2375,7 +2375,7 @@ func (a *API) handleCreateBoard(w http.ResponseWriter, r *http.Request) {
 }
 
 func (a *API) handleOnboard(w http.ResponseWriter, r *http.Request) {
-	// swagger:operation POST /api/v1/team/{teamID}/onboard onboard
+	// swagger:operation POST /team/{teamID}/onboard onboard
 	//
 	// Onboards a user on Boards.
 	//
@@ -2427,7 +2427,7 @@ func (a *API) handleOnboard(w http.ResponseWriter, r *http.Request) {
 }
 
 func (a *API) handleGetBoard(w http.ResponseWriter, r *http.Request) {
-	// swagger:operation GET /api/v1/boards/{boardID} getBoard
+	// swagger:operation GET /boards/{boardID} getBoard
 	//
 	// Returns a board
 	//
@@ -2508,7 +2508,7 @@ func (a *API) handleGetBoard(w http.ResponseWriter, r *http.Request) {
 }
 
 func (a *API) handlePatchBoard(w http.ResponseWriter, r *http.Request) {
-	// swagger:operation PATCH /api/v1/boards/{boardID} patchBoard
+	// swagger:operation PATCH /boards/{boardID} patchBoard
 	//
 	// Partially updates a board
 	//
@@ -2613,7 +2613,7 @@ func (a *API) handlePatchBoard(w http.ResponseWriter, r *http.Request) {
 }
 
 func (a *API) handleDeleteBoard(w http.ResponseWriter, r *http.Request) {
-	// swagger:operation DELETE /api/v1/boards/{boardID} deleteBoard
+	// swagger:operation DELETE /boards/{boardID} deleteBoard
 	//
 	// Removes a board
 	//
@@ -2673,7 +2673,7 @@ func (a *API) handleDeleteBoard(w http.ResponseWriter, r *http.Request) {
 }
 
 func (a *API) handleDuplicateBoard(w http.ResponseWriter, r *http.Request) {
-	// swagger:operation POST /api/v1/boards/{boardID}/duplicate duplicateBoard
+	// swagger:operation POST /boards/{boardID}/duplicate duplicateBoard
 	//
 	// Returns the new created board and all the blocks
 	//
@@ -2765,7 +2765,7 @@ func (a *API) handleDuplicateBoard(w http.ResponseWriter, r *http.Request) {
 }
 
 func (a *API) handleDuplicateBlock(w http.ResponseWriter, r *http.Request) {
-	// swagger:operation POST /api/v1/boards/{boardID}/blocks/{blockID}/duplicate duplicateBlock
+	// swagger:operation POST /boards/{boardID}/blocks/{blockID}/duplicate duplicateBlock
 	//
 	// Returns the new created blocks
 	//
@@ -2868,7 +2868,7 @@ func (a *API) handleDuplicateBlock(w http.ResponseWriter, r *http.Request) {
 }
 
 func (a *API) handleGetBoardMetadata(w http.ResponseWriter, r *http.Request) {
-	// swagger:operation GET /api/v1/boards/{boardID}/metadata getBoardMetadata
+	// swagger:operation GET /boards/{boardID}/metadata getBoardMetadata
 	//
 	// Returns a board's metadata
 	//
@@ -2943,7 +2943,7 @@ func (a *API) handleGetBoardMetadata(w http.ResponseWriter, r *http.Request) {
 }
 
 func (a *API) handleSearchBoards(w http.ResponseWriter, r *http.Request) {
-	// swagger:operation GET /api/v1/teams/{teamID}/boards/search searchBoards
+	// swagger:operation GET /teams/{teamID}/boards/search searchBoards
 	//
 	// Returns the boards that match with a search term
 	//
@@ -3019,7 +3019,7 @@ func (a *API) handleSearchBoards(w http.ResponseWriter, r *http.Request) {
 }
 
 func (a *API) handleGetMembersForBoard(w http.ResponseWriter, r *http.Request) {
-	// swagger:operation GET /api/v1/boards/{boardID}/members getMembersForBoard
+	// swagger:operation GET /boards/{boardID}/members getMembersForBoard
 	//
 	// Returns the members of the board
 	//
@@ -3453,7 +3453,7 @@ func (a *API) handleUpdateMember(w http.ResponseWriter, r *http.Request) {
 }
 
 func (a *API) handleDeleteMember(w http.ResponseWriter, r *http.Request) {
-	// swagger:operation DELETE /api/v1/boards/{boardID}/members/{userID} deleteMember
+	// swagger:operation DELETE /boards/{boardID}/members/{userID} deleteMember
 	//
 	// Deletes a member from a board
 	//
@@ -3529,7 +3529,7 @@ func (a *API) handleDeleteMember(w http.ResponseWriter, r *http.Request) {
 }
 
 func (a *API) handleCreateBoardsAndBlocks(w http.ResponseWriter, r *http.Request) {
-	// swagger:operation POST /api/v1/boards-and-blocks insertBoardsAndBlocks
+	// swagger:operation POST /boards-and-blocks insertBoardsAndBlocks
 	//
 	// Creates new boards and blocks
 	//
@@ -3673,7 +3673,7 @@ func (a *API) handleCreateBoardsAndBlocks(w http.ResponseWriter, r *http.Request
 }
 
 func (a *API) handlePatchBoardsAndBlocks(w http.ResponseWriter, r *http.Request) {
-	// swagger:operation PATCH /api/v1/boards-and-blocks patchBoardsAndBlocks
+	// swagger:operation PATCH /boards-and-blocks patchBoardsAndBlocks
 	//
 	// Patches a set of related boards and blocks
 	//
@@ -3811,7 +3811,7 @@ func (a *API) handlePatchBoardsAndBlocks(w http.ResponseWriter, r *http.Request)
 }
 
 func (a *API) handleDeleteBoardsAndBlocks(w http.ResponseWriter, r *http.Request) {
-	// swagger:operation DELETE /api/v1/boards-and-blocks deleteBoardsAndBlocks
+	// swagger:operation DELETE /boards-and-blocks deleteBoardsAndBlocks
 	//
 	// Deletes boards and blocks
 	//

--- a/server/api/archive.go
+++ b/server/api/archive.go
@@ -17,7 +17,7 @@ const (
 )
 
 func (a *API) handleArchiveExportBoard(w http.ResponseWriter, r *http.Request) {
-	// swagger:operation GET /api/v1/boards/{boardID}/archive/export archiveExportBoard
+	// swagger:operation GET /boards/{boardID}/archive/export archiveExportBoard
 	//
 	// Exports an archive of all blocks for one boards.
 	//
@@ -85,7 +85,7 @@ func (a *API) handleArchiveExportBoard(w http.ResponseWriter, r *http.Request) {
 }
 
 func (a *API) handleArchiveExportTeam(w http.ResponseWriter, r *http.Request) {
-	// swagger:operation GET /api/v1/teams/{teamID}/archive/export archiveExportTeam
+	// swagger:operation GET /teams/{teamID}/archive/export archiveExportTeam
 	//
 	// Exports an archive of all blocks for all the boards in a team.
 	//
@@ -159,7 +159,7 @@ func (a *API) handleArchiveExportTeam(w http.ResponseWriter, r *http.Request) {
 }
 
 func (a *API) handleArchiveImport(w http.ResponseWriter, r *http.Request) {
-	// swagger:operation POST /api/v1/teams/{teamID}/archive/import archiveImport
+	// swagger:operation POST /teams/{teamID}/archive/import archiveImport
 	//
 	// Import an archive of boards.
 	//

--- a/server/api/auth.go
+++ b/server/api/auth.go
@@ -139,7 +139,7 @@ func isValidPassword(password string) error {
 }
 
 func (a *API) handleLogin(w http.ResponseWriter, r *http.Request) {
-	// swagger:operation POST /api/v1/login login
+	// swagger:operation POST /login login
 	//
 	// Login user
 	//
@@ -220,7 +220,7 @@ func (a *API) handleLogin(w http.ResponseWriter, r *http.Request) {
 }
 
 func (a *API) handleLogout(w http.ResponseWriter, r *http.Request) {
-	// swagger:operation POST /api/v1/logout logout
+	// swagger:operation POST /logout logout
 	//
 	// Logout user
 	//
@@ -271,7 +271,7 @@ func (a *API) handleLogout(w http.ResponseWriter, r *http.Request) {
 }
 
 func (a *API) handleRegister(w http.ResponseWriter, r *http.Request) {
-	// swagger:operation POST /api/v1/register register
+	// swagger:operation POST /register register
 	//
 	// Register new user
 	//
@@ -369,7 +369,7 @@ func (a *API) handleRegister(w http.ResponseWriter, r *http.Request) {
 }
 
 func (a *API) handleChangePassword(w http.ResponseWriter, r *http.Request) {
-	// swagger:operation POST /api/v1/users/{userID}/changepassword changePassword
+	// swagger:operation POST /users/{userID}/changepassword changePassword
 	//
 	// Change a user's password
 	//

--- a/server/client/client.go
+++ b/server/client/client.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	APIURLSuffix = "/api/v1"
+	APIURLSuffix = "/api/v2"
 )
 
 type RequestReaderError struct {

--- a/server/main/doc.go
+++ b/server/main/doc.go
@@ -4,7 +4,7 @@
 //
 //     Schemes: http, https
 //     Host: localhost
-//     BasePath: /api/v1
+//     BasePath: /api/v2
 //     Version: 1.0.0
 //     License: Custom https://github.com/mattermost/focalboard/blob/main/LICENSE.txt
 //     Contact: Focalboard<api@focalboard.com> https://www.focalboard.com

--- a/server/swagger/README.md
+++ b/server/swagger/README.md
@@ -34,7 +34,7 @@ Refer to the [Mattermost API documentation here](https://api.mattermost.com/#tag
 Pass this token as a bearer token to the Boards APIs, e.g.
 
 ```
-curl -i -H "X-Requested-With: XMLHttpRequest" -H 'Authorization: Bearer abcdefghijklmnopqrstuvwxyz' https://community.mattermost.com/plugins/focalboard/api/v1/workspaces
+curl -i -H "X-Requested-With: XMLHttpRequest" -H 'Authorization: Bearer abcdefghijklmnopqrstuvwxyz' https://community.mattermost.com/plugins/focalboard/api/v2/workspaces
 ```
 
 Note that the `X-Requested-With: XMLHttpRequest` header is required to pass the CSRF check.

--- a/server/swagger/docs/html/index.html
+++ b/server/swagger/docs/html/index.html
@@ -847,9 +847,14 @@ ul.nav-tabs {
     // Script section to load models into a JS Var
     var defs = {}
     defs["Block"] = {
-  "required" : [ "createAt", "createdBy", "id", "modifiedBy", "rootId", "schema", "type", "updateAt", "workspaceId" ],
+  "required" : [ "boardId", "createAt", "createdBy", "id", "modifiedBy", "schema", "type", "updateAt" ],
   "type" : "object",
   "properties" : {
+    "boardId" : {
+      "type" : "string",
+      "description" : "The board id that the block belongs to",
+      "x-go-name" : "BoardID"
+    },
     "createAt" : {
       "type" : "integer",
       "description" : "The creation time",
@@ -891,11 +896,6 @@ ul.nav-tabs {
       "description" : "The id for this block's parent block. Empty for root blocks",
       "x-go-name" : "ParentID"
     },
-    "rootId" : {
-      "type" : "string",
-      "description" : "The id for this block's root block",
-      "x-go-name" : "RootID"
-    },
     "schema" : {
       "type" : "integer",
       "description" : "The schema version of this block",
@@ -915,11 +915,6 @@ ul.nav-tabs {
       "description" : "The last modified time",
       "format" : "int64",
       "x-go-name" : "UpdateAt"
-    },
-    "workspaceId" : {
-      "type" : "string",
-      "description" : "The workspace id that the block belongs to",
-      "x-go-name" : "WorkspaceID"
     }
   },
   "description" : "Block is the basic data unit",
@@ -928,6 +923,11 @@ ul.nav-tabs {
     defs["BlockPatch"] = {
   "type" : "object",
   "properties" : {
+    "boardId" : {
+      "type" : "string",
+      "description" : "The board id that the block belongs to",
+      "x-go-name" : "BoardID"
+    },
     "deletedFields" : {
       "type" : "array",
       "description" : "The block removed fields",
@@ -940,11 +940,6 @@ ul.nav-tabs {
       "type" : "string",
       "description" : "The id for this block's parent block. Empty for root blocks",
       "x-go-name" : "ParentID"
-    },
-    "rootId" : {
-      "type" : "string",
-      "description" : "The id for this block's root block",
-      "x-go-name" : "RootID"
     },
     "schema" : {
       "type" : "integer",
@@ -996,6 +991,335 @@ ul.nav-tabs {
   "description" : "BlockPatchBatch is a batch of IDs and patches for modify blocks",
   "x-go-package" : "github.com/mattermost/focalboard/server/model"
 };
+    defs["Board"] = {
+  "required" : [ "createAt", "createdBy", "id", "modifiedBy", "teamId", "type", "updateAt" ],
+  "type" : "object",
+  "properties" : {
+    "cardProperties" : {
+      "type" : "array",
+      "description" : "The properties of the board cards",
+      "items" : {
+        "type" : "object",
+        "additionalProperties" : {
+          "type" : "object",
+          "properties" : { }
+        }
+      },
+      "x-go-name" : "CardProperties"
+    },
+    "channelId" : {
+      "type" : "string",
+      "description" : "The ID of the channel that the board was created from",
+      "x-go-name" : "ChannelID"
+    },
+    "columnCalculations" : {
+      "type" : "object",
+      "additionalProperties" : {
+        "type" : "object",
+        "properties" : { }
+      },
+      "description" : "The calculations on the board's cards",
+      "x-go-name" : "ColumnCalculations"
+    },
+    "createAt" : {
+      "type" : "integer",
+      "description" : "The creation time",
+      "format" : "int64",
+      "x-go-name" : "CreateAt"
+    },
+    "createdBy" : {
+      "type" : "string",
+      "description" : "The ID of the user that created the board",
+      "x-go-name" : "CreatedBy"
+    },
+    "deleteAt" : {
+      "type" : "integer",
+      "description" : "The deleted time. Set to indicate this block is deleted",
+      "format" : "int64",
+      "x-go-name" : "DeleteAt"
+    },
+    "description" : {
+      "type" : "string",
+      "description" : "The description of the board",
+      "x-go-name" : "Description"
+    },
+    "icon" : {
+      "type" : "string",
+      "description" : "The icon of the board",
+      "x-go-name" : "Icon"
+    },
+    "id" : {
+      "type" : "string",
+      "description" : "The ID for the board",
+      "x-go-name" : "ID"
+    },
+    "isTemplate" : {
+      "type" : "boolean",
+      "description" : "Marks the template boards",
+      "x-go-name" : "IsTemplate"
+    },
+    "modifiedBy" : {
+      "type" : "string",
+      "description" : "The ID of the last user that updated the board",
+      "x-go-name" : "ModifiedBy"
+    },
+    "properties" : {
+      "type" : "object",
+      "additionalProperties" : {
+        "type" : "object",
+        "properties" : { }
+      },
+      "description" : "The properties of the board",
+      "x-go-name" : "Properties"
+    },
+    "showDescription" : {
+      "type" : "boolean",
+      "description" : "Indicates if the board shows the description on the interface",
+      "x-go-name" : "ShowDescription"
+    },
+    "teamId" : {
+      "type" : "string",
+      "description" : "The ID of the team that the board belongs to",
+      "x-go-name" : "TeamID"
+    },
+    "templateVersion" : {
+      "type" : "integer",
+      "description" : "Marks the template boards",
+      "format" : "int64",
+      "x-go-name" : "TemplateVersion"
+    },
+    "title" : {
+      "type" : "string",
+      "description" : "The title of the board",
+      "x-go-name" : "Title"
+    },
+    "type" : {
+      "$ref" : "#/components/schemas/BoardType"
+    },
+    "updateAt" : {
+      "type" : "integer",
+      "description" : "The last modified time",
+      "format" : "int64",
+      "x-go-name" : "UpdateAt"
+    }
+  },
+  "description" : "Board groups a set of blocks and its layout",
+  "x-go-package" : "github.com/mattermost/focalboard/server/model"
+};
+    defs["BoardMember"] = {
+  "required" : [ "boardId", "schemeAdmin", "schemeCommenter", "schemeEditor", "schemeViewer", "userId" ],
+  "type" : "object",
+  "properties" : {
+    "boardId" : {
+      "type" : "string",
+      "description" : "The ID of the board",
+      "x-go-name" : "BoardID"
+    },
+    "roles" : {
+      "type" : "string",
+      "description" : "The independent roles of the user on the board",
+      "x-go-name" : "Roles"
+    },
+    "schemeAdmin" : {
+      "type" : "boolean",
+      "description" : "Marks the user as an admin of the board",
+      "x-go-name" : "SchemeAdmin"
+    },
+    "schemeCommenter" : {
+      "type" : "boolean",
+      "description" : "Marks the user as an commenter of the board",
+      "x-go-name" : "SchemeCommenter"
+    },
+    "schemeEditor" : {
+      "type" : "boolean",
+      "description" : "Marks the user as an editor of the board",
+      "x-go-name" : "SchemeEditor"
+    },
+    "schemeViewer" : {
+      "type" : "boolean",
+      "description" : "Marks the user as an viewer of the board",
+      "x-go-name" : "SchemeViewer"
+    },
+    "userId" : {
+      "type" : "string",
+      "description" : "The ID of the user",
+      "x-go-name" : "UserID"
+    }
+  },
+  "description" : "BoardMember stores the information of the membership of a user on a board",
+  "x-go-package" : "github.com/mattermost/focalboard/server/model"
+};
+    defs["BoardMemberHistoryEntry"] = {
+  "required" : [ "boardId", "insertAt", "userId" ],
+  "type" : "object",
+  "properties" : {
+    "action" : {
+      "type" : "string",
+      "description" : "The action that added this history entry (created or deleted)",
+      "x-go-name" : "Action"
+    },
+    "boardId" : {
+      "type" : "string",
+      "description" : "The ID of the board",
+      "x-go-name" : "BoardID"
+    },
+    "insertAt" : {
+      "type" : "integer",
+      "description" : "The insertion time",
+      "format" : "int64",
+      "x-go-name" : "InsertAt"
+    },
+    "userId" : {
+      "type" : "string",
+      "description" : "The ID of the user",
+      "x-go-name" : "UserID"
+    }
+  },
+  "description" : "BoardMemberHistoryEntry stores the information of the membership of a user on a board",
+  "x-go-package" : "github.com/mattermost/focalboard/server/model"
+};
+    defs["BoardMetadata"] = {
+  "required" : [ "boardId", "createdBy", "descendantFirstUpdateAt", "descendantLastUpdateAt", "lastModifiedBy" ],
+  "type" : "object",
+  "properties" : {
+    "boardId" : {
+      "type" : "string",
+      "description" : "The ID for the board",
+      "x-go-name" : "BoardID"
+    },
+    "createdBy" : {
+      "type" : "string",
+      "description" : "The ID of the user that created the board",
+      "x-go-name" : "CreatedBy"
+    },
+    "descendantFirstUpdateAt" : {
+      "type" : "integer",
+      "description" : "The earliest time a descendant of this board was added, modified, or deleted",
+      "format" : "int64",
+      "x-go-name" : "DescendantFirstUpdateAt"
+    },
+    "descendantLastUpdateAt" : {
+      "type" : "integer",
+      "description" : "The most recent time a descendant of this board was added, modified, or deleted",
+      "format" : "int64",
+      "x-go-name" : "DescendantLastUpdateAt"
+    },
+    "lastModifiedBy" : {
+      "type" : "string",
+      "description" : "The ID of the user that last modified the most recently modified descendant",
+      "x-go-name" : "LastModifiedBy"
+    }
+  },
+  "description" : "BoardMetadata contains metadata for a Board",
+  "x-go-package" : "github.com/mattermost/focalboard/server/model"
+};
+    defs["BoardPatch"] = {
+  "type" : "object",
+  "properties" : {
+    "deletedCardProperties" : {
+      "type" : "array",
+      "description" : "The board removed card properties",
+      "items" : {
+        "type" : "string"
+      },
+      "x-go-name" : "DeletedCardProperties"
+    },
+    "deletedColumnCalculations" : {
+      "type" : "array",
+      "description" : "The board deleted column calculations",
+      "items" : {
+        "type" : "string"
+      },
+      "x-go-name" : "DeletedColumnCalculations"
+    },
+    "deletedProperties" : {
+      "type" : "array",
+      "description" : "The board removed properties",
+      "items" : {
+        "type" : "string"
+      },
+      "x-go-name" : "DeletedProperties"
+    },
+    "description" : {
+      "type" : "string",
+      "description" : "The description of the board",
+      "x-go-name" : "Description"
+    },
+    "icon" : {
+      "type" : "string",
+      "description" : "The icon of the board",
+      "x-go-name" : "Icon"
+    },
+    "showDescription" : {
+      "type" : "boolean",
+      "description" : "Indicates if the board shows the description on the interface",
+      "x-go-name" : "ShowDescription"
+    },
+    "title" : {
+      "type" : "string",
+      "description" : "The title of the board",
+      "x-go-name" : "Title"
+    },
+    "type" : {
+      "$ref" : "#/components/schemas/BoardType"
+    },
+    "updatedCardProperties" : {
+      "type" : "array",
+      "description" : "The board updated card properties",
+      "items" : {
+        "type" : "object",
+        "additionalProperties" : {
+          "type" : "object",
+          "properties" : { }
+        }
+      },
+      "x-go-name" : "UpdatedCardProperties"
+    },
+    "updatedColumnCalculations" : {
+      "type" : "object",
+      "additionalProperties" : {
+        "type" : "object",
+        "properties" : { }
+      },
+      "description" : "The board updated column calculations",
+      "x-go-name" : "UpdatedColumnCalculations"
+    },
+    "updatedProperties" : {
+      "type" : "object",
+      "additionalProperties" : {
+        "type" : "object",
+        "properties" : { }
+      },
+      "description" : "The board updated properties",
+      "x-go-name" : "UpdatedProperties"
+    }
+  },
+  "description" : "BoardPatch is a patch for modify boards",
+  "x-go-package" : "github.com/mattermost/focalboard/server/model"
+};
+    defs["BoardsAndBlocks"] = {
+  "type" : "object",
+  "properties" : {
+    "blocks" : {
+      "type" : "array",
+      "description" : "The blocks",
+      "items" : {
+        "$ref" : "#/components/schemas/Block"
+      },
+      "x-go-name" : "Blocks"
+    },
+    "boards" : {
+      "type" : "array",
+      "description" : "The boards",
+      "items" : {
+        "$ref" : "#/components/schemas/Board"
+      },
+      "x-go-name" : "Boards"
+    }
+  },
+  "description" : "BoardsAndBlocks is used to operate over boards and blocks at the\nsame time",
+  "x-go-package" : "github.com/mattermost/focalboard/server/model"
+};
     defs["ChangePasswordRequest"] = {
   "required" : [ "newPassword", "oldPassword" ],
   "type" : "object",
@@ -1013,6 +1337,30 @@ ul.nav-tabs {
   },
   "description" : "ChangePasswordRequest is a user password change request",
   "x-go-package" : "github.com/mattermost/focalboard/server/api"
+};
+    defs["DeleteBoardsAndBlocks"] = {
+  "required" : [ "blocks", "boards" ],
+  "type" : "object",
+  "properties" : {
+    "blocks" : {
+      "type" : "array",
+      "description" : "The blocks",
+      "items" : {
+        "type" : "string"
+      },
+      "x-go-name" : "Blocks"
+    },
+    "boards" : {
+      "type" : "array",
+      "description" : "The boards",
+      "items" : {
+        "type" : "string"
+      },
+      "x-go-name" : "Boards"
+    }
+  },
+  "description" : "DeleteBoardsAndBlocks is used to list the boards and blocks to\ndelete on a request",
+  "x-go-package" : "github.com/mattermost/focalboard/server/model"
 };
     defs["ErrorResponse"] = {
   "type" : "object",
@@ -1087,7 +1435,7 @@ ul.nav-tabs {
   "x-go-package" : "github.com/mattermost/focalboard/server/api"
 };
     defs["NotificationHint"] = {
-  "required" : [ "block_id", "block_type", "create_at", "notify_at", "workspace_id" ],
+  "required" : [ "block_id", "block_type", "create_at", "notify_at" ],
   "type" : "object",
   "properties" : {
     "block_id" : {
@@ -1114,14 +1462,49 @@ ul.nav-tabs {
       "description" : "NotifyAt is the timestamp this notification should be scheduled",
       "format" : "int64",
       "x-go-name" : "NotifyAt"
-    },
-    "workspace_id" : {
-      "type" : "string",
-      "description" : "WorkspaceID is id of workspace the block belongs to",
-      "x-go-name" : "WorkspaceID"
     }
   },
   "description" : "NotificationHint provides a hint that a block has been modified and has subscribers that\nshould be notified.",
+  "x-go-package" : "github.com/mattermost/focalboard/server/model"
+};
+    defs["PatchBoardsAndBlocks"] = {
+  "required" : [ "blockIDs", "blockPatches", "boardIDs", "boardPatches" ],
+  "type" : "object",
+  "properties" : {
+    "blockIDs" : {
+      "type" : "array",
+      "description" : "The block IDs to patch",
+      "items" : {
+        "type" : "string"
+      },
+      "x-go-name" : "BlockIDs"
+    },
+    "blockPatches" : {
+      "type" : "array",
+      "description" : "The block patches",
+      "items" : {
+        "$ref" : "#/components/schemas/BlockPatch"
+      },
+      "x-go-name" : "BlockPatches"
+    },
+    "boardIDs" : {
+      "type" : "array",
+      "description" : "The board IDs to patch",
+      "items" : {
+        "type" : "string"
+      },
+      "x-go-name" : "BoardIDs"
+    },
+    "boardPatches" : {
+      "type" : "array",
+      "description" : "The board patches",
+      "items" : {
+        "$ref" : "#/components/schemas/BoardPatch"
+      },
+      "x-go-name" : "BoardPatches"
+    }
+  },
+  "description" : "PatchBoardsAndBlocks is used to patch multiple boards and blocks on\na single request",
   "x-go-package" : "github.com/mattermost/focalboard/server/model"
 };
     defs["RegisterRequest"] = {
@@ -1210,7 +1593,7 @@ ul.nav-tabs {
 };
     defs["Subscription"] = {
   "title" : "Subscription is a subscription to a board, card, etc, for a user or channel.",
-  "required" : [ "blockId", "blockType", "createAt", "deleteAt", "notifiedAt", "subscriberId", "subscriberType", "workspaceId" ],
+  "required" : [ "blockId", "blockType", "createAt", "deleteAt", "notifiedAt", "subscriberId", "subscriberType" ],
   "type" : "object",
   "properties" : {
     "blockId" : {
@@ -1246,17 +1629,55 @@ ul.nav-tabs {
     },
     "subscriberType" : {
       "$ref" : "#/components/schemas/SubscriberType"
-    },
-    "workspaceId" : {
-      "type" : "string",
-      "description" : "WorkspaceID is id of the workspace the block belongs to",
-      "x-go-name" : "WorkspaceID"
     }
   },
   "x-go-package" : "github.com/mattermost/focalboard/server/model"
 };
+    defs["Team"] = {
+  "required" : [ "id", "modifiedBy", "signupToken", "updateAt" ],
+  "type" : "object",
+  "properties" : {
+    "id" : {
+      "type" : "string",
+      "description" : "ID of the team",
+      "x-go-name" : "ID"
+    },
+    "modifiedBy" : {
+      "type" : "string",
+      "description" : "ID of user who last modified this",
+      "x-go-name" : "ModifiedBy"
+    },
+    "settings" : {
+      "type" : "object",
+      "additionalProperties" : {
+        "type" : "object",
+        "properties" : { }
+      },
+      "description" : "Team settings",
+      "x-go-name" : "Settings"
+    },
+    "signupToken" : {
+      "type" : "string",
+      "description" : "Token required to register new users",
+      "x-go-name" : "SignupToken"
+    },
+    "title" : {
+      "type" : "string",
+      "description" : "Title of the team",
+      "x-go-name" : "Title"
+    },
+    "updateAt" : {
+      "type" : "integer",
+      "description" : "Updated time",
+      "format" : "int64",
+      "x-go-name" : "UpdateAt"
+    }
+  },
+  "description" : "Team is information global to a team",
+  "x-go-package" : "github.com/mattermost/focalboard/server/model"
+};
     defs["User"] = {
-  "required" : [ "create_at", "delete_at", "id", "is_bot", "props", "update_at", "username" ],
+  "required" : [ "create_at", "delete_at", "id", "is_bot", "is_guest", "props", "update_at", "username" ],
   "type" : "object",
   "properties" : {
     "create_at" : {
@@ -1280,6 +1701,11 @@ ul.nav-tabs {
       "type" : "boolean",
       "description" : "If the user is a bot or not",
       "x-go-name" : "IsBot"
+    },
+    "is_guest" : {
+      "type" : "boolean",
+      "description" : "If the user is a guest or not",
+      "x-go-name" : "IsGuest"
     },
     "props" : {
       "type" : "object",
@@ -1305,71 +1731,27 @@ ul.nav-tabs {
   "description" : "User is a user",
   "x-go-package" : "github.com/mattermost/focalboard/server/model"
 };
-    defs["UserWorkspace"] = {
-  "required" : [ "id" ],
+    defs["UserPropPatch"] = {
   "type" : "object",
   "properties" : {
-    "boardCount" : {
-      "type" : "integer",
-      "description" : "Number of boards in the workspace",
-      "format" : "int64",
-      "x-go-name" : "BoardCount"
+    "deletedFields" : {
+      "type" : "array",
+      "description" : "The user prop removed fields",
+      "items" : {
+        "type" : "string"
+      },
+      "x-go-name" : "DeletedFields"
     },
-    "id" : {
-      "type" : "string",
-      "description" : "ID of the workspace",
-      "x-go-name" : "ID"
-    },
-    "title" : {
-      "type" : "string",
-      "description" : "Title of the workspace",
-      "x-go-name" : "Title"
-    }
-  },
-  "description" : "UserWorkspace is a summary of a single association between\na user and a workspace",
-  "x-go-package" : "github.com/mattermost/focalboard/server/model"
-};
-    defs["Workspace"] = {
-  "required" : [ "id", "modifiedBy", "signupToken", "updateAt" ],
-  "type" : "object",
-  "properties" : {
-    "id" : {
-      "type" : "string",
-      "description" : "ID of the workspace",
-      "x-go-name" : "ID"
-    },
-    "modifiedBy" : {
-      "type" : "string",
-      "description" : "ID of user who last modified this",
-      "x-go-name" : "ModifiedBy"
-    },
-    "settings" : {
+    "updatedFields" : {
       "type" : "object",
       "additionalProperties" : {
-        "type" : "object",
-        "properties" : { }
+        "type" : "string"
       },
-      "description" : "Workspace settings",
-      "x-go-name" : "Settings"
-    },
-    "signupToken" : {
-      "type" : "string",
-      "description" : "Token required to register new users",
-      "x-go-name" : "SignupToken"
-    },
-    "title" : {
-      "type" : "string",
-      "description" : "Title of the workspace",
-      "x-go-name" : "Title"
-    },
-    "updateAt" : {
-      "type" : "integer",
-      "description" : "Updated time",
-      "format" : "int64",
-      "x-go-name" : "UpdateAt"
+      "description" : "The user prop updated fields",
+      "x-go-name" : "UpdatedFields"
     }
   },
-  "description" : "Workspace is information global to a workspace",
+  "description" : "UserPropPatch is a user property patch",
   "x-go-package" : "github.com/mattermost/focalboard/server/model"
 };
 
@@ -1391,8 +1773,23 @@ ul.nav-tabs {
             <li class="nav-fixed nav-header active" data-group="_"><a href="#api-_">API Summary</a></li>
 
                   <li class="nav-header" data-group="Default"><a href="#api-Default">API Methods - Default</a></li>
+                    <li data-group="Default" data-name="addMember" class="">
+                      <a href="#api-Default-addMember">addMember</a>
+                    </li>
+                    <li data-group="Default" data-name="archiveExportBoard" class="">
+                      <a href="#api-Default-archiveExportBoard">archiveExportBoard</a>
+                    </li>
+                    <li data-group="Default" data-name="archiveExportTeam" class="">
+                      <a href="#api-Default-archiveExportTeam">archiveExportTeam</a>
+                    </li>
+                    <li data-group="Default" data-name="archiveImport" class="">
+                      <a href="#api-Default-archiveImport">archiveImport</a>
+                    </li>
                     <li data-group="Default" data-name="changePassword" class="">
                       <a href="#api-Default-changePassword">changePassword</a>
+                    </li>
+                    <li data-group="Default" data-name="createBoard" class="">
+                      <a href="#api-Default-createBoard">createBoard</a>
                     </li>
                     <li data-group="Default" data-name="createSubscription" class="">
                       <a href="#api-Default-createSubscription">createSubscription</a>
@@ -1400,41 +1797,74 @@ ul.nav-tabs {
                     <li data-group="Default" data-name="deleteBlock" class="">
                       <a href="#api-Default-deleteBlock">deleteBlock</a>
                     </li>
+                    <li data-group="Default" data-name="deleteBoard" class="">
+                      <a href="#api-Default-deleteBoard">deleteBoard</a>
+                    </li>
+                    <li data-group="Default" data-name="deleteBoardsAndBlocks" class="">
+                      <a href="#api-Default-deleteBoardsAndBlocks">deleteBoardsAndBlocks</a>
+                    </li>
+                    <li data-group="Default" data-name="deleteMember" class="">
+                      <a href="#api-Default-deleteMember">deleteMember</a>
+                    </li>
                     <li data-group="Default" data-name="deleteSubscription" class="">
                       <a href="#api-Default-deleteSubscription">deleteSubscription</a>
                     </li>
-                    <li data-group="Default" data-name="exportBlocks" class="">
-                      <a href="#api-Default-exportBlocks">exportBlocks</a>
+                    <li data-group="Default" data-name="duplicateBlock" class="">
+                      <a href="#api-Default-duplicateBlock">duplicateBlock</a>
+                    </li>
+                    <li data-group="Default" data-name="duplicateBoard" class="">
+                      <a href="#api-Default-duplicateBoard">duplicateBoard</a>
                     </li>
                     <li data-group="Default" data-name="getBlocks" class="">
                       <a href="#api-Default-getBlocks">getBlocks</a>
                     </li>
-                    <li data-group="Default" data-name="getFile" class="">
-                      <a href="#api-Default-getFile">getFile</a>
+                    <li data-group="Default" data-name="getBoard" class="">
+                      <a href="#api-Default-getBoard">getBoard</a>
+                    </li>
+                    <li data-group="Default" data-name="getBoardMetadata" class="">
+                      <a href="#api-Default-getBoardMetadata">getBoardMetadata</a>
+                    </li>
+                    <li data-group="Default" data-name="getBoards" class="">
+                      <a href="#api-Default-getBoards">getBoards</a>
                     </li>
                     <li data-group="Default" data-name="getMe" class="">
                       <a href="#api-Default-getMe">getMe</a>
                     </li>
+                    <li data-group="Default" data-name="getMembersForBoard" class="">
+                      <a href="#api-Default-getMembersForBoard">getMembersForBoard</a>
+                    </li>
+                    <li data-group="Default" data-name="getMyMemberships" class="">
+                      <a href="#api-Default-getMyMemberships">getMyMemberships</a>
+                    </li>
                     <li data-group="Default" data-name="getSharing" class="">
                       <a href="#api-Default-getSharing">getSharing</a>
-                    </li>
-                    <li data-group="Default" data-name="getSubTree" class="">
-                      <a href="#api-Default-getSubTree">getSubTree</a>
                     </li>
                     <li data-group="Default" data-name="getSubscriptions" class="">
                       <a href="#api-Default-getSubscriptions">getSubscriptions</a>
                     </li>
+                    <li data-group="Default" data-name="getTeam" class="">
+                      <a href="#api-Default-getTeam">getTeam</a>
+                    </li>
+                    <li data-group="Default" data-name="getTeamUsers" class="">
+                      <a href="#api-Default-getTeamUsers">getTeamUsers</a>
+                    </li>
+                    <li data-group="Default" data-name="getTeams" class="">
+                      <a href="#api-Default-getTeams">getTeams</a>
+                    </li>
+                    <li data-group="Default" data-name="getTemplates" class="">
+                      <a href="#api-Default-getTemplates">getTemplates</a>
+                    </li>
                     <li data-group="Default" data-name="getUser" class="">
                       <a href="#api-Default-getUser">getUser</a>
                     </li>
-                    <li data-group="Default" data-name="getWorkspace" class="">
-                      <a href="#api-Default-getWorkspace">getWorkspace</a>
+                    <li data-group="Default" data-name="insertBoardsAndBlocks" class="">
+                      <a href="#api-Default-insertBoardsAndBlocks">insertBoardsAndBlocks</a>
                     </li>
-                    <li data-group="Default" data-name="getWorkspaceUsers" class="">
-                      <a href="#api-Default-getWorkspaceUsers">getWorkspaceUsers</a>
+                    <li data-group="Default" data-name="joinBoard" class="">
+                      <a href="#api-Default-joinBoard">joinBoard</a>
                     </li>
-                    <li data-group="Default" data-name="importBlocks" class="">
-                      <a href="#api-Default-importBlocks">importBlocks</a>
+                    <li data-group="Default" data-name="leaveBoard" class="">
+                      <a href="#api-Default-leaveBoard">leaveBoard</a>
                     </li>
                     <li data-group="Default" data-name="login" class="">
                       <a href="#api-Default-login">login</a>
@@ -1442,11 +1872,20 @@ ul.nav-tabs {
                     <li data-group="Default" data-name="logout" class="">
                       <a href="#api-Default-logout">logout</a>
                     </li>
+                    <li data-group="Default" data-name="onboard" class="">
+                      <a href="#api-Default-onboard">onboard</a>
+                    </li>
                     <li data-group="Default" data-name="patchBlock" class="">
                       <a href="#api-Default-patchBlock">patchBlock</a>
                     </li>
                     <li data-group="Default" data-name="patchBlocks" class="">
                       <a href="#api-Default-patchBlocks">patchBlocks</a>
+                    </li>
+                    <li data-group="Default" data-name="patchBoard" class="">
+                      <a href="#api-Default-patchBoard">patchBoard</a>
+                    </li>
+                    <li data-group="Default" data-name="patchBoardsAndBlocks" class="">
+                      <a href="#api-Default-patchBoardsAndBlocks">patchBoardsAndBlocks</a>
                     </li>
                     <li data-group="Default" data-name="postSharing" class="">
                       <a href="#api-Default-postSharing">postSharing</a>
@@ -1457,8 +1896,23 @@ ul.nav-tabs {
                     <li data-group="Default" data-name="register" class="">
                       <a href="#api-Default-register">register</a>
                     </li>
+                    <li data-group="Default" data-name="searchBoards" class="">
+                      <a href="#api-Default-searchBoards">searchBoards</a>
+                    </li>
+                    <li data-group="Default" data-name="undeleteBlock" class="">
+                      <a href="#api-Default-undeleteBlock">undeleteBlock</a>
+                    </li>
+                    <li data-group="Default" data-name="undeleteBoard" class="">
+                      <a href="#api-Default-undeleteBoard">undeleteBoard</a>
+                    </li>
                     <li data-group="Default" data-name="updateBlocks" class="">
                       <a href="#api-Default-updateBlocks">updateBlocks</a>
+                    </li>
+                    <li data-group="Default" data-name="updateMember" class="">
+                      <a href="#api-Default-updateMember">updateMember</a>
+                    </li>
+                    <li data-group="Default" data-name="updateUserConfig" class="">
+                      <a href="#api-Default-updateUserConfig">updateUserConfig</a>
                     </li>
                     <li data-group="Default" data-name="uploadFile" class="">
                       <a href="#api-Default-uploadFile">uploadFile</a>
@@ -1486,6 +1940,1765 @@ ul.nav-tabs {
         <div id="sections">
                 <section id="api-Default">
                   <h1>Default</h1>
+                    <div id="api-Default-addMember">
+                      <article id="api-Default-addMember-0" data-group="User" data-name="addMember" data-version="0">
+                        <div class="pull-left">
+                          <h1>addMember</h1>
+                          <p></p>
+                        </div>
+                        <div class="pull-right"></div>
+                        <div class="clearfix"></div>
+                        <p></p>
+                        <p class="marked">Adds a new member to a board</p>
+                        <p></p>
+                        <br />
+                        <pre class="prettyprint language-html prettyprinted" data-type="post"><code><span class="pln">/boards/{boardID}/members</span></code></pre>
+                        <p>
+                          <h3>Usage and SDK Samples</h3>
+                        </p>
+                        <ul class="nav nav-tabs nav-tabs-examples">
+                          <li class="active"><a href="#examples-Default-addMember-0-curl">Curl</a></li>
+                          <li class=""><a href="#examples-Default-addMember-0-java">Java</a></li>
+                          <li class=""><a href="#examples-Default-addMember-0-android">Android</a></li>
+                          <!--<li class=""><a href="#examples-Default-addMember-0-groovy">Groovy</a></li>-->
+                          <li class=""><a href="#examples-Default-addMember-0-objc">Obj-C</a></li>
+                          <li class=""><a href="#examples-Default-addMember-0-javascript">JavaScript</a></li>
+                          <!--<li class=""><a href="#examples-Default-addMember-0-angular">Angular</a></li>-->
+                          <li class=""><a href="#examples-Default-addMember-0-csharp">C#</a></li>
+                          <li class=""><a href="#examples-Default-addMember-0-php">PHP</a></li>
+                          <li class=""><a href="#examples-Default-addMember-0-perl">Perl</a></li>
+                          <li class=""><a href="#examples-Default-addMember-0-python">Python</a></li>
+                          <li class=""><a href="#examples-Default-addMember-0-rust">Rust</a></li>
+                        </ul>
+
+                        <div class="tab-content">
+                          <div class="tab-pane active" id="examples-Default-addMember-0-curl">
+                            <pre class="prettyprint"><code class="language-bsh">curl -X POST \
+-H "Authorization: [[apiKey]]" \
+ -H "Accept: application/json" \
+ -H "Content-Type: application/json" \
+ "http://localhost/api/v2/boards/{boardID}/members" \
+ -d '{
+  &quot;schemeAdmin&quot; : true,
+  &quot;schemeCommenter&quot; : true,
+  &quot;schemeViewer&quot; : true,
+  &quot;roles&quot; : &quot;roles&quot;,
+  &quot;schemeEditor&quot; : true,
+  &quot;boardId&quot; : &quot;boardId&quot;,
+  &quot;userId&quot; : &quot;userId&quot;
+}'
+</code></pre>
+                          </div>
+                          <div class="tab-pane" id="examples-Default-addMember-0-java">
+                            <pre class="prettyprint"><code class="language-java">import org.openapitools.client.*;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.model.*;
+import org.openapitools.client.api.DefaultApi;
+
+import java.io.File;
+import java.util.*;
+
+public class DefaultApiExample {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        
+        // Configure API key authorization: BearerAuth
+        ApiKeyAuth BearerAuth = (ApiKeyAuth) defaultClient.getAuthentication("BearerAuth");
+        BearerAuth.setApiKey("YOUR API KEY");
+        // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+        //BearerAuth.setApiKeyPrefix("Token");
+
+        // Create an instance of the API class
+        DefaultApi apiInstance = new DefaultApi();
+        String boardID = boardID_example; // String | Board ID
+        BoardMember body = ; // BoardMember | 
+
+        try {
+            BoardMember result = apiInstance.addMember(boardID, body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling DefaultApi#addMember");
+            e.printStackTrace();
+        }
+    }
+}
+</code></pre>
+                          </div>
+
+                          <div class="tab-pane" id="examples-Default-addMember-0-android">
+                            <pre class="prettyprint"><code class="language-java">import org.openapitools.client.api.DefaultApi;
+
+public class DefaultApiExample {
+    public static void main(String[] args) {
+        DefaultApi apiInstance = new DefaultApi();
+        String boardID = boardID_example; // String | Board ID
+        BoardMember body = ; // BoardMember | 
+
+        try {
+            BoardMember result = apiInstance.addMember(boardID, body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling DefaultApi#addMember");
+            e.printStackTrace();
+        }
+    }
+}</code></pre>
+                          </div>
+  <!--
+  <div class="tab-pane" id="examples-Default-addMember-0-groovy">
+  <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
+  </div> -->
+                            <div class="tab-pane" id="examples-Default-addMember-0-objc">
+                              <pre class="prettyprint"><code class="language-cpp">Configuration *apiConfig = [Configuration sharedConfig];
+
+// Configure API key authorization: (authentication scheme: BearerAuth)
+[apiConfig setApiKey:@"YOUR_API_KEY" forApiKeyIdentifier:@"Authorization"];
+// Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+//[apiConfig setApiKeyPrefix:@"Bearer" forApiKeyIdentifier:@"Authorization"];
+
+
+// Create an instance of the API class
+DefaultApi *apiInstance = [[DefaultApi alloc] init];
+String *boardID = boardID_example; // Board ID (default to null)
+BoardMember *body = ; // 
+
+[apiInstance addMemberWith:boardID
+    body:body
+              completionHandler: ^(BoardMember output, NSError* error) {
+    if (output) {
+        NSLog(@"%@", output);
+    }
+    if (error) {
+        NSLog(@"Error: %@", error);
+    }
+}];
+</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-addMember-0-javascript">
+                              <pre class="prettyprint"><code class="language-js">var FocalboardServer = require('focalboard_server');
+var defaultClient = FocalboardServer.ApiClient.instance;
+
+// Configure API key authorization: BearerAuth
+var BearerAuth = defaultClient.authentications['BearerAuth'];
+BearerAuth.apiKey = "YOUR API KEY";
+// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+//BearerAuth.apiKeyPrefix['Authorization'] = "Token";
+
+// Create an instance of the API class
+var api = new FocalboardServer.DefaultApi()
+var boardID = boardID_example; // {String} Board ID
+var body = ; // {BoardMember} 
+
+var callback = function(error, data, response) {
+  if (error) {
+    console.error(error);
+  } else {
+    console.log('API called successfully. Returned data: ' + data);
+  }
+};
+api.addMember(boardID, body, callback);
+</code></pre>
+                            </div>
+
+                            <!--<div class="tab-pane" id="examples-Default-addMember-0-angular">
+              <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
+            </div>-->
+                            <div class="tab-pane" id="examples-Default-addMember-0-csharp">
+                              <pre class="prettyprint"><code class="language-cs">using System;
+using System.Diagnostics;
+using Org.OpenAPITools.Api;
+using Org.OpenAPITools.Client;
+using Org.OpenAPITools.Model;
+
+namespace Example
+{
+    public class addMemberExample
+    {
+        public void main()
+        {
+            // Configure API key authorization: BearerAuth
+            Configuration.Default.ApiKey.Add("Authorization", "YOUR_API_KEY");
+            // Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+            // Configuration.Default.ApiKeyPrefix.Add("Authorization", "Bearer");
+
+            // Create an instance of the API class
+            var apiInstance = new DefaultApi();
+            var boardID = boardID_example;  // String | Board ID (default to null)
+            var body = new BoardMember(); // BoardMember | 
+
+            try {
+                BoardMember result = apiInstance.addMember(boardID, body);
+                Debug.WriteLine(result);
+            } catch (Exception e) {
+                Debug.Print("Exception when calling DefaultApi.addMember: " + e.Message );
+            }
+        }
+    }
+}
+</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-addMember-0-php">
+                              <pre class="prettyprint"><code class="language-php"><&#63;php
+require_once(__DIR__ . '/vendor/autoload.php');
+
+// Configure API key authorization: BearerAuth
+OpenAPITools\Client\Configuration::getDefaultConfiguration()->setApiKey('Authorization', 'YOUR_API_KEY');
+// Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+// OpenAPITools\Client\Configuration::getDefaultConfiguration()->setApiKeyPrefix('Authorization', 'Bearer');
+
+// Create an instance of the API class
+$api_instance = new OpenAPITools\Client\Api\DefaultApi();
+$boardID = boardID_example; // String | Board ID
+$body = ; // BoardMember | 
+
+try {
+    $result = $api_instance->addMember($boardID, $body);
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling DefaultApi->addMember: ', $e->getMessage(), PHP_EOL;
+}
+?></code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-addMember-0-perl">
+                              <pre class="prettyprint"><code class="language-perl">use Data::Dumper;
+use WWW::OPenAPIClient::Configuration;
+use WWW::OPenAPIClient::DefaultApi;
+
+# Configure API key authorization: BearerAuth
+$WWW::OPenAPIClient::Configuration::api_key->{'Authorization'} = 'YOUR_API_KEY';
+# uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+#$WWW::OPenAPIClient::Configuration::api_key_prefix->{'Authorization'} = "Bearer";
+
+# Create an instance of the API class
+my $api_instance = WWW::OPenAPIClient::DefaultApi->new();
+my $boardID = boardID_example; # String | Board ID
+my $body = WWW::OPenAPIClient::Object::BoardMember->new(); # BoardMember | 
+
+eval {
+    my $result = $api_instance->addMember(boardID => $boardID, body => $body);
+    print Dumper($result);
+};
+if ($@) {
+    warn "Exception when calling DefaultApi->addMember: $@\n";
+}</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-addMember-0-python">
+                              <pre class="prettyprint"><code class="language-python">from __future__ import print_statement
+import time
+import openapi_client
+from openapi_client.rest import ApiException
+from pprint import pprint
+
+# Configure API key authorization: BearerAuth
+openapi_client.configuration.api_key['Authorization'] = 'YOUR_API_KEY'
+# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+# openapi_client.configuration.api_key_prefix['Authorization'] = 'Bearer'
+
+# Create an instance of the API class
+api_instance = openapi_client.DefaultApi()
+boardID = boardID_example # String | Board ID (default to null)
+body =  # BoardMember | 
+
+try:
+    api_response = api_instance.add_member(boardID, body)
+    pprint(api_response)
+except ApiException as e:
+    print("Exception when calling DefaultApi->addMember: %s\n" % e)</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-addMember-0-rust">
+                              <pre class="prettyprint"><code class="language-rust">extern crate DefaultApi;
+
+pub fn main() {
+    let boardID = boardID_example; // String
+    let body = ; // BoardMember
+
+    let mut context = DefaultApi::Context::default();
+    let result = client.addMember(boardID, body, &context).wait();
+
+    println!("{:?}", result);
+}
+</code></pre>
+                            </div>
+                          </div>
+
+                          <h2>Scopes</h2>
+                          <table>
+                            
+                          </table>
+
+                          <h2>Parameters</h2>
+
+                            <div class="methodsubtabletitle">Path parameters</div>
+                            <table id="methodsubtable">
+                                <tr>
+                                  <th width="150px">Name</th>
+                                  <th>Description</th>
+                                </tr>
+                                  <tr><td style="width:150px;">boardID*</td>
+<td>
+
+
+    <div id="d2e199_addMember_boardID">
+        <div class="json-schema-view">
+            <div class="primitive">
+                <span class="type">
+                    String
+                </span>
+
+                    <div class="inner description marked">
+Board ID
+                    </div>
+            </div>
+                <div class="inner required">
+                    Required
+                </div>
+        </div>
+    </div>
+</td>
+</tr>
+
+                            </table>
+
+
+                            <div class="methodsubtabletitle">Body parameters</div>
+                            <table id="methodsubtable">
+                              <tr>
+                                <th width="150px">Name</th>
+                                <th>Description</th>
+                              </tr>
+                                <tr><td style="width:150px;">body <span style="color:red;">*</span></td>
+<td>
+<p class="marked">membership to replace the current one with</p>
+<script>
+$(document).ready(function() {
+  var schemaWrapper = {
+  "description" : "membership to replace the current one with",
+  "content" : {
+    "application/json" : {
+      "schema" : {
+        "$ref" : "#/components/schemas/BoardMember"
+      }
+    }
+  },
+  "required" : true
+};
+
+  var schema = findNode('schema',schemaWrapper).schema;
+  if (!schema) {
+    schema = schemaWrapper.schema;
+  }
+  if (schema.$ref != null) {
+    schema = defsParser.$refs.get(schema.$ref);
+  } else {
+    schemaWrapper.definitions = Object.assign({}, defs);
+    $RefParser.dereference(schemaWrapper).catch(function(err) {
+      console.log(err);
+    });
+  }
+
+  var view = new JSONSchemaView(schema,2,{isBodyParam: true});
+  var result = $('#d2e199_addMember_body');
+  result.empty();
+  result.append(view.render());
+});
+</script>
+<div id="d2e199_addMember_body"></div>
+</td>
+</tr>
+
+                            </table>
+
+
+
+                          <h2>Responses</h2>
+                            <h3 id="examples-Default-addMember-title-200"></h3>
+                            <p id="examples-Default-addMember-description-200" class="marked"></p>
+                            <script>
+                              var responseDefault200_description = `success`;
+                              var responseDefault200_description_break = responseDefault200_description.indexOf('\n');
+                              if (responseDefault200_description_break == -1) {
+                                $("#examples-Default-addMember-title-200").text("Status: 200 - " + responseDefault200_description);
+                              } else {
+                                $("#examples-Default-addMember-title-200").text("Status: 200 - " + responseDefault200_description.substring(0, responseDefault200_description_break));
+                                $("#examples-Default-addMember-description-200").html(responseDefault200_description.substring(responseDefault200_description_break));
+                              }
+                            </script>
+
+
+                            <ul id="responses-detail-Default-addMember-200" class="nav nav-tabs nav-tabs-examples" >
+                                <li class="active">
+                                  <a data-toggle="tab" href="#responses-Default-addMember-200-schema">Schema</a>
+                                </li>
+
+
+
+
+                            </ul>
+
+
+                            <div class="tab-content" id="responses-Default-addMember-200-wrapper" style='margin-bottom: 10px;'>
+                                <div class="tab-pane active" id="responses-Default-addMember-200-schema">
+                                  <div id="responses-Default-addMember-schema-200" class="exampleStyle">
+                                    <script>
+                                      $(document).ready(function() {
+                                        var schemaWrapper = {
+  "description" : "success",
+  "content" : {
+    "application/json" : {
+      "schema" : {
+        "$ref" : "#/components/schemas/BoardMember"
+      }
+    }
+  }
+};
+                                        var schema = findNode('schema',schemaWrapper).schema;
+                                        if (!schema) {
+                                          schema = schemaWrapper.schema;
+                                        }
+                                        if (schema.$ref != null) {
+                                          schema = defsParser.$refs.get(schema.$ref);
+                                        } else if (schema.items != null && schema.items.$ref != null) {
+                                            schema.items = defsParser.$refs.get(schema.items.$ref);
+                                        } else {
+                                          schemaWrapper.definitions = Object.assign({}, defs);
+                                          $RefParser.dereference(schemaWrapper).catch(function(err) {
+                                            console.log(err);
+                                          });
+                                        }
+
+                                        var view = new JSONSchemaView(schema, 3);
+                                        $('#responses-Default-addMember-200-schema-data').val(JSON.stringify(schema));
+                                        var result = $('#responses-Default-addMember-schema-200');
+                                        result.empty();
+                                        result.append(view.render());
+                                      });
+                                    </script>
+                                  </div>
+                                  <input id='responses-Default-addMember-200-schema-data' type='hidden' value=''></input>
+                                </div>
+                            </div>
+                            <h3 id="examples-Default-addMember-title-404"></h3>
+                            <p id="examples-Default-addMember-description-404" class="marked"></p>
+                            <script>
+                              var responseDefault404_description = `board not found`;
+                              var responseDefault404_description_break = responseDefault404_description.indexOf('\n');
+                              if (responseDefault404_description_break == -1) {
+                                $("#examples-Default-addMember-title-404").text("Status: 404 - " + responseDefault404_description);
+                              } else {
+                                $("#examples-Default-addMember-title-404").text("Status: 404 - " + responseDefault404_description.substring(0, responseDefault404_description_break));
+                                $("#examples-Default-addMember-description-404").html(responseDefault404_description.substring(responseDefault404_description_break));
+                              }
+                            </script>
+
+
+                            <ul id="responses-detail-Default-addMember-404" class="nav nav-tabs nav-tabs-examples" >
+
+
+                            </ul>
+
+
+                            <div class="tab-content" id="responses-Default-addMember-404-wrapper" style='margin-bottom: 10px;'>
+                            </div>
+                            <h3 id="examples-Default-addMember-title-default"></h3>
+                            <p id="examples-Default-addMember-description-default" class="marked"></p>
+                            <script>
+                              var responseDefaultdefault_description = `internal error`;
+                              var responseDefaultdefault_description_break = responseDefaultdefault_description.indexOf('\n');
+                              if (responseDefaultdefault_description_break == -1) {
+                                $("#examples-Default-addMember-title-default").text("Status: default - " + responseDefaultdefault_description);
+                              } else {
+                                $("#examples-Default-addMember-title-default").text("Status: default - " + responseDefaultdefault_description.substring(0, responseDefaultdefault_description_break));
+                                $("#examples-Default-addMember-description-default").html(responseDefaultdefault_description.substring(responseDefaultdefault_description_break));
+                              }
+                            </script>
+
+
+                            <ul id="responses-detail-Default-addMember-default" class="nav nav-tabs nav-tabs-examples" >
+                                <li class="active">
+                                  <a data-toggle="tab" href="#responses-Default-addMember-default-schema">Schema</a>
+                                </li>
+
+
+
+
+                            </ul>
+
+
+                            <div class="tab-content" id="responses-Default-addMember-default-wrapper" style='margin-bottom: 10px;'>
+                                <div class="tab-pane active" id="responses-Default-addMember-default-schema">
+                                  <div id="responses-Default-addMember-schema-default" class="exampleStyle">
+                                    <script>
+                                      $(document).ready(function() {
+                                        var schemaWrapper = {
+  "description" : "internal error",
+  "content" : {
+    "application/json" : {
+      "schema" : {
+        "$ref" : "#/components/schemas/ErrorResponse"
+      }
+    }
+  }
+};
+                                        var schema = findNode('schema',schemaWrapper).schema;
+                                        if (!schema) {
+                                          schema = schemaWrapper.schema;
+                                        }
+                                        if (schema.$ref != null) {
+                                          schema = defsParser.$refs.get(schema.$ref);
+                                        } else if (schema.items != null && schema.items.$ref != null) {
+                                            schema.items = defsParser.$refs.get(schema.items.$ref);
+                                        } else {
+                                          schemaWrapper.definitions = Object.assign({}, defs);
+                                          $RefParser.dereference(schemaWrapper).catch(function(err) {
+                                            console.log(err);
+                                          });
+                                        }
+
+                                        var view = new JSONSchemaView(schema, 3);
+                                        $('#responses-Default-addMember-default-schema-data').val(JSON.stringify(schema));
+                                        var result = $('#responses-Default-addMember-schema-default');
+                                        result.empty();
+                                        result.append(view.render());
+                                      });
+                                    </script>
+                                  </div>
+                                  <input id='responses-Default-addMember-default-schema-data' type='hidden' value=''></input>
+                                </div>
+                            </div>
+                        </article>
+                      </div>
+                      <hr>
+                    <div id="api-Default-archiveExportBoard">
+                      <article id="api-Default-archiveExportBoard-0" data-group="User" data-name="archiveExportBoard" data-version="0">
+                        <div class="pull-left">
+                          <h1>archiveExportBoard</h1>
+                          <p>Exports an archive of all blocks for one boards.</p>
+                        </div>
+                        <div class="pull-right"></div>
+                        <div class="clearfix"></div>
+                        <p></p>
+                        <p class="marked"></p>
+                        <p></p>
+                        <br />
+                        <pre class="prettyprint language-html prettyprinted" data-type="get"><code><span class="pln">/boards/{boardID}/archive/export</span></code></pre>
+                        <p>
+                          <h3>Usage and SDK Samples</h3>
+                        </p>
+                        <ul class="nav nav-tabs nav-tabs-examples">
+                          <li class="active"><a href="#examples-Default-archiveExportBoard-0-curl">Curl</a></li>
+                          <li class=""><a href="#examples-Default-archiveExportBoard-0-java">Java</a></li>
+                          <li class=""><a href="#examples-Default-archiveExportBoard-0-android">Android</a></li>
+                          <!--<li class=""><a href="#examples-Default-archiveExportBoard-0-groovy">Groovy</a></li>-->
+                          <li class=""><a href="#examples-Default-archiveExportBoard-0-objc">Obj-C</a></li>
+                          <li class=""><a href="#examples-Default-archiveExportBoard-0-javascript">JavaScript</a></li>
+                          <!--<li class=""><a href="#examples-Default-archiveExportBoard-0-angular">Angular</a></li>-->
+                          <li class=""><a href="#examples-Default-archiveExportBoard-0-csharp">C#</a></li>
+                          <li class=""><a href="#examples-Default-archiveExportBoard-0-php">PHP</a></li>
+                          <li class=""><a href="#examples-Default-archiveExportBoard-0-perl">Perl</a></li>
+                          <li class=""><a href="#examples-Default-archiveExportBoard-0-python">Python</a></li>
+                          <li class=""><a href="#examples-Default-archiveExportBoard-0-rust">Rust</a></li>
+                        </ul>
+
+                        <div class="tab-content">
+                          <div class="tab-pane active" id="examples-Default-archiveExportBoard-0-curl">
+                            <pre class="prettyprint"><code class="language-bsh">curl -X GET \
+-H "Authorization: [[apiKey]]" \
+ -H "Accept: application/json" \
+ "http://localhost/api/v2/boards/{boardID}/archive/export"
+</code></pre>
+                          </div>
+                          <div class="tab-pane" id="examples-Default-archiveExportBoard-0-java">
+                            <pre class="prettyprint"><code class="language-java">import org.openapitools.client.*;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.model.*;
+import org.openapitools.client.api.DefaultApi;
+
+import java.io.File;
+import java.util.*;
+
+public class DefaultApiExample {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        
+        // Configure API key authorization: BearerAuth
+        ApiKeyAuth BearerAuth = (ApiKeyAuth) defaultClient.getAuthentication("BearerAuth");
+        BearerAuth.setApiKey("YOUR API KEY");
+        // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+        //BearerAuth.setApiKeyPrefix("Token");
+
+        // Create an instance of the API class
+        DefaultApi apiInstance = new DefaultApi();
+        String boardID = boardID_example; // String | Id of board to export
+
+        try {
+            apiInstance.archiveExportBoard(boardID);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling DefaultApi#archiveExportBoard");
+            e.printStackTrace();
+        }
+    }
+}
+</code></pre>
+                          </div>
+
+                          <div class="tab-pane" id="examples-Default-archiveExportBoard-0-android">
+                            <pre class="prettyprint"><code class="language-java">import org.openapitools.client.api.DefaultApi;
+
+public class DefaultApiExample {
+    public static void main(String[] args) {
+        DefaultApi apiInstance = new DefaultApi();
+        String boardID = boardID_example; // String | Id of board to export
+
+        try {
+            apiInstance.archiveExportBoard(boardID);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling DefaultApi#archiveExportBoard");
+            e.printStackTrace();
+        }
+    }
+}</code></pre>
+                          </div>
+  <!--
+  <div class="tab-pane" id="examples-Default-archiveExportBoard-0-groovy">
+  <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
+  </div> -->
+                            <div class="tab-pane" id="examples-Default-archiveExportBoard-0-objc">
+                              <pre class="prettyprint"><code class="language-cpp">Configuration *apiConfig = [Configuration sharedConfig];
+
+// Configure API key authorization: (authentication scheme: BearerAuth)
+[apiConfig setApiKey:@"YOUR_API_KEY" forApiKeyIdentifier:@"Authorization"];
+// Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+//[apiConfig setApiKeyPrefix:@"Bearer" forApiKeyIdentifier:@"Authorization"];
+
+
+// Create an instance of the API class
+DefaultApi *apiInstance = [[DefaultApi alloc] init];
+String *boardID = boardID_example; // Id of board to export (default to null)
+
+// Exports an archive of all blocks for one boards.
+[apiInstance archiveExportBoardWith:boardID
+              completionHandler: ^(NSError* error) {
+    if (error) {
+        NSLog(@"Error: %@", error);
+    }
+}];
+</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-archiveExportBoard-0-javascript">
+                              <pre class="prettyprint"><code class="language-js">var FocalboardServer = require('focalboard_server');
+var defaultClient = FocalboardServer.ApiClient.instance;
+
+// Configure API key authorization: BearerAuth
+var BearerAuth = defaultClient.authentications['BearerAuth'];
+BearerAuth.apiKey = "YOUR API KEY";
+// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+//BearerAuth.apiKeyPrefix['Authorization'] = "Token";
+
+// Create an instance of the API class
+var api = new FocalboardServer.DefaultApi()
+var boardID = boardID_example; // {String} Id of board to export
+
+var callback = function(error, data, response) {
+  if (error) {
+    console.error(error);
+  } else {
+    console.log('API called successfully.');
+  }
+};
+api.archiveExportBoard(boardID, callback);
+</code></pre>
+                            </div>
+
+                            <!--<div class="tab-pane" id="examples-Default-archiveExportBoard-0-angular">
+              <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
+            </div>-->
+                            <div class="tab-pane" id="examples-Default-archiveExportBoard-0-csharp">
+                              <pre class="prettyprint"><code class="language-cs">using System;
+using System.Diagnostics;
+using Org.OpenAPITools.Api;
+using Org.OpenAPITools.Client;
+using Org.OpenAPITools.Model;
+
+namespace Example
+{
+    public class archiveExportBoardExample
+    {
+        public void main()
+        {
+            // Configure API key authorization: BearerAuth
+            Configuration.Default.ApiKey.Add("Authorization", "YOUR_API_KEY");
+            // Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+            // Configuration.Default.ApiKeyPrefix.Add("Authorization", "Bearer");
+
+            // Create an instance of the API class
+            var apiInstance = new DefaultApi();
+            var boardID = boardID_example;  // String | Id of board to export (default to null)
+
+            try {
+                // Exports an archive of all blocks for one boards.
+                apiInstance.archiveExportBoard(boardID);
+            } catch (Exception e) {
+                Debug.Print("Exception when calling DefaultApi.archiveExportBoard: " + e.Message );
+            }
+        }
+    }
+}
+</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-archiveExportBoard-0-php">
+                              <pre class="prettyprint"><code class="language-php"><&#63;php
+require_once(__DIR__ . '/vendor/autoload.php');
+
+// Configure API key authorization: BearerAuth
+OpenAPITools\Client\Configuration::getDefaultConfiguration()->setApiKey('Authorization', 'YOUR_API_KEY');
+// Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+// OpenAPITools\Client\Configuration::getDefaultConfiguration()->setApiKeyPrefix('Authorization', 'Bearer');
+
+// Create an instance of the API class
+$api_instance = new OpenAPITools\Client\Api\DefaultApi();
+$boardID = boardID_example; // String | Id of board to export
+
+try {
+    $api_instance->archiveExportBoard($boardID);
+} catch (Exception $e) {
+    echo 'Exception when calling DefaultApi->archiveExportBoard: ', $e->getMessage(), PHP_EOL;
+}
+?></code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-archiveExportBoard-0-perl">
+                              <pre class="prettyprint"><code class="language-perl">use Data::Dumper;
+use WWW::OPenAPIClient::Configuration;
+use WWW::OPenAPIClient::DefaultApi;
+
+# Configure API key authorization: BearerAuth
+$WWW::OPenAPIClient::Configuration::api_key->{'Authorization'} = 'YOUR_API_KEY';
+# uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+#$WWW::OPenAPIClient::Configuration::api_key_prefix->{'Authorization'} = "Bearer";
+
+# Create an instance of the API class
+my $api_instance = WWW::OPenAPIClient::DefaultApi->new();
+my $boardID = boardID_example; # String | Id of board to export
+
+eval {
+    $api_instance->archiveExportBoard(boardID => $boardID);
+};
+if ($@) {
+    warn "Exception when calling DefaultApi->archiveExportBoard: $@\n";
+}</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-archiveExportBoard-0-python">
+                              <pre class="prettyprint"><code class="language-python">from __future__ import print_statement
+import time
+import openapi_client
+from openapi_client.rest import ApiException
+from pprint import pprint
+
+# Configure API key authorization: BearerAuth
+openapi_client.configuration.api_key['Authorization'] = 'YOUR_API_KEY'
+# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+# openapi_client.configuration.api_key_prefix['Authorization'] = 'Bearer'
+
+# Create an instance of the API class
+api_instance = openapi_client.DefaultApi()
+boardID = boardID_example # String | Id of board to export (default to null)
+
+try:
+    # Exports an archive of all blocks for one boards.
+    api_instance.archive_export_board(boardID)
+except ApiException as e:
+    print("Exception when calling DefaultApi->archiveExportBoard: %s\n" % e)</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-archiveExportBoard-0-rust">
+                              <pre class="prettyprint"><code class="language-rust">extern crate DefaultApi;
+
+pub fn main() {
+    let boardID = boardID_example; // String
+
+    let mut context = DefaultApi::Context::default();
+    let result = client.archiveExportBoard(boardID, &context).wait();
+
+    println!("{:?}", result);
+}
+</code></pre>
+                            </div>
+                          </div>
+
+                          <h2>Scopes</h2>
+                          <table>
+                            
+                          </table>
+
+                          <h2>Parameters</h2>
+
+                            <div class="methodsubtabletitle">Path parameters</div>
+                            <table id="methodsubtable">
+                                <tr>
+                                  <th width="150px">Name</th>
+                                  <th>Description</th>
+                                </tr>
+                                  <tr><td style="width:150px;">boardID*</td>
+<td>
+
+
+    <div id="d2e199_archiveExportBoard_boardID">
+        <div class="json-schema-view">
+            <div class="primitive">
+                <span class="type">
+                    String
+                </span>
+
+                    <div class="inner description marked">
+Id of board to export
+                    </div>
+            </div>
+                <div class="inner required">
+                    Required
+                </div>
+        </div>
+    </div>
+</td>
+</tr>
+
+                            </table>
+
+
+
+
+
+                          <h2>Responses</h2>
+                            <h3 id="examples-Default-archiveExportBoard-title-200"></h3>
+                            <p id="examples-Default-archiveExportBoard-description-200" class="marked"></p>
+                            <script>
+                              var responseDefault200_description = `success`;
+                              var responseDefault200_description_break = responseDefault200_description.indexOf('\n');
+                              if (responseDefault200_description_break == -1) {
+                                $("#examples-Default-archiveExportBoard-title-200").text("Status: 200 - " + responseDefault200_description);
+                              } else {
+                                $("#examples-Default-archiveExportBoard-title-200").text("Status: 200 - " + responseDefault200_description.substring(0, responseDefault200_description_break));
+                                $("#examples-Default-archiveExportBoard-description-200").html(responseDefault200_description.substring(responseDefault200_description_break));
+                              }
+                            </script>
+
+
+                            <ul id="responses-detail-Default-archiveExportBoard-200" class="nav nav-tabs nav-tabs-examples" >
+
+
+                            </ul>
+
+
+                            <div class="tab-content" id="responses-Default-archiveExportBoard-200-wrapper" style='margin-bottom: 10px;'>
+                            </div>
+                            <h3 id="examples-Default-archiveExportBoard-title-default"></h3>
+                            <p id="examples-Default-archiveExportBoard-description-default" class="marked"></p>
+                            <script>
+                              var responseDefaultdefault_description = `internal error`;
+                              var responseDefaultdefault_description_break = responseDefaultdefault_description.indexOf('\n');
+                              if (responseDefaultdefault_description_break == -1) {
+                                $("#examples-Default-archiveExportBoard-title-default").text("Status: default - " + responseDefaultdefault_description);
+                              } else {
+                                $("#examples-Default-archiveExportBoard-title-default").text("Status: default - " + responseDefaultdefault_description.substring(0, responseDefaultdefault_description_break));
+                                $("#examples-Default-archiveExportBoard-description-default").html(responseDefaultdefault_description.substring(responseDefaultdefault_description_break));
+                              }
+                            </script>
+
+
+                            <ul id="responses-detail-Default-archiveExportBoard-default" class="nav nav-tabs nav-tabs-examples" >
+                                <li class="active">
+                                  <a data-toggle="tab" href="#responses-Default-archiveExportBoard-default-schema">Schema</a>
+                                </li>
+
+
+
+
+                            </ul>
+
+
+                            <div class="tab-content" id="responses-Default-archiveExportBoard-default-wrapper" style='margin-bottom: 10px;'>
+                                <div class="tab-pane active" id="responses-Default-archiveExportBoard-default-schema">
+                                  <div id="responses-Default-archiveExportBoard-schema-default" class="exampleStyle">
+                                    <script>
+                                      $(document).ready(function() {
+                                        var schemaWrapper = {
+  "description" : "internal error",
+  "content" : {
+    "application/json" : {
+      "schema" : {
+        "$ref" : "#/components/schemas/ErrorResponse"
+      }
+    }
+  }
+};
+                                        var schema = findNode('schema',schemaWrapper).schema;
+                                        if (!schema) {
+                                          schema = schemaWrapper.schema;
+                                        }
+                                        if (schema.$ref != null) {
+                                          schema = defsParser.$refs.get(schema.$ref);
+                                        } else if (schema.items != null && schema.items.$ref != null) {
+                                            schema.items = defsParser.$refs.get(schema.items.$ref);
+                                        } else {
+                                          schemaWrapper.definitions = Object.assign({}, defs);
+                                          $RefParser.dereference(schemaWrapper).catch(function(err) {
+                                            console.log(err);
+                                          });
+                                        }
+
+                                        var view = new JSONSchemaView(schema, 3);
+                                        $('#responses-Default-archiveExportBoard-default-schema-data').val(JSON.stringify(schema));
+                                        var result = $('#responses-Default-archiveExportBoard-schema-default');
+                                        result.empty();
+                                        result.append(view.render());
+                                      });
+                                    </script>
+                                  </div>
+                                  <input id='responses-Default-archiveExportBoard-default-schema-data' type='hidden' value=''></input>
+                                </div>
+                            </div>
+                        </article>
+                      </div>
+                      <hr>
+                    <div id="api-Default-archiveExportTeam">
+                      <article id="api-Default-archiveExportTeam-0" data-group="User" data-name="archiveExportTeam" data-version="0">
+                        <div class="pull-left">
+                          <h1>archiveExportTeam</h1>
+                          <p>Exports an archive of all blocks for all the boards in a team.</p>
+                        </div>
+                        <div class="pull-right"></div>
+                        <div class="clearfix"></div>
+                        <p></p>
+                        <p class="marked"></p>
+                        <p></p>
+                        <br />
+                        <pre class="prettyprint language-html prettyprinted" data-type="get"><code><span class="pln">/teams/{teamID}/archive/export</span></code></pre>
+                        <p>
+                          <h3>Usage and SDK Samples</h3>
+                        </p>
+                        <ul class="nav nav-tabs nav-tabs-examples">
+                          <li class="active"><a href="#examples-Default-archiveExportTeam-0-curl">Curl</a></li>
+                          <li class=""><a href="#examples-Default-archiveExportTeam-0-java">Java</a></li>
+                          <li class=""><a href="#examples-Default-archiveExportTeam-0-android">Android</a></li>
+                          <!--<li class=""><a href="#examples-Default-archiveExportTeam-0-groovy">Groovy</a></li>-->
+                          <li class=""><a href="#examples-Default-archiveExportTeam-0-objc">Obj-C</a></li>
+                          <li class=""><a href="#examples-Default-archiveExportTeam-0-javascript">JavaScript</a></li>
+                          <!--<li class=""><a href="#examples-Default-archiveExportTeam-0-angular">Angular</a></li>-->
+                          <li class=""><a href="#examples-Default-archiveExportTeam-0-csharp">C#</a></li>
+                          <li class=""><a href="#examples-Default-archiveExportTeam-0-php">PHP</a></li>
+                          <li class=""><a href="#examples-Default-archiveExportTeam-0-perl">Perl</a></li>
+                          <li class=""><a href="#examples-Default-archiveExportTeam-0-python">Python</a></li>
+                          <li class=""><a href="#examples-Default-archiveExportTeam-0-rust">Rust</a></li>
+                        </ul>
+
+                        <div class="tab-content">
+                          <div class="tab-pane active" id="examples-Default-archiveExportTeam-0-curl">
+                            <pre class="prettyprint"><code class="language-bsh">curl -X GET \
+-H "Authorization: [[apiKey]]" \
+ -H "Accept: application/json" \
+ "http://localhost/api/v2/teams/{teamID}/archive/export"
+</code></pre>
+                          </div>
+                          <div class="tab-pane" id="examples-Default-archiveExportTeam-0-java">
+                            <pre class="prettyprint"><code class="language-java">import org.openapitools.client.*;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.model.*;
+import org.openapitools.client.api.DefaultApi;
+
+import java.io.File;
+import java.util.*;
+
+public class DefaultApiExample {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        
+        // Configure API key authorization: BearerAuth
+        ApiKeyAuth BearerAuth = (ApiKeyAuth) defaultClient.getAuthentication("BearerAuth");
+        BearerAuth.setApiKey("YOUR API KEY");
+        // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+        //BearerAuth.setApiKeyPrefix("Token");
+
+        // Create an instance of the API class
+        DefaultApi apiInstance = new DefaultApi();
+        String teamID = teamID_example; // String | Id of team
+
+        try {
+            apiInstance.archiveExportTeam(teamID);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling DefaultApi#archiveExportTeam");
+            e.printStackTrace();
+        }
+    }
+}
+</code></pre>
+                          </div>
+
+                          <div class="tab-pane" id="examples-Default-archiveExportTeam-0-android">
+                            <pre class="prettyprint"><code class="language-java">import org.openapitools.client.api.DefaultApi;
+
+public class DefaultApiExample {
+    public static void main(String[] args) {
+        DefaultApi apiInstance = new DefaultApi();
+        String teamID = teamID_example; // String | Id of team
+
+        try {
+            apiInstance.archiveExportTeam(teamID);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling DefaultApi#archiveExportTeam");
+            e.printStackTrace();
+        }
+    }
+}</code></pre>
+                          </div>
+  <!--
+  <div class="tab-pane" id="examples-Default-archiveExportTeam-0-groovy">
+  <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
+  </div> -->
+                            <div class="tab-pane" id="examples-Default-archiveExportTeam-0-objc">
+                              <pre class="prettyprint"><code class="language-cpp">Configuration *apiConfig = [Configuration sharedConfig];
+
+// Configure API key authorization: (authentication scheme: BearerAuth)
+[apiConfig setApiKey:@"YOUR_API_KEY" forApiKeyIdentifier:@"Authorization"];
+// Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+//[apiConfig setApiKeyPrefix:@"Bearer" forApiKeyIdentifier:@"Authorization"];
+
+
+// Create an instance of the API class
+DefaultApi *apiInstance = [[DefaultApi alloc] init];
+String *teamID = teamID_example; // Id of team (default to null)
+
+// Exports an archive of all blocks for all the boards in a team.
+[apiInstance archiveExportTeamWith:teamID
+              completionHandler: ^(NSError* error) {
+    if (error) {
+        NSLog(@"Error: %@", error);
+    }
+}];
+</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-archiveExportTeam-0-javascript">
+                              <pre class="prettyprint"><code class="language-js">var FocalboardServer = require('focalboard_server');
+var defaultClient = FocalboardServer.ApiClient.instance;
+
+// Configure API key authorization: BearerAuth
+var BearerAuth = defaultClient.authentications['BearerAuth'];
+BearerAuth.apiKey = "YOUR API KEY";
+// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+//BearerAuth.apiKeyPrefix['Authorization'] = "Token";
+
+// Create an instance of the API class
+var api = new FocalboardServer.DefaultApi()
+var teamID = teamID_example; // {String} Id of team
+
+var callback = function(error, data, response) {
+  if (error) {
+    console.error(error);
+  } else {
+    console.log('API called successfully.');
+  }
+};
+api.archiveExportTeam(teamID, callback);
+</code></pre>
+                            </div>
+
+                            <!--<div class="tab-pane" id="examples-Default-archiveExportTeam-0-angular">
+              <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
+            </div>-->
+                            <div class="tab-pane" id="examples-Default-archiveExportTeam-0-csharp">
+                              <pre class="prettyprint"><code class="language-cs">using System;
+using System.Diagnostics;
+using Org.OpenAPITools.Api;
+using Org.OpenAPITools.Client;
+using Org.OpenAPITools.Model;
+
+namespace Example
+{
+    public class archiveExportTeamExample
+    {
+        public void main()
+        {
+            // Configure API key authorization: BearerAuth
+            Configuration.Default.ApiKey.Add("Authorization", "YOUR_API_KEY");
+            // Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+            // Configuration.Default.ApiKeyPrefix.Add("Authorization", "Bearer");
+
+            // Create an instance of the API class
+            var apiInstance = new DefaultApi();
+            var teamID = teamID_example;  // String | Id of team (default to null)
+
+            try {
+                // Exports an archive of all blocks for all the boards in a team.
+                apiInstance.archiveExportTeam(teamID);
+            } catch (Exception e) {
+                Debug.Print("Exception when calling DefaultApi.archiveExportTeam: " + e.Message );
+            }
+        }
+    }
+}
+</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-archiveExportTeam-0-php">
+                              <pre class="prettyprint"><code class="language-php"><&#63;php
+require_once(__DIR__ . '/vendor/autoload.php');
+
+// Configure API key authorization: BearerAuth
+OpenAPITools\Client\Configuration::getDefaultConfiguration()->setApiKey('Authorization', 'YOUR_API_KEY');
+// Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+// OpenAPITools\Client\Configuration::getDefaultConfiguration()->setApiKeyPrefix('Authorization', 'Bearer');
+
+// Create an instance of the API class
+$api_instance = new OpenAPITools\Client\Api\DefaultApi();
+$teamID = teamID_example; // String | Id of team
+
+try {
+    $api_instance->archiveExportTeam($teamID);
+} catch (Exception $e) {
+    echo 'Exception when calling DefaultApi->archiveExportTeam: ', $e->getMessage(), PHP_EOL;
+}
+?></code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-archiveExportTeam-0-perl">
+                              <pre class="prettyprint"><code class="language-perl">use Data::Dumper;
+use WWW::OPenAPIClient::Configuration;
+use WWW::OPenAPIClient::DefaultApi;
+
+# Configure API key authorization: BearerAuth
+$WWW::OPenAPIClient::Configuration::api_key->{'Authorization'} = 'YOUR_API_KEY';
+# uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+#$WWW::OPenAPIClient::Configuration::api_key_prefix->{'Authorization'} = "Bearer";
+
+# Create an instance of the API class
+my $api_instance = WWW::OPenAPIClient::DefaultApi->new();
+my $teamID = teamID_example; # String | Id of team
+
+eval {
+    $api_instance->archiveExportTeam(teamID => $teamID);
+};
+if ($@) {
+    warn "Exception when calling DefaultApi->archiveExportTeam: $@\n";
+}</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-archiveExportTeam-0-python">
+                              <pre class="prettyprint"><code class="language-python">from __future__ import print_statement
+import time
+import openapi_client
+from openapi_client.rest import ApiException
+from pprint import pprint
+
+# Configure API key authorization: BearerAuth
+openapi_client.configuration.api_key['Authorization'] = 'YOUR_API_KEY'
+# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+# openapi_client.configuration.api_key_prefix['Authorization'] = 'Bearer'
+
+# Create an instance of the API class
+api_instance = openapi_client.DefaultApi()
+teamID = teamID_example # String | Id of team (default to null)
+
+try:
+    # Exports an archive of all blocks for all the boards in a team.
+    api_instance.archive_export_team(teamID)
+except ApiException as e:
+    print("Exception when calling DefaultApi->archiveExportTeam: %s\n" % e)</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-archiveExportTeam-0-rust">
+                              <pre class="prettyprint"><code class="language-rust">extern crate DefaultApi;
+
+pub fn main() {
+    let teamID = teamID_example; // String
+
+    let mut context = DefaultApi::Context::default();
+    let result = client.archiveExportTeam(teamID, &context).wait();
+
+    println!("{:?}", result);
+}
+</code></pre>
+                            </div>
+                          </div>
+
+                          <h2>Scopes</h2>
+                          <table>
+                            
+                          </table>
+
+                          <h2>Parameters</h2>
+
+                            <div class="methodsubtabletitle">Path parameters</div>
+                            <table id="methodsubtable">
+                                <tr>
+                                  <th width="150px">Name</th>
+                                  <th>Description</th>
+                                </tr>
+                                  <tr><td style="width:150px;">teamID*</td>
+<td>
+
+
+    <div id="d2e199_archiveExportTeam_teamID">
+        <div class="json-schema-view">
+            <div class="primitive">
+                <span class="type">
+                    String
+                </span>
+
+                    <div class="inner description marked">
+Id of team
+                    </div>
+            </div>
+                <div class="inner required">
+                    Required
+                </div>
+        </div>
+    </div>
+</td>
+</tr>
+
+                            </table>
+
+
+
+
+
+                          <h2>Responses</h2>
+                            <h3 id="examples-Default-archiveExportTeam-title-200"></h3>
+                            <p id="examples-Default-archiveExportTeam-description-200" class="marked"></p>
+                            <script>
+                              var responseDefault200_description = `success`;
+                              var responseDefault200_description_break = responseDefault200_description.indexOf('\n');
+                              if (responseDefault200_description_break == -1) {
+                                $("#examples-Default-archiveExportTeam-title-200").text("Status: 200 - " + responseDefault200_description);
+                              } else {
+                                $("#examples-Default-archiveExportTeam-title-200").text("Status: 200 - " + responseDefault200_description.substring(0, responseDefault200_description_break));
+                                $("#examples-Default-archiveExportTeam-description-200").html(responseDefault200_description.substring(responseDefault200_description_break));
+                              }
+                            </script>
+
+
+                            <ul id="responses-detail-Default-archiveExportTeam-200" class="nav nav-tabs nav-tabs-examples" >
+
+
+                            </ul>
+
+
+                            <div class="tab-content" id="responses-Default-archiveExportTeam-200-wrapper" style='margin-bottom: 10px;'>
+                            </div>
+                            <h3 id="examples-Default-archiveExportTeam-title-default"></h3>
+                            <p id="examples-Default-archiveExportTeam-description-default" class="marked"></p>
+                            <script>
+                              var responseDefaultdefault_description = `internal error`;
+                              var responseDefaultdefault_description_break = responseDefaultdefault_description.indexOf('\n');
+                              if (responseDefaultdefault_description_break == -1) {
+                                $("#examples-Default-archiveExportTeam-title-default").text("Status: default - " + responseDefaultdefault_description);
+                              } else {
+                                $("#examples-Default-archiveExportTeam-title-default").text("Status: default - " + responseDefaultdefault_description.substring(0, responseDefaultdefault_description_break));
+                                $("#examples-Default-archiveExportTeam-description-default").html(responseDefaultdefault_description.substring(responseDefaultdefault_description_break));
+                              }
+                            </script>
+
+
+                            <ul id="responses-detail-Default-archiveExportTeam-default" class="nav nav-tabs nav-tabs-examples" >
+                                <li class="active">
+                                  <a data-toggle="tab" href="#responses-Default-archiveExportTeam-default-schema">Schema</a>
+                                </li>
+
+
+
+
+                            </ul>
+
+
+                            <div class="tab-content" id="responses-Default-archiveExportTeam-default-wrapper" style='margin-bottom: 10px;'>
+                                <div class="tab-pane active" id="responses-Default-archiveExportTeam-default-schema">
+                                  <div id="responses-Default-archiveExportTeam-schema-default" class="exampleStyle">
+                                    <script>
+                                      $(document).ready(function() {
+                                        var schemaWrapper = {
+  "description" : "internal error",
+  "content" : {
+    "application/json" : {
+      "schema" : {
+        "$ref" : "#/components/schemas/ErrorResponse"
+      }
+    }
+  }
+};
+                                        var schema = findNode('schema',schemaWrapper).schema;
+                                        if (!schema) {
+                                          schema = schemaWrapper.schema;
+                                        }
+                                        if (schema.$ref != null) {
+                                          schema = defsParser.$refs.get(schema.$ref);
+                                        } else if (schema.items != null && schema.items.$ref != null) {
+                                            schema.items = defsParser.$refs.get(schema.items.$ref);
+                                        } else {
+                                          schemaWrapper.definitions = Object.assign({}, defs);
+                                          $RefParser.dereference(schemaWrapper).catch(function(err) {
+                                            console.log(err);
+                                          });
+                                        }
+
+                                        var view = new JSONSchemaView(schema, 3);
+                                        $('#responses-Default-archiveExportTeam-default-schema-data').val(JSON.stringify(schema));
+                                        var result = $('#responses-Default-archiveExportTeam-schema-default');
+                                        result.empty();
+                                        result.append(view.render());
+                                      });
+                                    </script>
+                                  </div>
+                                  <input id='responses-Default-archiveExportTeam-default-schema-data' type='hidden' value=''></input>
+                                </div>
+                            </div>
+                        </article>
+                      </div>
+                      <hr>
+                    <div id="api-Default-archiveImport">
+                      <article id="api-Default-archiveImport-0" data-group="User" data-name="archiveImport" data-version="0">
+                        <div class="pull-left">
+                          <h1>archiveImport</h1>
+                          <p>Import an archive of boards.</p>
+                        </div>
+                        <div class="pull-right"></div>
+                        <div class="clearfix"></div>
+                        <p></p>
+                        <p class="marked"></p>
+                        <p></p>
+                        <br />
+                        <pre class="prettyprint language-html prettyprinted" data-type="post"><code><span class="pln">/teams/{teamID}/archive/import</span></code></pre>
+                        <p>
+                          <h3>Usage and SDK Samples</h3>
+                        </p>
+                        <ul class="nav nav-tabs nav-tabs-examples">
+                          <li class="active"><a href="#examples-Default-archiveImport-0-curl">Curl</a></li>
+                          <li class=""><a href="#examples-Default-archiveImport-0-java">Java</a></li>
+                          <li class=""><a href="#examples-Default-archiveImport-0-android">Android</a></li>
+                          <!--<li class=""><a href="#examples-Default-archiveImport-0-groovy">Groovy</a></li>-->
+                          <li class=""><a href="#examples-Default-archiveImport-0-objc">Obj-C</a></li>
+                          <li class=""><a href="#examples-Default-archiveImport-0-javascript">JavaScript</a></li>
+                          <!--<li class=""><a href="#examples-Default-archiveImport-0-angular">Angular</a></li>-->
+                          <li class=""><a href="#examples-Default-archiveImport-0-csharp">C#</a></li>
+                          <li class=""><a href="#examples-Default-archiveImport-0-php">PHP</a></li>
+                          <li class=""><a href="#examples-Default-archiveImport-0-perl">Perl</a></li>
+                          <li class=""><a href="#examples-Default-archiveImport-0-python">Python</a></li>
+                          <li class=""><a href="#examples-Default-archiveImport-0-rust">Rust</a></li>
+                        </ul>
+
+                        <div class="tab-content">
+                          <div class="tab-pane active" id="examples-Default-archiveImport-0-curl">
+                            <pre class="prettyprint"><code class="language-bsh">curl -X POST \
+-H "Authorization: [[apiKey]]" \
+ -H "Accept: application/json" \
+ -H "Content-Type: multipart/form-data" \
+ "http://localhost/api/v2/teams/{teamID}/archive/import"
+</code></pre>
+                          </div>
+                          <div class="tab-pane" id="examples-Default-archiveImport-0-java">
+                            <pre class="prettyprint"><code class="language-java">import org.openapitools.client.*;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.model.*;
+import org.openapitools.client.api.DefaultApi;
+
+import java.io.File;
+import java.util.*;
+
+public class DefaultApiExample {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        
+        // Configure API key authorization: BearerAuth
+        ApiKeyAuth BearerAuth = (ApiKeyAuth) defaultClient.getAuthentication("BearerAuth");
+        BearerAuth.setApiKey("YOUR API KEY");
+        // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+        //BearerAuth.setApiKeyPrefix("Token");
+
+        // Create an instance of the API class
+        DefaultApi apiInstance = new DefaultApi();
+        String teamID = teamID_example; // String | Team ID
+        File file = BINARY_DATA_HERE; // File | archive file to import
+
+        try {
+            apiInstance.archiveImport(teamID, file);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling DefaultApi#archiveImport");
+            e.printStackTrace();
+        }
+    }
+}
+</code></pre>
+                          </div>
+
+                          <div class="tab-pane" id="examples-Default-archiveImport-0-android">
+                            <pre class="prettyprint"><code class="language-java">import org.openapitools.client.api.DefaultApi;
+
+public class DefaultApiExample {
+    public static void main(String[] args) {
+        DefaultApi apiInstance = new DefaultApi();
+        String teamID = teamID_example; // String | Team ID
+        File file = BINARY_DATA_HERE; // File | archive file to import
+
+        try {
+            apiInstance.archiveImport(teamID, file);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling DefaultApi#archiveImport");
+            e.printStackTrace();
+        }
+    }
+}</code></pre>
+                          </div>
+  <!--
+  <div class="tab-pane" id="examples-Default-archiveImport-0-groovy">
+  <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
+  </div> -->
+                            <div class="tab-pane" id="examples-Default-archiveImport-0-objc">
+                              <pre class="prettyprint"><code class="language-cpp">Configuration *apiConfig = [Configuration sharedConfig];
+
+// Configure API key authorization: (authentication scheme: BearerAuth)
+[apiConfig setApiKey:@"YOUR_API_KEY" forApiKeyIdentifier:@"Authorization"];
+// Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+//[apiConfig setApiKeyPrefix:@"Bearer" forApiKeyIdentifier:@"Authorization"];
+
+
+// Create an instance of the API class
+DefaultApi *apiInstance = [[DefaultApi alloc] init];
+String *teamID = teamID_example; // Team ID (default to null)
+File *file = BINARY_DATA_HERE; // archive file to import (default to null)
+
+// Import an archive of boards.
+[apiInstance archiveImportWith:teamID
+    file:file
+              completionHandler: ^(NSError* error) {
+    if (error) {
+        NSLog(@"Error: %@", error);
+    }
+}];
+</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-archiveImport-0-javascript">
+                              <pre class="prettyprint"><code class="language-js">var FocalboardServer = require('focalboard_server');
+var defaultClient = FocalboardServer.ApiClient.instance;
+
+// Configure API key authorization: BearerAuth
+var BearerAuth = defaultClient.authentications['BearerAuth'];
+BearerAuth.apiKey = "YOUR API KEY";
+// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+//BearerAuth.apiKeyPrefix['Authorization'] = "Token";
+
+// Create an instance of the API class
+var api = new FocalboardServer.DefaultApi()
+var teamID = teamID_example; // {String} Team ID
+var file = BINARY_DATA_HERE; // {File} archive file to import
+
+var callback = function(error, data, response) {
+  if (error) {
+    console.error(error);
+  } else {
+    console.log('API called successfully.');
+  }
+};
+api.archiveImport(teamID, file, callback);
+</code></pre>
+                            </div>
+
+                            <!--<div class="tab-pane" id="examples-Default-archiveImport-0-angular">
+              <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
+            </div>-->
+                            <div class="tab-pane" id="examples-Default-archiveImport-0-csharp">
+                              <pre class="prettyprint"><code class="language-cs">using System;
+using System.Diagnostics;
+using Org.OpenAPITools.Api;
+using Org.OpenAPITools.Client;
+using Org.OpenAPITools.Model;
+
+namespace Example
+{
+    public class archiveImportExample
+    {
+        public void main()
+        {
+            // Configure API key authorization: BearerAuth
+            Configuration.Default.ApiKey.Add("Authorization", "YOUR_API_KEY");
+            // Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+            // Configuration.Default.ApiKeyPrefix.Add("Authorization", "Bearer");
+
+            // Create an instance of the API class
+            var apiInstance = new DefaultApi();
+            var teamID = teamID_example;  // String | Team ID (default to null)
+            var file = BINARY_DATA_HERE;  // File | archive file to import (default to null)
+
+            try {
+                // Import an archive of boards.
+                apiInstance.archiveImport(teamID, file);
+            } catch (Exception e) {
+                Debug.Print("Exception when calling DefaultApi.archiveImport: " + e.Message );
+            }
+        }
+    }
+}
+</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-archiveImport-0-php">
+                              <pre class="prettyprint"><code class="language-php"><&#63;php
+require_once(__DIR__ . '/vendor/autoload.php');
+
+// Configure API key authorization: BearerAuth
+OpenAPITools\Client\Configuration::getDefaultConfiguration()->setApiKey('Authorization', 'YOUR_API_KEY');
+// Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+// OpenAPITools\Client\Configuration::getDefaultConfiguration()->setApiKeyPrefix('Authorization', 'Bearer');
+
+// Create an instance of the API class
+$api_instance = new OpenAPITools\Client\Api\DefaultApi();
+$teamID = teamID_example; // String | Team ID
+$file = BINARY_DATA_HERE; // File | archive file to import
+
+try {
+    $api_instance->archiveImport($teamID, $file);
+} catch (Exception $e) {
+    echo 'Exception when calling DefaultApi->archiveImport: ', $e->getMessage(), PHP_EOL;
+}
+?></code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-archiveImport-0-perl">
+                              <pre class="prettyprint"><code class="language-perl">use Data::Dumper;
+use WWW::OPenAPIClient::Configuration;
+use WWW::OPenAPIClient::DefaultApi;
+
+# Configure API key authorization: BearerAuth
+$WWW::OPenAPIClient::Configuration::api_key->{'Authorization'} = 'YOUR_API_KEY';
+# uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+#$WWW::OPenAPIClient::Configuration::api_key_prefix->{'Authorization'} = "Bearer";
+
+# Create an instance of the API class
+my $api_instance = WWW::OPenAPIClient::DefaultApi->new();
+my $teamID = teamID_example; # String | Team ID
+my $file = BINARY_DATA_HERE; # File | archive file to import
+
+eval {
+    $api_instance->archiveImport(teamID => $teamID, file => $file);
+};
+if ($@) {
+    warn "Exception when calling DefaultApi->archiveImport: $@\n";
+}</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-archiveImport-0-python">
+                              <pre class="prettyprint"><code class="language-python">from __future__ import print_statement
+import time
+import openapi_client
+from openapi_client.rest import ApiException
+from pprint import pprint
+
+# Configure API key authorization: BearerAuth
+openapi_client.configuration.api_key['Authorization'] = 'YOUR_API_KEY'
+# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+# openapi_client.configuration.api_key_prefix['Authorization'] = 'Bearer'
+
+# Create an instance of the API class
+api_instance = openapi_client.DefaultApi()
+teamID = teamID_example # String | Team ID (default to null)
+file = BINARY_DATA_HERE # File | archive file to import (default to null)
+
+try:
+    # Import an archive of boards.
+    api_instance.archive_import(teamID, file)
+except ApiException as e:
+    print("Exception when calling DefaultApi->archiveImport: %s\n" % e)</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-archiveImport-0-rust">
+                              <pre class="prettyprint"><code class="language-rust">extern crate DefaultApi;
+
+pub fn main() {
+    let teamID = teamID_example; // String
+    let file = BINARY_DATA_HERE; // File
+
+    let mut context = DefaultApi::Context::default();
+    let result = client.archiveImport(teamID, file, &context).wait();
+
+    println!("{:?}", result);
+}
+</code></pre>
+                            </div>
+                          </div>
+
+                          <h2>Scopes</h2>
+                          <table>
+                            
+                          </table>
+
+                          <h2>Parameters</h2>
+
+                            <div class="methodsubtabletitle">Path parameters</div>
+                            <table id="methodsubtable">
+                                <tr>
+                                  <th width="150px">Name</th>
+                                  <th>Description</th>
+                                </tr>
+                                  <tr><td style="width:150px;">teamID*</td>
+<td>
+
+
+    <div id="d2e199_archiveImport_teamID">
+        <div class="json-schema-view">
+            <div class="primitive">
+                <span class="type">
+                    String
+                </span>
+
+                    <div class="inner description marked">
+Team ID
+                    </div>
+            </div>
+                <div class="inner required">
+                    Required
+                </div>
+        </div>
+    </div>
+</td>
+</tr>
+
+                            </table>
+
+
+
+                            <div class="methodsubtabletitle">Form parameters</div>
+                            <table id="methodsubtable">
+                              <tr>
+                                <th width="150px">Name</th>
+                                <th>Description</th>
+                              </tr>
+                                  <tr><td style="width:150px;">file*</td>
+<td>
+
+
+    <div id="d2e199_archiveImport_file">
+        <div class="json-schema-view">
+            <div class="primitive">
+                <span class="type">
+                    File
+                </span>
+                    <span class="format">
+                        (binary)
+                    </span>
+
+                    <div class="inner description marked">
+archive file to import
+                    </div>
+            </div>
+                <div class="inner required">
+                    Required
+                </div>
+        </div>
+    </div>
+</td>
+</tr>
+
+                            </table>
+
+
+                          <h2>Responses</h2>
+                            <h3 id="examples-Default-archiveImport-title-200"></h3>
+                            <p id="examples-Default-archiveImport-description-200" class="marked"></p>
+                            <script>
+                              var responseDefault200_description = `success`;
+                              var responseDefault200_description_break = responseDefault200_description.indexOf('\n');
+                              if (responseDefault200_description_break == -1) {
+                                $("#examples-Default-archiveImport-title-200").text("Status: 200 - " + responseDefault200_description);
+                              } else {
+                                $("#examples-Default-archiveImport-title-200").text("Status: 200 - " + responseDefault200_description.substring(0, responseDefault200_description_break));
+                                $("#examples-Default-archiveImport-description-200").html(responseDefault200_description.substring(responseDefault200_description_break));
+                              }
+                            </script>
+
+
+                            <ul id="responses-detail-Default-archiveImport-200" class="nav nav-tabs nav-tabs-examples" >
+
+
+                            </ul>
+
+
+                            <div class="tab-content" id="responses-Default-archiveImport-200-wrapper" style='margin-bottom: 10px;'>
+                            </div>
+                            <h3 id="examples-Default-archiveImport-title-default"></h3>
+                            <p id="examples-Default-archiveImport-description-default" class="marked"></p>
+                            <script>
+                              var responseDefaultdefault_description = `internal error`;
+                              var responseDefaultdefault_description_break = responseDefaultdefault_description.indexOf('\n');
+                              if (responseDefaultdefault_description_break == -1) {
+                                $("#examples-Default-archiveImport-title-default").text("Status: default - " + responseDefaultdefault_description);
+                              } else {
+                                $("#examples-Default-archiveImport-title-default").text("Status: default - " + responseDefaultdefault_description.substring(0, responseDefaultdefault_description_break));
+                                $("#examples-Default-archiveImport-description-default").html(responseDefaultdefault_description.substring(responseDefaultdefault_description_break));
+                              }
+                            </script>
+
+
+                            <ul id="responses-detail-Default-archiveImport-default" class="nav nav-tabs nav-tabs-examples" >
+                                <li class="active">
+                                  <a data-toggle="tab" href="#responses-Default-archiveImport-default-schema">Schema</a>
+                                </li>
+
+
+
+
+                            </ul>
+
+
+                            <div class="tab-content" id="responses-Default-archiveImport-default-wrapper" style='margin-bottom: 10px;'>
+                                <div class="tab-pane active" id="responses-Default-archiveImport-default-schema">
+                                  <div id="responses-Default-archiveImport-schema-default" class="exampleStyle">
+                                    <script>
+                                      $(document).ready(function() {
+                                        var schemaWrapper = {
+  "description" : "internal error",
+  "content" : {
+    "application/json" : {
+      "schema" : {
+        "$ref" : "#/components/schemas/ErrorResponse"
+      }
+    }
+  }
+};
+                                        var schema = findNode('schema',schemaWrapper).schema;
+                                        if (!schema) {
+                                          schema = schemaWrapper.schema;
+                                        }
+                                        if (schema.$ref != null) {
+                                          schema = defsParser.$refs.get(schema.$ref);
+                                        } else if (schema.items != null && schema.items.$ref != null) {
+                                            schema.items = defsParser.$refs.get(schema.items.$ref);
+                                        } else {
+                                          schemaWrapper.definitions = Object.assign({}, defs);
+                                          $RefParser.dereference(schemaWrapper).catch(function(err) {
+                                            console.log(err);
+                                          });
+                                        }
+
+                                        var view = new JSONSchemaView(schema, 3);
+                                        $('#responses-Default-archiveImport-default-schema-data').val(JSON.stringify(schema));
+                                        var result = $('#responses-Default-archiveImport-schema-default');
+                                        result.empty();
+                                        result.append(view.render());
+                                      });
+                                    </script>
+                                  </div>
+                                  <input id='responses-Default-archiveImport-default-schema-data' type='hidden' value=''></input>
+                                </div>
+                            </div>
+                        </article>
+                      </div>
+                      <hr>
                     <div id="api-Default-changePassword">
                       <article id="api-Default-changePassword-0" data-group="User" data-name="changePassword" data-version="0">
                         <div class="pull-left">
@@ -1498,7 +3711,7 @@ ul.nav-tabs {
                         <p class="marked">Change a user&#39;s password</p>
                         <p></p>
                         <br />
-                        <pre class="prettyprint language-html prettyprinted" data-type="post"><code><span class="pln">/api/v1/users/{userID}/changepassword</span></code></pre>
+                        <pre class="prettyprint language-html prettyprinted" data-type="post"><code><span class="pln">/users/{userID}/changepassword</span></code></pre>
                         <p>
                           <h3>Usage and SDK Samples</h3>
                         </p>
@@ -1523,7 +3736,7 @@ ul.nav-tabs {
 -H "Authorization: [[apiKey]]" \
  -H "Accept: application/json" \
  -H "Content-Type: application/json" \
- "http://localhost/api/v1/api/v1/users/{userID}/changepassword" \
+ "http://localhost/api/v2/users/{userID}/changepassword" \
  -d '{
   &quot;oldPassword&quot; : &quot;oldPassword&quot;,
   &quot;newPassword&quot; : &quot;newPassword&quot;
@@ -2005,6 +4218,496 @@ $(document).ready(function() {
                         </article>
                       </div>
                       <hr>
+                    <div id="api-Default-createBoard">
+                      <article id="api-Default-createBoard-0" data-group="User" data-name="createBoard" data-version="0">
+                        <div class="pull-left">
+                          <h1>createBoard</h1>
+                          <p></p>
+                        </div>
+                        <div class="pull-right"></div>
+                        <div class="clearfix"></div>
+                        <p></p>
+                        <p class="marked">Creates a new board</p>
+                        <p></p>
+                        <br />
+                        <pre class="prettyprint language-html prettyprinted" data-type="post"><code><span class="pln">/boards</span></code></pre>
+                        <p>
+                          <h3>Usage and SDK Samples</h3>
+                        </p>
+                        <ul class="nav nav-tabs nav-tabs-examples">
+                          <li class="active"><a href="#examples-Default-createBoard-0-curl">Curl</a></li>
+                          <li class=""><a href="#examples-Default-createBoard-0-java">Java</a></li>
+                          <li class=""><a href="#examples-Default-createBoard-0-android">Android</a></li>
+                          <!--<li class=""><a href="#examples-Default-createBoard-0-groovy">Groovy</a></li>-->
+                          <li class=""><a href="#examples-Default-createBoard-0-objc">Obj-C</a></li>
+                          <li class=""><a href="#examples-Default-createBoard-0-javascript">JavaScript</a></li>
+                          <!--<li class=""><a href="#examples-Default-createBoard-0-angular">Angular</a></li>-->
+                          <li class=""><a href="#examples-Default-createBoard-0-csharp">C#</a></li>
+                          <li class=""><a href="#examples-Default-createBoard-0-php">PHP</a></li>
+                          <li class=""><a href="#examples-Default-createBoard-0-perl">Perl</a></li>
+                          <li class=""><a href="#examples-Default-createBoard-0-python">Python</a></li>
+                          <li class=""><a href="#examples-Default-createBoard-0-rust">Rust</a></li>
+                        </ul>
+
+                        <div class="tab-content">
+                          <div class="tab-pane active" id="examples-Default-createBoard-0-curl">
+                            <pre class="prettyprint"><code class="language-bsh">curl -X POST \
+-H "Authorization: [[apiKey]]" \
+ -H "Accept: application/json" \
+ -H "Content-Type: application/json" \
+ "http://localhost/api/v2/boards" \
+ -d '{
+  &quot;deleteAt&quot; : 6,
+  &quot;icon&quot; : &quot;icon&quot;,
+  &quot;description&quot; : &quot;description&quot;,
+  &quot;updateAt&quot; : 5,
+  &quot;title&quot; : &quot;title&quot;,
+  &quot;type&quot; : &quot;type&quot;,
+  &quot;createAt&quot; : 0,
+  &quot;showDescription&quot; : true,
+  &quot;createdBy&quot; : &quot;createdBy&quot;,
+  &quot;isTemplate&quot; : true,
+  &quot;teamId&quot; : &quot;teamId&quot;,
+  &quot;cardProperties&quot; : [ {
+    &quot;key&quot; : &quot;{}&quot;
+  }, {
+    &quot;key&quot; : &quot;{}&quot;
+  } ],
+  &quot;modifiedBy&quot; : &quot;modifiedBy&quot;,
+  &quot;templateVersion&quot; : 1,
+  &quot;columnCalculations&quot; : {
+    &quot;key&quot; : &quot;{}&quot;
+  },
+  &quot;id&quot; : &quot;id&quot;,
+  &quot;channelId&quot; : &quot;channelId&quot;,
+  &quot;properties&quot; : {
+    &quot;key&quot; : &quot;{}&quot;
+  }
+}'
+</code></pre>
+                          </div>
+                          <div class="tab-pane" id="examples-Default-createBoard-0-java">
+                            <pre class="prettyprint"><code class="language-java">import org.openapitools.client.*;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.model.*;
+import org.openapitools.client.api.DefaultApi;
+
+import java.io.File;
+import java.util.*;
+
+public class DefaultApiExample {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        
+        // Configure API key authorization: BearerAuth
+        ApiKeyAuth BearerAuth = (ApiKeyAuth) defaultClient.getAuthentication("BearerAuth");
+        BearerAuth.setApiKey("YOUR API KEY");
+        // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+        //BearerAuth.setApiKeyPrefix("Token");
+
+        // Create an instance of the API class
+        DefaultApi apiInstance = new DefaultApi();
+        Board body = ; // Board | 
+
+        try {
+            Board result = apiInstance.createBoard(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling DefaultApi#createBoard");
+            e.printStackTrace();
+        }
+    }
+}
+</code></pre>
+                          </div>
+
+                          <div class="tab-pane" id="examples-Default-createBoard-0-android">
+                            <pre class="prettyprint"><code class="language-java">import org.openapitools.client.api.DefaultApi;
+
+public class DefaultApiExample {
+    public static void main(String[] args) {
+        DefaultApi apiInstance = new DefaultApi();
+        Board body = ; // Board | 
+
+        try {
+            Board result = apiInstance.createBoard(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling DefaultApi#createBoard");
+            e.printStackTrace();
+        }
+    }
+}</code></pre>
+                          </div>
+  <!--
+  <div class="tab-pane" id="examples-Default-createBoard-0-groovy">
+  <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
+  </div> -->
+                            <div class="tab-pane" id="examples-Default-createBoard-0-objc">
+                              <pre class="prettyprint"><code class="language-cpp">Configuration *apiConfig = [Configuration sharedConfig];
+
+// Configure API key authorization: (authentication scheme: BearerAuth)
+[apiConfig setApiKey:@"YOUR_API_KEY" forApiKeyIdentifier:@"Authorization"];
+// Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+//[apiConfig setApiKeyPrefix:@"Bearer" forApiKeyIdentifier:@"Authorization"];
+
+
+// Create an instance of the API class
+DefaultApi *apiInstance = [[DefaultApi alloc] init];
+Board *body = ; // 
+
+[apiInstance createBoardWith:body
+              completionHandler: ^(Board output, NSError* error) {
+    if (output) {
+        NSLog(@"%@", output);
+    }
+    if (error) {
+        NSLog(@"Error: %@", error);
+    }
+}];
+</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-createBoard-0-javascript">
+                              <pre class="prettyprint"><code class="language-js">var FocalboardServer = require('focalboard_server');
+var defaultClient = FocalboardServer.ApiClient.instance;
+
+// Configure API key authorization: BearerAuth
+var BearerAuth = defaultClient.authentications['BearerAuth'];
+BearerAuth.apiKey = "YOUR API KEY";
+// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+//BearerAuth.apiKeyPrefix['Authorization'] = "Token";
+
+// Create an instance of the API class
+var api = new FocalboardServer.DefaultApi()
+var body = ; // {Board} 
+
+var callback = function(error, data, response) {
+  if (error) {
+    console.error(error);
+  } else {
+    console.log('API called successfully. Returned data: ' + data);
+  }
+};
+api.createBoard(body, callback);
+</code></pre>
+                            </div>
+
+                            <!--<div class="tab-pane" id="examples-Default-createBoard-0-angular">
+              <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
+            </div>-->
+                            <div class="tab-pane" id="examples-Default-createBoard-0-csharp">
+                              <pre class="prettyprint"><code class="language-cs">using System;
+using System.Diagnostics;
+using Org.OpenAPITools.Api;
+using Org.OpenAPITools.Client;
+using Org.OpenAPITools.Model;
+
+namespace Example
+{
+    public class createBoardExample
+    {
+        public void main()
+        {
+            // Configure API key authorization: BearerAuth
+            Configuration.Default.ApiKey.Add("Authorization", "YOUR_API_KEY");
+            // Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+            // Configuration.Default.ApiKeyPrefix.Add("Authorization", "Bearer");
+
+            // Create an instance of the API class
+            var apiInstance = new DefaultApi();
+            var body = new Board(); // Board | 
+
+            try {
+                Board result = apiInstance.createBoard(body);
+                Debug.WriteLine(result);
+            } catch (Exception e) {
+                Debug.Print("Exception when calling DefaultApi.createBoard: " + e.Message );
+            }
+        }
+    }
+}
+</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-createBoard-0-php">
+                              <pre class="prettyprint"><code class="language-php"><&#63;php
+require_once(__DIR__ . '/vendor/autoload.php');
+
+// Configure API key authorization: BearerAuth
+OpenAPITools\Client\Configuration::getDefaultConfiguration()->setApiKey('Authorization', 'YOUR_API_KEY');
+// Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+// OpenAPITools\Client\Configuration::getDefaultConfiguration()->setApiKeyPrefix('Authorization', 'Bearer');
+
+// Create an instance of the API class
+$api_instance = new OpenAPITools\Client\Api\DefaultApi();
+$body = ; // Board | 
+
+try {
+    $result = $api_instance->createBoard($body);
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling DefaultApi->createBoard: ', $e->getMessage(), PHP_EOL;
+}
+?></code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-createBoard-0-perl">
+                              <pre class="prettyprint"><code class="language-perl">use Data::Dumper;
+use WWW::OPenAPIClient::Configuration;
+use WWW::OPenAPIClient::DefaultApi;
+
+# Configure API key authorization: BearerAuth
+$WWW::OPenAPIClient::Configuration::api_key->{'Authorization'} = 'YOUR_API_KEY';
+# uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+#$WWW::OPenAPIClient::Configuration::api_key_prefix->{'Authorization'} = "Bearer";
+
+# Create an instance of the API class
+my $api_instance = WWW::OPenAPIClient::DefaultApi->new();
+my $body = WWW::OPenAPIClient::Object::Board->new(); # Board | 
+
+eval {
+    my $result = $api_instance->createBoard(body => $body);
+    print Dumper($result);
+};
+if ($@) {
+    warn "Exception when calling DefaultApi->createBoard: $@\n";
+}</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-createBoard-0-python">
+                              <pre class="prettyprint"><code class="language-python">from __future__ import print_statement
+import time
+import openapi_client
+from openapi_client.rest import ApiException
+from pprint import pprint
+
+# Configure API key authorization: BearerAuth
+openapi_client.configuration.api_key['Authorization'] = 'YOUR_API_KEY'
+# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+# openapi_client.configuration.api_key_prefix['Authorization'] = 'Bearer'
+
+# Create an instance of the API class
+api_instance = openapi_client.DefaultApi()
+body =  # Board | 
+
+try:
+    api_response = api_instance.create_board(body)
+    pprint(api_response)
+except ApiException as e:
+    print("Exception when calling DefaultApi->createBoard: %s\n" % e)</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-createBoard-0-rust">
+                              <pre class="prettyprint"><code class="language-rust">extern crate DefaultApi;
+
+pub fn main() {
+    let body = ; // Board
+
+    let mut context = DefaultApi::Context::default();
+    let result = client.createBoard(body, &context).wait();
+
+    println!("{:?}", result);
+}
+</code></pre>
+                            </div>
+                          </div>
+
+                          <h2>Scopes</h2>
+                          <table>
+                            
+                          </table>
+
+                          <h2>Parameters</h2>
+
+
+
+                            <div class="methodsubtabletitle">Body parameters</div>
+                            <table id="methodsubtable">
+                              <tr>
+                                <th width="150px">Name</th>
+                                <th>Description</th>
+                              </tr>
+                                <tr><td style="width:150px;">body <span style="color:red;">*</span></td>
+<td>
+<p class="marked">the board to create</p>
+<script>
+$(document).ready(function() {
+  var schemaWrapper = {
+  "description" : "the board to create",
+  "content" : {
+    "application/json" : {
+      "schema" : {
+        "$ref" : "#/components/schemas/Board"
+      }
+    }
+  },
+  "required" : true
+};
+
+  var schema = findNode('schema',schemaWrapper).schema;
+  if (!schema) {
+    schema = schemaWrapper.schema;
+  }
+  if (schema.$ref != null) {
+    schema = defsParser.$refs.get(schema.$ref);
+  } else {
+    schemaWrapper.definitions = Object.assign({}, defs);
+    $RefParser.dereference(schemaWrapper).catch(function(err) {
+      console.log(err);
+    });
+  }
+
+  var view = new JSONSchemaView(schema,2,{isBodyParam: true});
+  var result = $('#d2e199_createBoard_body');
+  result.empty();
+  result.append(view.render());
+});
+</script>
+<div id="d2e199_createBoard_body"></div>
+</td>
+</tr>
+
+                            </table>
+
+
+
+                          <h2>Responses</h2>
+                            <h3 id="examples-Default-createBoard-title-200"></h3>
+                            <p id="examples-Default-createBoard-description-200" class="marked"></p>
+                            <script>
+                              var responseDefault200_description = `success`;
+                              var responseDefault200_description_break = responseDefault200_description.indexOf('\n');
+                              if (responseDefault200_description_break == -1) {
+                                $("#examples-Default-createBoard-title-200").text("Status: 200 - " + responseDefault200_description);
+                              } else {
+                                $("#examples-Default-createBoard-title-200").text("Status: 200 - " + responseDefault200_description.substring(0, responseDefault200_description_break));
+                                $("#examples-Default-createBoard-description-200").html(responseDefault200_description.substring(responseDefault200_description_break));
+                              }
+                            </script>
+
+
+                            <ul id="responses-detail-Default-createBoard-200" class="nav nav-tabs nav-tabs-examples" >
+                                <li class="active">
+                                  <a data-toggle="tab" href="#responses-Default-createBoard-200-schema">Schema</a>
+                                </li>
+
+
+
+
+                            </ul>
+
+
+                            <div class="tab-content" id="responses-Default-createBoard-200-wrapper" style='margin-bottom: 10px;'>
+                                <div class="tab-pane active" id="responses-Default-createBoard-200-schema">
+                                  <div id="responses-Default-createBoard-schema-200" class="exampleStyle">
+                                    <script>
+                                      $(document).ready(function() {
+                                        var schemaWrapper = {
+  "description" : "success",
+  "content" : {
+    "application/json" : {
+      "schema" : {
+        "$ref" : "#/components/schemas/Board"
+      }
+    }
+  }
+};
+                                        var schema = findNode('schema',schemaWrapper).schema;
+                                        if (!schema) {
+                                          schema = schemaWrapper.schema;
+                                        }
+                                        if (schema.$ref != null) {
+                                          schema = defsParser.$refs.get(schema.$ref);
+                                        } else if (schema.items != null && schema.items.$ref != null) {
+                                            schema.items = defsParser.$refs.get(schema.items.$ref);
+                                        } else {
+                                          schemaWrapper.definitions = Object.assign({}, defs);
+                                          $RefParser.dereference(schemaWrapper).catch(function(err) {
+                                            console.log(err);
+                                          });
+                                        }
+
+                                        var view = new JSONSchemaView(schema, 3);
+                                        $('#responses-Default-createBoard-200-schema-data').val(JSON.stringify(schema));
+                                        var result = $('#responses-Default-createBoard-schema-200');
+                                        result.empty();
+                                        result.append(view.render());
+                                      });
+                                    </script>
+                                  </div>
+                                  <input id='responses-Default-createBoard-200-schema-data' type='hidden' value=''></input>
+                                </div>
+                            </div>
+                            <h3 id="examples-Default-createBoard-title-default"></h3>
+                            <p id="examples-Default-createBoard-description-default" class="marked"></p>
+                            <script>
+                              var responseDefaultdefault_description = `internal error`;
+                              var responseDefaultdefault_description_break = responseDefaultdefault_description.indexOf('\n');
+                              if (responseDefaultdefault_description_break == -1) {
+                                $("#examples-Default-createBoard-title-default").text("Status: default - " + responseDefaultdefault_description);
+                              } else {
+                                $("#examples-Default-createBoard-title-default").text("Status: default - " + responseDefaultdefault_description.substring(0, responseDefaultdefault_description_break));
+                                $("#examples-Default-createBoard-description-default").html(responseDefaultdefault_description.substring(responseDefaultdefault_description_break));
+                              }
+                            </script>
+
+
+                            <ul id="responses-detail-Default-createBoard-default" class="nav nav-tabs nav-tabs-examples" >
+                                <li class="active">
+                                  <a data-toggle="tab" href="#responses-Default-createBoard-default-schema">Schema</a>
+                                </li>
+
+
+
+
+                            </ul>
+
+
+                            <div class="tab-content" id="responses-Default-createBoard-default-wrapper" style='margin-bottom: 10px;'>
+                                <div class="tab-pane active" id="responses-Default-createBoard-default-schema">
+                                  <div id="responses-Default-createBoard-schema-default" class="exampleStyle">
+                                    <script>
+                                      $(document).ready(function() {
+                                        var schemaWrapper = {
+  "description" : "internal error",
+  "content" : {
+    "application/json" : {
+      "schema" : {
+        "$ref" : "#/components/schemas/ErrorResponse"
+      }
+    }
+  }
+};
+                                        var schema = findNode('schema',schemaWrapper).schema;
+                                        if (!schema) {
+                                          schema = schemaWrapper.schema;
+                                        }
+                                        if (schema.$ref != null) {
+                                          schema = defsParser.$refs.get(schema.$ref);
+                                        } else if (schema.items != null && schema.items.$ref != null) {
+                                            schema.items = defsParser.$refs.get(schema.items.$ref);
+                                        } else {
+                                          schemaWrapper.definitions = Object.assign({}, defs);
+                                          $RefParser.dereference(schemaWrapper).catch(function(err) {
+                                            console.log(err);
+                                          });
+                                        }
+
+                                        var view = new JSONSchemaView(schema, 3);
+                                        $('#responses-Default-createBoard-default-schema-data').val(JSON.stringify(schema));
+                                        var result = $('#responses-Default-createBoard-schema-default');
+                                        result.empty();
+                                        result.append(view.render());
+                                      });
+                                    </script>
+                                  </div>
+                                  <input id='responses-Default-createBoard-default-schema-data' type='hidden' value=''></input>
+                                </div>
+                            </div>
+                        </article>
+                      </div>
+                      <hr>
                     <div id="api-Default-createSubscription">
                       <article id="api-Default-createSubscription-0" data-group="User" data-name="createSubscription" data-version="0">
                         <div class="pull-left">
@@ -2017,7 +4720,7 @@ $(document).ready(function() {
                         <p class="marked"></p>
                         <p></p>
                         <br />
-                        <pre class="prettyprint language-html prettyprinted" data-type="post"><code><span class="pln">/api/v1/workspaces/{workspaceID}/subscriptions</span></code></pre>
+                        <pre class="prettyprint language-html prettyprinted" data-type="post"><code><span class="pln">/subscriptions</span></code></pre>
                         <p>
                           <h3>Usage and SDK Samples</h3>
                         </p>
@@ -2042,7 +4745,7 @@ $(document).ready(function() {
 -H "Authorization: [[apiKey]]" \
  -H "Accept: application/json" \
  -H "Content-Type: application/json" \
- "http://localhost/api/v1/api/v1/workspaces/{workspaceID}/subscriptions" \
+ "http://localhost/api/v2/subscriptions" \
  -d '{
   &quot;blockId&quot; : &quot;blockId&quot;,
   &quot;deleteAt&quot; : 6,
@@ -2050,8 +4753,7 @@ $(document).ready(function() {
   &quot;blockType&quot; : &quot;blockType&quot;,
   &quot;subscriberId&quot; : &quot;subscriberId&quot;,
   &quot;notifiedAt&quot; : 1,
-  &quot;createAt&quot; : 0,
-  &quot;workspaceId&quot; : &quot;workspaceId&quot;
+  &quot;createAt&quot; : 0
 }'
 </code></pre>
                           </div>
@@ -2076,11 +4778,10 @@ public class DefaultApiExample {
 
         // Create an instance of the API class
         DefaultApi apiInstance = new DefaultApi();
-        String workspaceID = workspaceID_example; // String | Workspace ID
         Subscription body = ; // Subscription | 
 
         try {
-            User result = apiInstance.createSubscription(workspaceID, body);
+            User result = apiInstance.createSubscription(body);
             System.out.println(result);
         } catch (ApiException e) {
             System.err.println("Exception when calling DefaultApi#createSubscription");
@@ -2097,11 +4798,10 @@ public class DefaultApiExample {
 public class DefaultApiExample {
     public static void main(String[] args) {
         DefaultApi apiInstance = new DefaultApi();
-        String workspaceID = workspaceID_example; // String | Workspace ID
         Subscription body = ; // Subscription | 
 
         try {
-            User result = apiInstance.createSubscription(workspaceID, body);
+            User result = apiInstance.createSubscription(body);
             System.out.println(result);
         } catch (ApiException e) {
             System.err.println("Exception when calling DefaultApi#createSubscription");
@@ -2125,12 +4825,10 @@ public class DefaultApiExample {
 
 // Create an instance of the API class
 DefaultApi *apiInstance = [[DefaultApi alloc] init];
-String *workspaceID = workspaceID_example; // Workspace ID (default to null)
 Subscription *body = ; // 
 
 // Creates a subscription to a block for a user. The user will receive change notifications for the block.
-[apiInstance createSubscriptionWith:workspaceID
-    body:body
+[apiInstance createSubscriptionWith:body
               completionHandler: ^(User output, NSError* error) {
     if (output) {
         NSLog(@"%@", output);
@@ -2154,7 +4852,6 @@ BearerAuth.apiKey = "YOUR API KEY";
 
 // Create an instance of the API class
 var api = new FocalboardServer.DefaultApi()
-var workspaceID = workspaceID_example; // {String} Workspace ID
 var body = ; // {Subscription} 
 
 var callback = function(error, data, response) {
@@ -2164,7 +4861,7 @@ var callback = function(error, data, response) {
     console.log('API called successfully. Returned data: ' + data);
   }
 };
-api.createSubscription(workspaceID, body, callback);
+api.createSubscription(body, callback);
 </code></pre>
                             </div>
 
@@ -2191,12 +4888,11 @@ namespace Example
 
             // Create an instance of the API class
             var apiInstance = new DefaultApi();
-            var workspaceID = workspaceID_example;  // String | Workspace ID (default to null)
             var body = new Subscription(); // Subscription | 
 
             try {
                 // Creates a subscription to a block for a user. The user will receive change notifications for the block.
-                User result = apiInstance.createSubscription(workspaceID, body);
+                User result = apiInstance.createSubscription(body);
                 Debug.WriteLine(result);
             } catch (Exception e) {
                 Debug.Print("Exception when calling DefaultApi.createSubscription: " + e.Message );
@@ -2218,11 +4914,10 @@ OpenAPITools\Client\Configuration::getDefaultConfiguration()->setApiKey('Authori
 
 // Create an instance of the API class
 $api_instance = new OpenAPITools\Client\Api\DefaultApi();
-$workspaceID = workspaceID_example; // String | Workspace ID
 $body = ; // Subscription | 
 
 try {
-    $result = $api_instance->createSubscription($workspaceID, $body);
+    $result = $api_instance->createSubscription($body);
     print_r($result);
 } catch (Exception $e) {
     echo 'Exception when calling DefaultApi->createSubscription: ', $e->getMessage(), PHP_EOL;
@@ -2242,11 +4937,10 @@ $WWW::OPenAPIClient::Configuration::api_key->{'Authorization'} = 'YOUR_API_KEY';
 
 # Create an instance of the API class
 my $api_instance = WWW::OPenAPIClient::DefaultApi->new();
-my $workspaceID = workspaceID_example; # String | Workspace ID
 my $body = WWW::OPenAPIClient::Object::Subscription->new(); # Subscription | 
 
 eval {
-    my $result = $api_instance->createSubscription(workspaceID => $workspaceID, body => $body);
+    my $result = $api_instance->createSubscription(body => $body);
     print Dumper($result);
 };
 if ($@) {
@@ -2268,12 +4962,11 @@ openapi_client.configuration.api_key['Authorization'] = 'YOUR_API_KEY'
 
 # Create an instance of the API class
 api_instance = openapi_client.DefaultApi()
-workspaceID = workspaceID_example # String | Workspace ID (default to null)
 body =  # Subscription | 
 
 try:
     # Creates a subscription to a block for a user. The user will receive change notifications for the block.
-    api_response = api_instance.create_subscription(workspaceID, body)
+    api_response = api_instance.create_subscription(body)
     pprint(api_response)
 except ApiException as e:
     print("Exception when calling DefaultApi->createSubscription: %s\n" % e)</code></pre>
@@ -2283,11 +4976,10 @@ except ApiException as e:
                               <pre class="prettyprint"><code class="language-rust">extern crate DefaultApi;
 
 pub fn main() {
-    let workspaceID = workspaceID_example; // String
     let body = ; // Subscription
 
     let mut context = DefaultApi::Context::default();
-    let result = client.createSubscription(workspaceID, body, &context).wait();
+    let result = client.createSubscription(body, &context).wait();
 
     println!("{:?}", result);
 }
@@ -2302,36 +4994,6 @@ pub fn main() {
 
                           <h2>Parameters</h2>
 
-                            <div class="methodsubtabletitle">Path parameters</div>
-                            <table id="methodsubtable">
-                                <tr>
-                                  <th width="150px">Name</th>
-                                  <th>Description</th>
-                                </tr>
-                                  <tr><td style="width:150px;">workspaceID*</td>
-<td>
-
-
-    <div id="d2e199_createSubscription_workspaceID">
-        <div class="json-schema-view">
-            <div class="primitive">
-                <span class="type">
-                    String
-                </span>
-
-                    <div class="inner description marked">
-Workspace ID
-                    </div>
-            </div>
-                <div class="inner required">
-                    Required
-                </div>
-        </div>
-    </div>
-</td>
-</tr>
-
-                            </table>
 
 
                             <div class="methodsubtabletitle">Body parameters</div>
@@ -2532,7 +5194,7 @@ $(document).ready(function() {
                         <p class="marked">Deletes a block</p>
                         <p></p>
                         <br />
-                        <pre class="prettyprint language-html prettyprinted" data-type="delete"><code><span class="pln">/api/v1/workspaces/{workspaceID}/blocks/{blockID}</span></code></pre>
+                        <pre class="prettyprint language-html prettyprinted" data-type="delete"><code><span class="pln">/boards/{boardID}/blocks/{blockID}</span></code></pre>
                         <p>
                           <h3>Usage and SDK Samples</h3>
                         </p>
@@ -2556,7 +5218,7 @@ $(document).ready(function() {
                             <pre class="prettyprint"><code class="language-bsh">curl -X DELETE \
 -H "Authorization: [[apiKey]]" \
  -H "Accept: application/json" \
- "http://localhost/api/v1/api/v1/workspaces/{workspaceID}/blocks/{blockID}"
+ "http://localhost/api/v2/boards/{boardID}/blocks/{blockID}"
 </code></pre>
                           </div>
                           <div class="tab-pane" id="examples-Default-deleteBlock-0-java">
@@ -2580,11 +5242,11 @@ public class DefaultApiExample {
 
         // Create an instance of the API class
         DefaultApi apiInstance = new DefaultApi();
-        String workspaceID = workspaceID_example; // String | Workspace ID
+        String boardID = boardID_example; // String | Board ID
         String blockID = blockID_example; // String | ID of block to delete
 
         try {
-            apiInstance.deleteBlock(workspaceID, blockID);
+            apiInstance.deleteBlock(boardID, blockID);
         } catch (ApiException e) {
             System.err.println("Exception when calling DefaultApi#deleteBlock");
             e.printStackTrace();
@@ -2600,11 +5262,11 @@ public class DefaultApiExample {
 public class DefaultApiExample {
     public static void main(String[] args) {
         DefaultApi apiInstance = new DefaultApi();
-        String workspaceID = workspaceID_example; // String | Workspace ID
+        String boardID = boardID_example; // String | Board ID
         String blockID = blockID_example; // String | ID of block to delete
 
         try {
-            apiInstance.deleteBlock(workspaceID, blockID);
+            apiInstance.deleteBlock(boardID, blockID);
         } catch (ApiException e) {
             System.err.println("Exception when calling DefaultApi#deleteBlock");
             e.printStackTrace();
@@ -2627,10 +5289,10 @@ public class DefaultApiExample {
 
 // Create an instance of the API class
 DefaultApi *apiInstance = [[DefaultApi alloc] init];
-String *workspaceID = workspaceID_example; // Workspace ID (default to null)
+String *boardID = boardID_example; // Board ID (default to null)
 String *blockID = blockID_example; // ID of block to delete (default to null)
 
-[apiInstance deleteBlockWith:workspaceID
+[apiInstance deleteBlockWith:boardID
     blockID:blockID
               completionHandler: ^(NSError* error) {
     if (error) {
@@ -2652,7 +5314,7 @@ BearerAuth.apiKey = "YOUR API KEY";
 
 // Create an instance of the API class
 var api = new FocalboardServer.DefaultApi()
-var workspaceID = workspaceID_example; // {String} Workspace ID
+var boardID = boardID_example; // {String} Board ID
 var blockID = blockID_example; // {String} ID of block to delete
 
 var callback = function(error, data, response) {
@@ -2662,7 +5324,7 @@ var callback = function(error, data, response) {
     console.log('API called successfully.');
   }
 };
-api.deleteBlock(workspaceID, blockID, callback);
+api.deleteBlock(boardID, blockID, callback);
 </code></pre>
                             </div>
 
@@ -2689,11 +5351,11 @@ namespace Example
 
             // Create an instance of the API class
             var apiInstance = new DefaultApi();
-            var workspaceID = workspaceID_example;  // String | Workspace ID (default to null)
+            var boardID = boardID_example;  // String | Board ID (default to null)
             var blockID = blockID_example;  // String | ID of block to delete (default to null)
 
             try {
-                apiInstance.deleteBlock(workspaceID, blockID);
+                apiInstance.deleteBlock(boardID, blockID);
             } catch (Exception e) {
                 Debug.Print("Exception when calling DefaultApi.deleteBlock: " + e.Message );
             }
@@ -2714,11 +5376,11 @@ OpenAPITools\Client\Configuration::getDefaultConfiguration()->setApiKey('Authori
 
 // Create an instance of the API class
 $api_instance = new OpenAPITools\Client\Api\DefaultApi();
-$workspaceID = workspaceID_example; // String | Workspace ID
+$boardID = boardID_example; // String | Board ID
 $blockID = blockID_example; // String | ID of block to delete
 
 try {
-    $api_instance->deleteBlock($workspaceID, $blockID);
+    $api_instance->deleteBlock($boardID, $blockID);
 } catch (Exception $e) {
     echo 'Exception when calling DefaultApi->deleteBlock: ', $e->getMessage(), PHP_EOL;
 }
@@ -2737,11 +5399,11 @@ $WWW::OPenAPIClient::Configuration::api_key->{'Authorization'} = 'YOUR_API_KEY';
 
 # Create an instance of the API class
 my $api_instance = WWW::OPenAPIClient::DefaultApi->new();
-my $workspaceID = workspaceID_example; # String | Workspace ID
+my $boardID = boardID_example; # String | Board ID
 my $blockID = blockID_example; # String | ID of block to delete
 
 eval {
-    $api_instance->deleteBlock(workspaceID => $workspaceID, blockID => $blockID);
+    $api_instance->deleteBlock(boardID => $boardID, blockID => $blockID);
 };
 if ($@) {
     warn "Exception when calling DefaultApi->deleteBlock: $@\n";
@@ -2762,11 +5424,11 @@ openapi_client.configuration.api_key['Authorization'] = 'YOUR_API_KEY'
 
 # Create an instance of the API class
 api_instance = openapi_client.DefaultApi()
-workspaceID = workspaceID_example # String | Workspace ID (default to null)
+boardID = boardID_example # String | Board ID (default to null)
 blockID = blockID_example # String | ID of block to delete (default to null)
 
 try:
-    api_instance.delete_block(workspaceID, blockID)
+    api_instance.delete_block(boardID, blockID)
 except ApiException as e:
     print("Exception when calling DefaultApi->deleteBlock: %s\n" % e)</code></pre>
                             </div>
@@ -2775,11 +5437,11 @@ except ApiException as e:
                               <pre class="prettyprint"><code class="language-rust">extern crate DefaultApi;
 
 pub fn main() {
-    let workspaceID = workspaceID_example; // String
+    let boardID = boardID_example; // String
     let blockID = blockID_example; // String
 
     let mut context = DefaultApi::Context::default();
-    let result = client.deleteBlock(workspaceID, blockID, &context).wait();
+    let result = client.deleteBlock(boardID, blockID, &context).wait();
 
     println!("{:?}", result);
 }
@@ -2800,11 +5462,11 @@ pub fn main() {
                                   <th width="150px">Name</th>
                                   <th>Description</th>
                                 </tr>
-                                  <tr><td style="width:150px;">workspaceID*</td>
+                                  <tr><td style="width:150px;">boardID*</td>
 <td>
 
 
-    <div id="d2e199_deleteBlock_workspaceID">
+    <div id="d2e199_deleteBlock_boardID">
         <div class="json-schema-view">
             <div class="primitive">
                 <span class="type">
@@ -2812,7 +5474,7 @@ pub fn main() {
                 </span>
 
                     <div class="inner description marked">
-Workspace ID
+Board ID
                     </div>
             </div>
                 <div class="inner required">
@@ -2874,6 +5536,28 @@ ID of block to delete
 
 
                             <div class="tab-content" id="responses-Default-deleteBlock-200-wrapper" style='margin-bottom: 10px;'>
+                            </div>
+                            <h3 id="examples-Default-deleteBlock-title-404"></h3>
+                            <p id="examples-Default-deleteBlock-description-404" class="marked"></p>
+                            <script>
+                              var responseDefault404_description = `block not found`;
+                              var responseDefault404_description_break = responseDefault404_description.indexOf('\n');
+                              if (responseDefault404_description_break == -1) {
+                                $("#examples-Default-deleteBlock-title-404").text("Status: 404 - " + responseDefault404_description);
+                              } else {
+                                $("#examples-Default-deleteBlock-title-404").text("Status: 404 - " + responseDefault404_description.substring(0, responseDefault404_description_break));
+                                $("#examples-Default-deleteBlock-description-404").html(responseDefault404_description.substring(responseDefault404_description_break));
+                              }
+                            </script>
+
+
+                            <ul id="responses-detail-Default-deleteBlock-404" class="nav nav-tabs nav-tabs-examples" >
+
+
+                            </ul>
+
+
+                            <div class="tab-content" id="responses-Default-deleteBlock-404-wrapper" style='margin-bottom: 10px;'>
                             </div>
                             <h3 id="examples-Default-deleteBlock-title-default"></h3>
                             <p id="examples-Default-deleteBlock-description-default" class="marked"></p>
@@ -2944,6 +5628,1278 @@ ID of block to delete
                         </article>
                       </div>
                       <hr>
+                    <div id="api-Default-deleteBoard">
+                      <article id="api-Default-deleteBoard-0" data-group="User" data-name="deleteBoard" data-version="0">
+                        <div class="pull-left">
+                          <h1>deleteBoard</h1>
+                          <p></p>
+                        </div>
+                        <div class="pull-right"></div>
+                        <div class="clearfix"></div>
+                        <p></p>
+                        <p class="marked">Removes a board</p>
+                        <p></p>
+                        <br />
+                        <pre class="prettyprint language-html prettyprinted" data-type="delete"><code><span class="pln">/boards/{boardID}</span></code></pre>
+                        <p>
+                          <h3>Usage and SDK Samples</h3>
+                        </p>
+                        <ul class="nav nav-tabs nav-tabs-examples">
+                          <li class="active"><a href="#examples-Default-deleteBoard-0-curl">Curl</a></li>
+                          <li class=""><a href="#examples-Default-deleteBoard-0-java">Java</a></li>
+                          <li class=""><a href="#examples-Default-deleteBoard-0-android">Android</a></li>
+                          <!--<li class=""><a href="#examples-Default-deleteBoard-0-groovy">Groovy</a></li>-->
+                          <li class=""><a href="#examples-Default-deleteBoard-0-objc">Obj-C</a></li>
+                          <li class=""><a href="#examples-Default-deleteBoard-0-javascript">JavaScript</a></li>
+                          <!--<li class=""><a href="#examples-Default-deleteBoard-0-angular">Angular</a></li>-->
+                          <li class=""><a href="#examples-Default-deleteBoard-0-csharp">C#</a></li>
+                          <li class=""><a href="#examples-Default-deleteBoard-0-php">PHP</a></li>
+                          <li class=""><a href="#examples-Default-deleteBoard-0-perl">Perl</a></li>
+                          <li class=""><a href="#examples-Default-deleteBoard-0-python">Python</a></li>
+                          <li class=""><a href="#examples-Default-deleteBoard-0-rust">Rust</a></li>
+                        </ul>
+
+                        <div class="tab-content">
+                          <div class="tab-pane active" id="examples-Default-deleteBoard-0-curl">
+                            <pre class="prettyprint"><code class="language-bsh">curl -X DELETE \
+-H "Authorization: [[apiKey]]" \
+ -H "Accept: application/json" \
+ "http://localhost/api/v2/boards/{boardID}"
+</code></pre>
+                          </div>
+                          <div class="tab-pane" id="examples-Default-deleteBoard-0-java">
+                            <pre class="prettyprint"><code class="language-java">import org.openapitools.client.*;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.model.*;
+import org.openapitools.client.api.DefaultApi;
+
+import java.io.File;
+import java.util.*;
+
+public class DefaultApiExample {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        
+        // Configure API key authorization: BearerAuth
+        ApiKeyAuth BearerAuth = (ApiKeyAuth) defaultClient.getAuthentication("BearerAuth");
+        BearerAuth.setApiKey("YOUR API KEY");
+        // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+        //BearerAuth.setApiKeyPrefix("Token");
+
+        // Create an instance of the API class
+        DefaultApi apiInstance = new DefaultApi();
+        String boardID = boardID_example; // String | Board ID
+
+        try {
+            apiInstance.deleteBoard(boardID);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling DefaultApi#deleteBoard");
+            e.printStackTrace();
+        }
+    }
+}
+</code></pre>
+                          </div>
+
+                          <div class="tab-pane" id="examples-Default-deleteBoard-0-android">
+                            <pre class="prettyprint"><code class="language-java">import org.openapitools.client.api.DefaultApi;
+
+public class DefaultApiExample {
+    public static void main(String[] args) {
+        DefaultApi apiInstance = new DefaultApi();
+        String boardID = boardID_example; // String | Board ID
+
+        try {
+            apiInstance.deleteBoard(boardID);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling DefaultApi#deleteBoard");
+            e.printStackTrace();
+        }
+    }
+}</code></pre>
+                          </div>
+  <!--
+  <div class="tab-pane" id="examples-Default-deleteBoard-0-groovy">
+  <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
+  </div> -->
+                            <div class="tab-pane" id="examples-Default-deleteBoard-0-objc">
+                              <pre class="prettyprint"><code class="language-cpp">Configuration *apiConfig = [Configuration sharedConfig];
+
+// Configure API key authorization: (authentication scheme: BearerAuth)
+[apiConfig setApiKey:@"YOUR_API_KEY" forApiKeyIdentifier:@"Authorization"];
+// Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+//[apiConfig setApiKeyPrefix:@"Bearer" forApiKeyIdentifier:@"Authorization"];
+
+
+// Create an instance of the API class
+DefaultApi *apiInstance = [[DefaultApi alloc] init];
+String *boardID = boardID_example; // Board ID (default to null)
+
+[apiInstance deleteBoardWith:boardID
+              completionHandler: ^(NSError* error) {
+    if (error) {
+        NSLog(@"Error: %@", error);
+    }
+}];
+</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-deleteBoard-0-javascript">
+                              <pre class="prettyprint"><code class="language-js">var FocalboardServer = require('focalboard_server');
+var defaultClient = FocalboardServer.ApiClient.instance;
+
+// Configure API key authorization: BearerAuth
+var BearerAuth = defaultClient.authentications['BearerAuth'];
+BearerAuth.apiKey = "YOUR API KEY";
+// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+//BearerAuth.apiKeyPrefix['Authorization'] = "Token";
+
+// Create an instance of the API class
+var api = new FocalboardServer.DefaultApi()
+var boardID = boardID_example; // {String} Board ID
+
+var callback = function(error, data, response) {
+  if (error) {
+    console.error(error);
+  } else {
+    console.log('API called successfully.');
+  }
+};
+api.deleteBoard(boardID, callback);
+</code></pre>
+                            </div>
+
+                            <!--<div class="tab-pane" id="examples-Default-deleteBoard-0-angular">
+              <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
+            </div>-->
+                            <div class="tab-pane" id="examples-Default-deleteBoard-0-csharp">
+                              <pre class="prettyprint"><code class="language-cs">using System;
+using System.Diagnostics;
+using Org.OpenAPITools.Api;
+using Org.OpenAPITools.Client;
+using Org.OpenAPITools.Model;
+
+namespace Example
+{
+    public class deleteBoardExample
+    {
+        public void main()
+        {
+            // Configure API key authorization: BearerAuth
+            Configuration.Default.ApiKey.Add("Authorization", "YOUR_API_KEY");
+            // Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+            // Configuration.Default.ApiKeyPrefix.Add("Authorization", "Bearer");
+
+            // Create an instance of the API class
+            var apiInstance = new DefaultApi();
+            var boardID = boardID_example;  // String | Board ID (default to null)
+
+            try {
+                apiInstance.deleteBoard(boardID);
+            } catch (Exception e) {
+                Debug.Print("Exception when calling DefaultApi.deleteBoard: " + e.Message );
+            }
+        }
+    }
+}
+</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-deleteBoard-0-php">
+                              <pre class="prettyprint"><code class="language-php"><&#63;php
+require_once(__DIR__ . '/vendor/autoload.php');
+
+// Configure API key authorization: BearerAuth
+OpenAPITools\Client\Configuration::getDefaultConfiguration()->setApiKey('Authorization', 'YOUR_API_KEY');
+// Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+// OpenAPITools\Client\Configuration::getDefaultConfiguration()->setApiKeyPrefix('Authorization', 'Bearer');
+
+// Create an instance of the API class
+$api_instance = new OpenAPITools\Client\Api\DefaultApi();
+$boardID = boardID_example; // String | Board ID
+
+try {
+    $api_instance->deleteBoard($boardID);
+} catch (Exception $e) {
+    echo 'Exception when calling DefaultApi->deleteBoard: ', $e->getMessage(), PHP_EOL;
+}
+?></code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-deleteBoard-0-perl">
+                              <pre class="prettyprint"><code class="language-perl">use Data::Dumper;
+use WWW::OPenAPIClient::Configuration;
+use WWW::OPenAPIClient::DefaultApi;
+
+# Configure API key authorization: BearerAuth
+$WWW::OPenAPIClient::Configuration::api_key->{'Authorization'} = 'YOUR_API_KEY';
+# uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+#$WWW::OPenAPIClient::Configuration::api_key_prefix->{'Authorization'} = "Bearer";
+
+# Create an instance of the API class
+my $api_instance = WWW::OPenAPIClient::DefaultApi->new();
+my $boardID = boardID_example; # String | Board ID
+
+eval {
+    $api_instance->deleteBoard(boardID => $boardID);
+};
+if ($@) {
+    warn "Exception when calling DefaultApi->deleteBoard: $@\n";
+}</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-deleteBoard-0-python">
+                              <pre class="prettyprint"><code class="language-python">from __future__ import print_statement
+import time
+import openapi_client
+from openapi_client.rest import ApiException
+from pprint import pprint
+
+# Configure API key authorization: BearerAuth
+openapi_client.configuration.api_key['Authorization'] = 'YOUR_API_KEY'
+# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+# openapi_client.configuration.api_key_prefix['Authorization'] = 'Bearer'
+
+# Create an instance of the API class
+api_instance = openapi_client.DefaultApi()
+boardID = boardID_example # String | Board ID (default to null)
+
+try:
+    api_instance.delete_board(boardID)
+except ApiException as e:
+    print("Exception when calling DefaultApi->deleteBoard: %s\n" % e)</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-deleteBoard-0-rust">
+                              <pre class="prettyprint"><code class="language-rust">extern crate DefaultApi;
+
+pub fn main() {
+    let boardID = boardID_example; // String
+
+    let mut context = DefaultApi::Context::default();
+    let result = client.deleteBoard(boardID, &context).wait();
+
+    println!("{:?}", result);
+}
+</code></pre>
+                            </div>
+                          </div>
+
+                          <h2>Scopes</h2>
+                          <table>
+                            
+                          </table>
+
+                          <h2>Parameters</h2>
+
+                            <div class="methodsubtabletitle">Path parameters</div>
+                            <table id="methodsubtable">
+                                <tr>
+                                  <th width="150px">Name</th>
+                                  <th>Description</th>
+                                </tr>
+                                  <tr><td style="width:150px;">boardID*</td>
+<td>
+
+
+    <div id="d2e199_deleteBoard_boardID">
+        <div class="json-schema-view">
+            <div class="primitive">
+                <span class="type">
+                    String
+                </span>
+
+                    <div class="inner description marked">
+Board ID
+                    </div>
+            </div>
+                <div class="inner required">
+                    Required
+                </div>
+        </div>
+    </div>
+</td>
+</tr>
+
+                            </table>
+
+
+
+
+
+                          <h2>Responses</h2>
+                            <h3 id="examples-Default-deleteBoard-title-200"></h3>
+                            <p id="examples-Default-deleteBoard-description-200" class="marked"></p>
+                            <script>
+                              var responseDefault200_description = `success`;
+                              var responseDefault200_description_break = responseDefault200_description.indexOf('\n');
+                              if (responseDefault200_description_break == -1) {
+                                $("#examples-Default-deleteBoard-title-200").text("Status: 200 - " + responseDefault200_description);
+                              } else {
+                                $("#examples-Default-deleteBoard-title-200").text("Status: 200 - " + responseDefault200_description.substring(0, responseDefault200_description_break));
+                                $("#examples-Default-deleteBoard-description-200").html(responseDefault200_description.substring(responseDefault200_description_break));
+                              }
+                            </script>
+
+
+                            <ul id="responses-detail-Default-deleteBoard-200" class="nav nav-tabs nav-tabs-examples" >
+
+
+                            </ul>
+
+
+                            <div class="tab-content" id="responses-Default-deleteBoard-200-wrapper" style='margin-bottom: 10px;'>
+                            </div>
+                            <h3 id="examples-Default-deleteBoard-title-404"></h3>
+                            <p id="examples-Default-deleteBoard-description-404" class="marked"></p>
+                            <script>
+                              var responseDefault404_description = `board not found`;
+                              var responseDefault404_description_break = responseDefault404_description.indexOf('\n');
+                              if (responseDefault404_description_break == -1) {
+                                $("#examples-Default-deleteBoard-title-404").text("Status: 404 - " + responseDefault404_description);
+                              } else {
+                                $("#examples-Default-deleteBoard-title-404").text("Status: 404 - " + responseDefault404_description.substring(0, responseDefault404_description_break));
+                                $("#examples-Default-deleteBoard-description-404").html(responseDefault404_description.substring(responseDefault404_description_break));
+                              }
+                            </script>
+
+
+                            <ul id="responses-detail-Default-deleteBoard-404" class="nav nav-tabs nav-tabs-examples" >
+
+
+                            </ul>
+
+
+                            <div class="tab-content" id="responses-Default-deleteBoard-404-wrapper" style='margin-bottom: 10px;'>
+                            </div>
+                            <h3 id="examples-Default-deleteBoard-title-default"></h3>
+                            <p id="examples-Default-deleteBoard-description-default" class="marked"></p>
+                            <script>
+                              var responseDefaultdefault_description = `internal error`;
+                              var responseDefaultdefault_description_break = responseDefaultdefault_description.indexOf('\n');
+                              if (responseDefaultdefault_description_break == -1) {
+                                $("#examples-Default-deleteBoard-title-default").text("Status: default - " + responseDefaultdefault_description);
+                              } else {
+                                $("#examples-Default-deleteBoard-title-default").text("Status: default - " + responseDefaultdefault_description.substring(0, responseDefaultdefault_description_break));
+                                $("#examples-Default-deleteBoard-description-default").html(responseDefaultdefault_description.substring(responseDefaultdefault_description_break));
+                              }
+                            </script>
+
+
+                            <ul id="responses-detail-Default-deleteBoard-default" class="nav nav-tabs nav-tabs-examples" >
+                                <li class="active">
+                                  <a data-toggle="tab" href="#responses-Default-deleteBoard-default-schema">Schema</a>
+                                </li>
+
+
+
+
+                            </ul>
+
+
+                            <div class="tab-content" id="responses-Default-deleteBoard-default-wrapper" style='margin-bottom: 10px;'>
+                                <div class="tab-pane active" id="responses-Default-deleteBoard-default-schema">
+                                  <div id="responses-Default-deleteBoard-schema-default" class="exampleStyle">
+                                    <script>
+                                      $(document).ready(function() {
+                                        var schemaWrapper = {
+  "description" : "internal error",
+  "content" : {
+    "application/json" : {
+      "schema" : {
+        "$ref" : "#/components/schemas/ErrorResponse"
+      }
+    }
+  }
+};
+                                        var schema = findNode('schema',schemaWrapper).schema;
+                                        if (!schema) {
+                                          schema = schemaWrapper.schema;
+                                        }
+                                        if (schema.$ref != null) {
+                                          schema = defsParser.$refs.get(schema.$ref);
+                                        } else if (schema.items != null && schema.items.$ref != null) {
+                                            schema.items = defsParser.$refs.get(schema.items.$ref);
+                                        } else {
+                                          schemaWrapper.definitions = Object.assign({}, defs);
+                                          $RefParser.dereference(schemaWrapper).catch(function(err) {
+                                            console.log(err);
+                                          });
+                                        }
+
+                                        var view = new JSONSchemaView(schema, 3);
+                                        $('#responses-Default-deleteBoard-default-schema-data').val(JSON.stringify(schema));
+                                        var result = $('#responses-Default-deleteBoard-schema-default');
+                                        result.empty();
+                                        result.append(view.render());
+                                      });
+                                    </script>
+                                  </div>
+                                  <input id='responses-Default-deleteBoard-default-schema-data' type='hidden' value=''></input>
+                                </div>
+                            </div>
+                        </article>
+                      </div>
+                      <hr>
+                    <div id="api-Default-deleteBoardsAndBlocks">
+                      <article id="api-Default-deleteBoardsAndBlocks-0" data-group="User" data-name="deleteBoardsAndBlocks" data-version="0">
+                        <div class="pull-left">
+                          <h1>deleteBoardsAndBlocks</h1>
+                          <p></p>
+                        </div>
+                        <div class="pull-right"></div>
+                        <div class="clearfix"></div>
+                        <p></p>
+                        <p class="marked">Deletes boards and blocks</p>
+                        <p></p>
+                        <br />
+                        <pre class="prettyprint language-html prettyprinted" data-type="delete"><code><span class="pln">/boards-and-blocks</span></code></pre>
+                        <p>
+                          <h3>Usage and SDK Samples</h3>
+                        </p>
+                        <ul class="nav nav-tabs nav-tabs-examples">
+                          <li class="active"><a href="#examples-Default-deleteBoardsAndBlocks-0-curl">Curl</a></li>
+                          <li class=""><a href="#examples-Default-deleteBoardsAndBlocks-0-java">Java</a></li>
+                          <li class=""><a href="#examples-Default-deleteBoardsAndBlocks-0-android">Android</a></li>
+                          <!--<li class=""><a href="#examples-Default-deleteBoardsAndBlocks-0-groovy">Groovy</a></li>-->
+                          <li class=""><a href="#examples-Default-deleteBoardsAndBlocks-0-objc">Obj-C</a></li>
+                          <li class=""><a href="#examples-Default-deleteBoardsAndBlocks-0-javascript">JavaScript</a></li>
+                          <!--<li class=""><a href="#examples-Default-deleteBoardsAndBlocks-0-angular">Angular</a></li>-->
+                          <li class=""><a href="#examples-Default-deleteBoardsAndBlocks-0-csharp">C#</a></li>
+                          <li class=""><a href="#examples-Default-deleteBoardsAndBlocks-0-php">PHP</a></li>
+                          <li class=""><a href="#examples-Default-deleteBoardsAndBlocks-0-perl">Perl</a></li>
+                          <li class=""><a href="#examples-Default-deleteBoardsAndBlocks-0-python">Python</a></li>
+                          <li class=""><a href="#examples-Default-deleteBoardsAndBlocks-0-rust">Rust</a></li>
+                        </ul>
+
+                        <div class="tab-content">
+                          <div class="tab-pane active" id="examples-Default-deleteBoardsAndBlocks-0-curl">
+                            <pre class="prettyprint"><code class="language-bsh">curl -X DELETE \
+-H "Authorization: [[apiKey]]" \
+ -H "Accept: application/json" \
+ -H "Content-Type: application/json" \
+ "http://localhost/api/v2/boards-and-blocks" \
+ -d '{
+  &quot;blocks&quot; : [ &quot;blocks&quot;, &quot;blocks&quot; ],
+  &quot;boards&quot; : [ &quot;boards&quot;, &quot;boards&quot; ]
+}'
+</code></pre>
+                          </div>
+                          <div class="tab-pane" id="examples-Default-deleteBoardsAndBlocks-0-java">
+                            <pre class="prettyprint"><code class="language-java">import org.openapitools.client.*;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.model.*;
+import org.openapitools.client.api.DefaultApi;
+
+import java.io.File;
+import java.util.*;
+
+public class DefaultApiExample {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        
+        // Configure API key authorization: BearerAuth
+        ApiKeyAuth BearerAuth = (ApiKeyAuth) defaultClient.getAuthentication("BearerAuth");
+        BearerAuth.setApiKey("YOUR API KEY");
+        // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+        //BearerAuth.setApiKeyPrefix("Token");
+
+        // Create an instance of the API class
+        DefaultApi apiInstance = new DefaultApi();
+        DeleteBoardsAndBlocks body = ; // DeleteBoardsAndBlocks | 
+
+        try {
+            apiInstance.deleteBoardsAndBlocks(body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling DefaultApi#deleteBoardsAndBlocks");
+            e.printStackTrace();
+        }
+    }
+}
+</code></pre>
+                          </div>
+
+                          <div class="tab-pane" id="examples-Default-deleteBoardsAndBlocks-0-android">
+                            <pre class="prettyprint"><code class="language-java">import org.openapitools.client.api.DefaultApi;
+
+public class DefaultApiExample {
+    public static void main(String[] args) {
+        DefaultApi apiInstance = new DefaultApi();
+        DeleteBoardsAndBlocks body = ; // DeleteBoardsAndBlocks | 
+
+        try {
+            apiInstance.deleteBoardsAndBlocks(body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling DefaultApi#deleteBoardsAndBlocks");
+            e.printStackTrace();
+        }
+    }
+}</code></pre>
+                          </div>
+  <!--
+  <div class="tab-pane" id="examples-Default-deleteBoardsAndBlocks-0-groovy">
+  <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
+  </div> -->
+                            <div class="tab-pane" id="examples-Default-deleteBoardsAndBlocks-0-objc">
+                              <pre class="prettyprint"><code class="language-cpp">Configuration *apiConfig = [Configuration sharedConfig];
+
+// Configure API key authorization: (authentication scheme: BearerAuth)
+[apiConfig setApiKey:@"YOUR_API_KEY" forApiKeyIdentifier:@"Authorization"];
+// Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+//[apiConfig setApiKeyPrefix:@"Bearer" forApiKeyIdentifier:@"Authorization"];
+
+
+// Create an instance of the API class
+DefaultApi *apiInstance = [[DefaultApi alloc] init];
+DeleteBoardsAndBlocks *body = ; // 
+
+[apiInstance deleteBoardsAndBlocksWith:body
+              completionHandler: ^(NSError* error) {
+    if (error) {
+        NSLog(@"Error: %@", error);
+    }
+}];
+</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-deleteBoardsAndBlocks-0-javascript">
+                              <pre class="prettyprint"><code class="language-js">var FocalboardServer = require('focalboard_server');
+var defaultClient = FocalboardServer.ApiClient.instance;
+
+// Configure API key authorization: BearerAuth
+var BearerAuth = defaultClient.authentications['BearerAuth'];
+BearerAuth.apiKey = "YOUR API KEY";
+// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+//BearerAuth.apiKeyPrefix['Authorization'] = "Token";
+
+// Create an instance of the API class
+var api = new FocalboardServer.DefaultApi()
+var body = ; // {DeleteBoardsAndBlocks} 
+
+var callback = function(error, data, response) {
+  if (error) {
+    console.error(error);
+  } else {
+    console.log('API called successfully.');
+  }
+};
+api.deleteBoardsAndBlocks(body, callback);
+</code></pre>
+                            </div>
+
+                            <!--<div class="tab-pane" id="examples-Default-deleteBoardsAndBlocks-0-angular">
+              <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
+            </div>-->
+                            <div class="tab-pane" id="examples-Default-deleteBoardsAndBlocks-0-csharp">
+                              <pre class="prettyprint"><code class="language-cs">using System;
+using System.Diagnostics;
+using Org.OpenAPITools.Api;
+using Org.OpenAPITools.Client;
+using Org.OpenAPITools.Model;
+
+namespace Example
+{
+    public class deleteBoardsAndBlocksExample
+    {
+        public void main()
+        {
+            // Configure API key authorization: BearerAuth
+            Configuration.Default.ApiKey.Add("Authorization", "YOUR_API_KEY");
+            // Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+            // Configuration.Default.ApiKeyPrefix.Add("Authorization", "Bearer");
+
+            // Create an instance of the API class
+            var apiInstance = new DefaultApi();
+            var body = new DeleteBoardsAndBlocks(); // DeleteBoardsAndBlocks | 
+
+            try {
+                apiInstance.deleteBoardsAndBlocks(body);
+            } catch (Exception e) {
+                Debug.Print("Exception when calling DefaultApi.deleteBoardsAndBlocks: " + e.Message );
+            }
+        }
+    }
+}
+</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-deleteBoardsAndBlocks-0-php">
+                              <pre class="prettyprint"><code class="language-php"><&#63;php
+require_once(__DIR__ . '/vendor/autoload.php');
+
+// Configure API key authorization: BearerAuth
+OpenAPITools\Client\Configuration::getDefaultConfiguration()->setApiKey('Authorization', 'YOUR_API_KEY');
+// Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+// OpenAPITools\Client\Configuration::getDefaultConfiguration()->setApiKeyPrefix('Authorization', 'Bearer');
+
+// Create an instance of the API class
+$api_instance = new OpenAPITools\Client\Api\DefaultApi();
+$body = ; // DeleteBoardsAndBlocks | 
+
+try {
+    $api_instance->deleteBoardsAndBlocks($body);
+} catch (Exception $e) {
+    echo 'Exception when calling DefaultApi->deleteBoardsAndBlocks: ', $e->getMessage(), PHP_EOL;
+}
+?></code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-deleteBoardsAndBlocks-0-perl">
+                              <pre class="prettyprint"><code class="language-perl">use Data::Dumper;
+use WWW::OPenAPIClient::Configuration;
+use WWW::OPenAPIClient::DefaultApi;
+
+# Configure API key authorization: BearerAuth
+$WWW::OPenAPIClient::Configuration::api_key->{'Authorization'} = 'YOUR_API_KEY';
+# uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+#$WWW::OPenAPIClient::Configuration::api_key_prefix->{'Authorization'} = "Bearer";
+
+# Create an instance of the API class
+my $api_instance = WWW::OPenAPIClient::DefaultApi->new();
+my $body = WWW::OPenAPIClient::Object::DeleteBoardsAndBlocks->new(); # DeleteBoardsAndBlocks | 
+
+eval {
+    $api_instance->deleteBoardsAndBlocks(body => $body);
+};
+if ($@) {
+    warn "Exception when calling DefaultApi->deleteBoardsAndBlocks: $@\n";
+}</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-deleteBoardsAndBlocks-0-python">
+                              <pre class="prettyprint"><code class="language-python">from __future__ import print_statement
+import time
+import openapi_client
+from openapi_client.rest import ApiException
+from pprint import pprint
+
+# Configure API key authorization: BearerAuth
+openapi_client.configuration.api_key['Authorization'] = 'YOUR_API_KEY'
+# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+# openapi_client.configuration.api_key_prefix['Authorization'] = 'Bearer'
+
+# Create an instance of the API class
+api_instance = openapi_client.DefaultApi()
+body =  # DeleteBoardsAndBlocks | 
+
+try:
+    api_instance.delete_boards_and_blocks(body)
+except ApiException as e:
+    print("Exception when calling DefaultApi->deleteBoardsAndBlocks: %s\n" % e)</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-deleteBoardsAndBlocks-0-rust">
+                              <pre class="prettyprint"><code class="language-rust">extern crate DefaultApi;
+
+pub fn main() {
+    let body = ; // DeleteBoardsAndBlocks
+
+    let mut context = DefaultApi::Context::default();
+    let result = client.deleteBoardsAndBlocks(body, &context).wait();
+
+    println!("{:?}", result);
+}
+</code></pre>
+                            </div>
+                          </div>
+
+                          <h2>Scopes</h2>
+                          <table>
+                            
+                          </table>
+
+                          <h2>Parameters</h2>
+
+
+
+                            <div class="methodsubtabletitle">Body parameters</div>
+                            <table id="methodsubtable">
+                              <tr>
+                                <th width="150px">Name</th>
+                                <th>Description</th>
+                              </tr>
+                                <tr><td style="width:150px;">body <span style="color:red;">*</span></td>
+<td>
+<p class="marked">the boards and blocks to delete</p>
+<script>
+$(document).ready(function() {
+  var schemaWrapper = {
+  "description" : "the boards and blocks to delete",
+  "content" : {
+    "application/json" : {
+      "schema" : {
+        "$ref" : "#/components/schemas/DeleteBoardsAndBlocks"
+      }
+    }
+  },
+  "required" : true
+};
+
+  var schema = findNode('schema',schemaWrapper).schema;
+  if (!schema) {
+    schema = schemaWrapper.schema;
+  }
+  if (schema.$ref != null) {
+    schema = defsParser.$refs.get(schema.$ref);
+  } else {
+    schemaWrapper.definitions = Object.assign({}, defs);
+    $RefParser.dereference(schemaWrapper).catch(function(err) {
+      console.log(err);
+    });
+  }
+
+  var view = new JSONSchemaView(schema,2,{isBodyParam: true});
+  var result = $('#d2e199_deleteBoardsAndBlocks_body');
+  result.empty();
+  result.append(view.render());
+});
+</script>
+<div id="d2e199_deleteBoardsAndBlocks_body"></div>
+</td>
+</tr>
+
+                            </table>
+
+
+
+                          <h2>Responses</h2>
+                            <h3 id="examples-Default-deleteBoardsAndBlocks-title-200"></h3>
+                            <p id="examples-Default-deleteBoardsAndBlocks-description-200" class="marked"></p>
+                            <script>
+                              var responseDefault200_description = `success`;
+                              var responseDefault200_description_break = responseDefault200_description.indexOf('\n');
+                              if (responseDefault200_description_break == -1) {
+                                $("#examples-Default-deleteBoardsAndBlocks-title-200").text("Status: 200 - " + responseDefault200_description);
+                              } else {
+                                $("#examples-Default-deleteBoardsAndBlocks-title-200").text("Status: 200 - " + responseDefault200_description.substring(0, responseDefault200_description_break));
+                                $("#examples-Default-deleteBoardsAndBlocks-description-200").html(responseDefault200_description.substring(responseDefault200_description_break));
+                              }
+                            </script>
+
+
+                            <ul id="responses-detail-Default-deleteBoardsAndBlocks-200" class="nav nav-tabs nav-tabs-examples" >
+
+
+                            </ul>
+
+
+                            <div class="tab-content" id="responses-Default-deleteBoardsAndBlocks-200-wrapper" style='margin-bottom: 10px;'>
+                            </div>
+                            <h3 id="examples-Default-deleteBoardsAndBlocks-title-default"></h3>
+                            <p id="examples-Default-deleteBoardsAndBlocks-description-default" class="marked"></p>
+                            <script>
+                              var responseDefaultdefault_description = `internal error`;
+                              var responseDefaultdefault_description_break = responseDefaultdefault_description.indexOf('\n');
+                              if (responseDefaultdefault_description_break == -1) {
+                                $("#examples-Default-deleteBoardsAndBlocks-title-default").text("Status: default - " + responseDefaultdefault_description);
+                              } else {
+                                $("#examples-Default-deleteBoardsAndBlocks-title-default").text("Status: default - " + responseDefaultdefault_description.substring(0, responseDefaultdefault_description_break));
+                                $("#examples-Default-deleteBoardsAndBlocks-description-default").html(responseDefaultdefault_description.substring(responseDefaultdefault_description_break));
+                              }
+                            </script>
+
+
+                            <ul id="responses-detail-Default-deleteBoardsAndBlocks-default" class="nav nav-tabs nav-tabs-examples" >
+                                <li class="active">
+                                  <a data-toggle="tab" href="#responses-Default-deleteBoardsAndBlocks-default-schema">Schema</a>
+                                </li>
+
+
+
+
+                            </ul>
+
+
+                            <div class="tab-content" id="responses-Default-deleteBoardsAndBlocks-default-wrapper" style='margin-bottom: 10px;'>
+                                <div class="tab-pane active" id="responses-Default-deleteBoardsAndBlocks-default-schema">
+                                  <div id="responses-Default-deleteBoardsAndBlocks-schema-default" class="exampleStyle">
+                                    <script>
+                                      $(document).ready(function() {
+                                        var schemaWrapper = {
+  "description" : "internal error",
+  "content" : {
+    "application/json" : {
+      "schema" : {
+        "$ref" : "#/components/schemas/ErrorResponse"
+      }
+    }
+  }
+};
+                                        var schema = findNode('schema',schemaWrapper).schema;
+                                        if (!schema) {
+                                          schema = schemaWrapper.schema;
+                                        }
+                                        if (schema.$ref != null) {
+                                          schema = defsParser.$refs.get(schema.$ref);
+                                        } else if (schema.items != null && schema.items.$ref != null) {
+                                            schema.items = defsParser.$refs.get(schema.items.$ref);
+                                        } else {
+                                          schemaWrapper.definitions = Object.assign({}, defs);
+                                          $RefParser.dereference(schemaWrapper).catch(function(err) {
+                                            console.log(err);
+                                          });
+                                        }
+
+                                        var view = new JSONSchemaView(schema, 3);
+                                        $('#responses-Default-deleteBoardsAndBlocks-default-schema-data').val(JSON.stringify(schema));
+                                        var result = $('#responses-Default-deleteBoardsAndBlocks-schema-default');
+                                        result.empty();
+                                        result.append(view.render());
+                                      });
+                                    </script>
+                                  </div>
+                                  <input id='responses-Default-deleteBoardsAndBlocks-default-schema-data' type='hidden' value=''></input>
+                                </div>
+                            </div>
+                        </article>
+                      </div>
+                      <hr>
+                    <div id="api-Default-deleteMember">
+                      <article id="api-Default-deleteMember-0" data-group="User" data-name="deleteMember" data-version="0">
+                        <div class="pull-left">
+                          <h1>deleteMember</h1>
+                          <p></p>
+                        </div>
+                        <div class="pull-right"></div>
+                        <div class="clearfix"></div>
+                        <p></p>
+                        <p class="marked">Deletes a member from a board</p>
+                        <p></p>
+                        <br />
+                        <pre class="prettyprint language-html prettyprinted" data-type="delete"><code><span class="pln">/boards/{boardID}/members/{userID}</span></code></pre>
+                        <p>
+                          <h3>Usage and SDK Samples</h3>
+                        </p>
+                        <ul class="nav nav-tabs nav-tabs-examples">
+                          <li class="active"><a href="#examples-Default-deleteMember-0-curl">Curl</a></li>
+                          <li class=""><a href="#examples-Default-deleteMember-0-java">Java</a></li>
+                          <li class=""><a href="#examples-Default-deleteMember-0-android">Android</a></li>
+                          <!--<li class=""><a href="#examples-Default-deleteMember-0-groovy">Groovy</a></li>-->
+                          <li class=""><a href="#examples-Default-deleteMember-0-objc">Obj-C</a></li>
+                          <li class=""><a href="#examples-Default-deleteMember-0-javascript">JavaScript</a></li>
+                          <!--<li class=""><a href="#examples-Default-deleteMember-0-angular">Angular</a></li>-->
+                          <li class=""><a href="#examples-Default-deleteMember-0-csharp">C#</a></li>
+                          <li class=""><a href="#examples-Default-deleteMember-0-php">PHP</a></li>
+                          <li class=""><a href="#examples-Default-deleteMember-0-perl">Perl</a></li>
+                          <li class=""><a href="#examples-Default-deleteMember-0-python">Python</a></li>
+                          <li class=""><a href="#examples-Default-deleteMember-0-rust">Rust</a></li>
+                        </ul>
+
+                        <div class="tab-content">
+                          <div class="tab-pane active" id="examples-Default-deleteMember-0-curl">
+                            <pre class="prettyprint"><code class="language-bsh">curl -X DELETE \
+-H "Authorization: [[apiKey]]" \
+ -H "Accept: application/json" \
+ "http://localhost/api/v2/boards/{boardID}/members/{userID}"
+</code></pre>
+                          </div>
+                          <div class="tab-pane" id="examples-Default-deleteMember-0-java">
+                            <pre class="prettyprint"><code class="language-java">import org.openapitools.client.*;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.model.*;
+import org.openapitools.client.api.DefaultApi;
+
+import java.io.File;
+import java.util.*;
+
+public class DefaultApiExample {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        
+        // Configure API key authorization: BearerAuth
+        ApiKeyAuth BearerAuth = (ApiKeyAuth) defaultClient.getAuthentication("BearerAuth");
+        BearerAuth.setApiKey("YOUR API KEY");
+        // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+        //BearerAuth.setApiKeyPrefix("Token");
+
+        // Create an instance of the API class
+        DefaultApi apiInstance = new DefaultApi();
+        String boardID = boardID_example; // String | Board ID
+        String userID = userID_example; // String | User ID
+
+        try {
+            apiInstance.deleteMember(boardID, userID);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling DefaultApi#deleteMember");
+            e.printStackTrace();
+        }
+    }
+}
+</code></pre>
+                          </div>
+
+                          <div class="tab-pane" id="examples-Default-deleteMember-0-android">
+                            <pre class="prettyprint"><code class="language-java">import org.openapitools.client.api.DefaultApi;
+
+public class DefaultApiExample {
+    public static void main(String[] args) {
+        DefaultApi apiInstance = new DefaultApi();
+        String boardID = boardID_example; // String | Board ID
+        String userID = userID_example; // String | User ID
+
+        try {
+            apiInstance.deleteMember(boardID, userID);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling DefaultApi#deleteMember");
+            e.printStackTrace();
+        }
+    }
+}</code></pre>
+                          </div>
+  <!--
+  <div class="tab-pane" id="examples-Default-deleteMember-0-groovy">
+  <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
+  </div> -->
+                            <div class="tab-pane" id="examples-Default-deleteMember-0-objc">
+                              <pre class="prettyprint"><code class="language-cpp">Configuration *apiConfig = [Configuration sharedConfig];
+
+// Configure API key authorization: (authentication scheme: BearerAuth)
+[apiConfig setApiKey:@"YOUR_API_KEY" forApiKeyIdentifier:@"Authorization"];
+// Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+//[apiConfig setApiKeyPrefix:@"Bearer" forApiKeyIdentifier:@"Authorization"];
+
+
+// Create an instance of the API class
+DefaultApi *apiInstance = [[DefaultApi alloc] init];
+String *boardID = boardID_example; // Board ID (default to null)
+String *userID = userID_example; // User ID (default to null)
+
+[apiInstance deleteMemberWith:boardID
+    userID:userID
+              completionHandler: ^(NSError* error) {
+    if (error) {
+        NSLog(@"Error: %@", error);
+    }
+}];
+</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-deleteMember-0-javascript">
+                              <pre class="prettyprint"><code class="language-js">var FocalboardServer = require('focalboard_server');
+var defaultClient = FocalboardServer.ApiClient.instance;
+
+// Configure API key authorization: BearerAuth
+var BearerAuth = defaultClient.authentications['BearerAuth'];
+BearerAuth.apiKey = "YOUR API KEY";
+// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+//BearerAuth.apiKeyPrefix['Authorization'] = "Token";
+
+// Create an instance of the API class
+var api = new FocalboardServer.DefaultApi()
+var boardID = boardID_example; // {String} Board ID
+var userID = userID_example; // {String} User ID
+
+var callback = function(error, data, response) {
+  if (error) {
+    console.error(error);
+  } else {
+    console.log('API called successfully.');
+  }
+};
+api.deleteMember(boardID, userID, callback);
+</code></pre>
+                            </div>
+
+                            <!--<div class="tab-pane" id="examples-Default-deleteMember-0-angular">
+              <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
+            </div>-->
+                            <div class="tab-pane" id="examples-Default-deleteMember-0-csharp">
+                              <pre class="prettyprint"><code class="language-cs">using System;
+using System.Diagnostics;
+using Org.OpenAPITools.Api;
+using Org.OpenAPITools.Client;
+using Org.OpenAPITools.Model;
+
+namespace Example
+{
+    public class deleteMemberExample
+    {
+        public void main()
+        {
+            // Configure API key authorization: BearerAuth
+            Configuration.Default.ApiKey.Add("Authorization", "YOUR_API_KEY");
+            // Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+            // Configuration.Default.ApiKeyPrefix.Add("Authorization", "Bearer");
+
+            // Create an instance of the API class
+            var apiInstance = new DefaultApi();
+            var boardID = boardID_example;  // String | Board ID (default to null)
+            var userID = userID_example;  // String | User ID (default to null)
+
+            try {
+                apiInstance.deleteMember(boardID, userID);
+            } catch (Exception e) {
+                Debug.Print("Exception when calling DefaultApi.deleteMember: " + e.Message );
+            }
+        }
+    }
+}
+</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-deleteMember-0-php">
+                              <pre class="prettyprint"><code class="language-php"><&#63;php
+require_once(__DIR__ . '/vendor/autoload.php');
+
+// Configure API key authorization: BearerAuth
+OpenAPITools\Client\Configuration::getDefaultConfiguration()->setApiKey('Authorization', 'YOUR_API_KEY');
+// Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+// OpenAPITools\Client\Configuration::getDefaultConfiguration()->setApiKeyPrefix('Authorization', 'Bearer');
+
+// Create an instance of the API class
+$api_instance = new OpenAPITools\Client\Api\DefaultApi();
+$boardID = boardID_example; // String | Board ID
+$userID = userID_example; // String | User ID
+
+try {
+    $api_instance->deleteMember($boardID, $userID);
+} catch (Exception $e) {
+    echo 'Exception when calling DefaultApi->deleteMember: ', $e->getMessage(), PHP_EOL;
+}
+?></code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-deleteMember-0-perl">
+                              <pre class="prettyprint"><code class="language-perl">use Data::Dumper;
+use WWW::OPenAPIClient::Configuration;
+use WWW::OPenAPIClient::DefaultApi;
+
+# Configure API key authorization: BearerAuth
+$WWW::OPenAPIClient::Configuration::api_key->{'Authorization'} = 'YOUR_API_KEY';
+# uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+#$WWW::OPenAPIClient::Configuration::api_key_prefix->{'Authorization'} = "Bearer";
+
+# Create an instance of the API class
+my $api_instance = WWW::OPenAPIClient::DefaultApi->new();
+my $boardID = boardID_example; # String | Board ID
+my $userID = userID_example; # String | User ID
+
+eval {
+    $api_instance->deleteMember(boardID => $boardID, userID => $userID);
+};
+if ($@) {
+    warn "Exception when calling DefaultApi->deleteMember: $@\n";
+}</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-deleteMember-0-python">
+                              <pre class="prettyprint"><code class="language-python">from __future__ import print_statement
+import time
+import openapi_client
+from openapi_client.rest import ApiException
+from pprint import pprint
+
+# Configure API key authorization: BearerAuth
+openapi_client.configuration.api_key['Authorization'] = 'YOUR_API_KEY'
+# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+# openapi_client.configuration.api_key_prefix['Authorization'] = 'Bearer'
+
+# Create an instance of the API class
+api_instance = openapi_client.DefaultApi()
+boardID = boardID_example # String | Board ID (default to null)
+userID = userID_example # String | User ID (default to null)
+
+try:
+    api_instance.delete_member(boardID, userID)
+except ApiException as e:
+    print("Exception when calling DefaultApi->deleteMember: %s\n" % e)</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-deleteMember-0-rust">
+                              <pre class="prettyprint"><code class="language-rust">extern crate DefaultApi;
+
+pub fn main() {
+    let boardID = boardID_example; // String
+    let userID = userID_example; // String
+
+    let mut context = DefaultApi::Context::default();
+    let result = client.deleteMember(boardID, userID, &context).wait();
+
+    println!("{:?}", result);
+}
+</code></pre>
+                            </div>
+                          </div>
+
+                          <h2>Scopes</h2>
+                          <table>
+                            
+                          </table>
+
+                          <h2>Parameters</h2>
+
+                            <div class="methodsubtabletitle">Path parameters</div>
+                            <table id="methodsubtable">
+                                <tr>
+                                  <th width="150px">Name</th>
+                                  <th>Description</th>
+                                </tr>
+                                  <tr><td style="width:150px;">boardID*</td>
+<td>
+
+
+    <div id="d2e199_deleteMember_boardID">
+        <div class="json-schema-view">
+            <div class="primitive">
+                <span class="type">
+                    String
+                </span>
+
+                    <div class="inner description marked">
+Board ID
+                    </div>
+            </div>
+                <div class="inner required">
+                    Required
+                </div>
+        </div>
+    </div>
+</td>
+</tr>
+
+                                  <tr><td style="width:150px;">userID*</td>
+<td>
+
+
+    <div id="d2e199_deleteMember_userID">
+        <div class="json-schema-view">
+            <div class="primitive">
+                <span class="type">
+                    String
+                </span>
+
+                    <div class="inner description marked">
+User ID
+                    </div>
+            </div>
+                <div class="inner required">
+                    Required
+                </div>
+        </div>
+    </div>
+</td>
+</tr>
+
+                            </table>
+
+
+
+
+
+                          <h2>Responses</h2>
+                            <h3 id="examples-Default-deleteMember-title-200"></h3>
+                            <p id="examples-Default-deleteMember-description-200" class="marked"></p>
+                            <script>
+                              var responseDefault200_description = `success`;
+                              var responseDefault200_description_break = responseDefault200_description.indexOf('\n');
+                              if (responseDefault200_description_break == -1) {
+                                $("#examples-Default-deleteMember-title-200").text("Status: 200 - " + responseDefault200_description);
+                              } else {
+                                $("#examples-Default-deleteMember-title-200").text("Status: 200 - " + responseDefault200_description.substring(0, responseDefault200_description_break));
+                                $("#examples-Default-deleteMember-description-200").html(responseDefault200_description.substring(responseDefault200_description_break));
+                              }
+                            </script>
+
+
+                            <ul id="responses-detail-Default-deleteMember-200" class="nav nav-tabs nav-tabs-examples" >
+
+
+                            </ul>
+
+
+                            <div class="tab-content" id="responses-Default-deleteMember-200-wrapper" style='margin-bottom: 10px;'>
+                            </div>
+                            <h3 id="examples-Default-deleteMember-title-404"></h3>
+                            <p id="examples-Default-deleteMember-description-404" class="marked"></p>
+                            <script>
+                              var responseDefault404_description = `board not found`;
+                              var responseDefault404_description_break = responseDefault404_description.indexOf('\n');
+                              if (responseDefault404_description_break == -1) {
+                                $("#examples-Default-deleteMember-title-404").text("Status: 404 - " + responseDefault404_description);
+                              } else {
+                                $("#examples-Default-deleteMember-title-404").text("Status: 404 - " + responseDefault404_description.substring(0, responseDefault404_description_break));
+                                $("#examples-Default-deleteMember-description-404").html(responseDefault404_description.substring(responseDefault404_description_break));
+                              }
+                            </script>
+
+
+                            <ul id="responses-detail-Default-deleteMember-404" class="nav nav-tabs nav-tabs-examples" >
+
+
+                            </ul>
+
+
+                            <div class="tab-content" id="responses-Default-deleteMember-404-wrapper" style='margin-bottom: 10px;'>
+                            </div>
+                            <h3 id="examples-Default-deleteMember-title-default"></h3>
+                            <p id="examples-Default-deleteMember-description-default" class="marked"></p>
+                            <script>
+                              var responseDefaultdefault_description = `internal error`;
+                              var responseDefaultdefault_description_break = responseDefaultdefault_description.indexOf('\n');
+                              if (responseDefaultdefault_description_break == -1) {
+                                $("#examples-Default-deleteMember-title-default").text("Status: default - " + responseDefaultdefault_description);
+                              } else {
+                                $("#examples-Default-deleteMember-title-default").text("Status: default - " + responseDefaultdefault_description.substring(0, responseDefaultdefault_description_break));
+                                $("#examples-Default-deleteMember-description-default").html(responseDefaultdefault_description.substring(responseDefaultdefault_description_break));
+                              }
+                            </script>
+
+
+                            <ul id="responses-detail-Default-deleteMember-default" class="nav nav-tabs nav-tabs-examples" >
+                                <li class="active">
+                                  <a data-toggle="tab" href="#responses-Default-deleteMember-default-schema">Schema</a>
+                                </li>
+
+
+
+
+                            </ul>
+
+
+                            <div class="tab-content" id="responses-Default-deleteMember-default-wrapper" style='margin-bottom: 10px;'>
+                                <div class="tab-pane active" id="responses-Default-deleteMember-default-schema">
+                                  <div id="responses-Default-deleteMember-schema-default" class="exampleStyle">
+                                    <script>
+                                      $(document).ready(function() {
+                                        var schemaWrapper = {
+  "description" : "internal error",
+  "content" : {
+    "application/json" : {
+      "schema" : {
+        "$ref" : "#/components/schemas/ErrorResponse"
+      }
+    }
+  }
+};
+                                        var schema = findNode('schema',schemaWrapper).schema;
+                                        if (!schema) {
+                                          schema = schemaWrapper.schema;
+                                        }
+                                        if (schema.$ref != null) {
+                                          schema = defsParser.$refs.get(schema.$ref);
+                                        } else if (schema.items != null && schema.items.$ref != null) {
+                                            schema.items = defsParser.$refs.get(schema.items.$ref);
+                                        } else {
+                                          schemaWrapper.definitions = Object.assign({}, defs);
+                                          $RefParser.dereference(schemaWrapper).catch(function(err) {
+                                            console.log(err);
+                                          });
+                                        }
+
+                                        var view = new JSONSchemaView(schema, 3);
+                                        $('#responses-Default-deleteMember-default-schema-data').val(JSON.stringify(schema));
+                                        var result = $('#responses-Default-deleteMember-schema-default');
+                                        result.empty();
+                                        result.append(view.render());
+                                      });
+                                    </script>
+                                  </div>
+                                  <input id='responses-Default-deleteMember-default-schema-data' type='hidden' value=''></input>
+                                </div>
+                            </div>
+                        </article>
+                      </div>
+                      <hr>
                     <div id="api-Default-deleteSubscription">
                       <article id="api-Default-deleteSubscription-0" data-group="User" data-name="deleteSubscription" data-version="0">
                         <div class="pull-left">
@@ -2956,7 +6912,7 @@ ID of block to delete
                         <p class="marked"></p>
                         <p></p>
                         <br />
-                        <pre class="prettyprint language-html prettyprinted" data-type="delete"><code><span class="pln">/api/v1/workspaces/{workspaceID}/subscriptions/{blockID}/{subscriberID}</span></code></pre>
+                        <pre class="prettyprint language-html prettyprinted" data-type="delete"><code><span class="pln">/subscriptions/{blockID}/{subscriberID}</span></code></pre>
                         <p>
                           <h3>Usage and SDK Samples</h3>
                         </p>
@@ -2980,7 +6936,7 @@ ID of block to delete
                             <pre class="prettyprint"><code class="language-bsh">curl -X DELETE \
 -H "Authorization: [[apiKey]]" \
  -H "Accept: application/json" \
- "http://localhost/api/v1/api/v1/workspaces/{workspaceID}/subscriptions/{blockID}/{subscriberID}"
+ "http://localhost/api/v2/subscriptions/{blockID}/{subscriberID}"
 </code></pre>
                           </div>
                           <div class="tab-pane" id="examples-Default-deleteSubscription-0-java">
@@ -3004,12 +6960,11 @@ public class DefaultApiExample {
 
         // Create an instance of the API class
         DefaultApi apiInstance = new DefaultApi();
-        String workspaceID = workspaceID_example; // String | Workspace ID
         String blockID = blockID_example; // String | Block ID
         String subscriberID = subscriberID_example; // String | Subscriber ID
 
         try {
-            apiInstance.deleteSubscription(workspaceID, blockID, subscriberID);
+            apiInstance.deleteSubscription(blockID, subscriberID);
         } catch (ApiException e) {
             System.err.println("Exception when calling DefaultApi#deleteSubscription");
             e.printStackTrace();
@@ -3025,12 +6980,11 @@ public class DefaultApiExample {
 public class DefaultApiExample {
     public static void main(String[] args) {
         DefaultApi apiInstance = new DefaultApi();
-        String workspaceID = workspaceID_example; // String | Workspace ID
         String blockID = blockID_example; // String | Block ID
         String subscriberID = subscriberID_example; // String | Subscriber ID
 
         try {
-            apiInstance.deleteSubscription(workspaceID, blockID, subscriberID);
+            apiInstance.deleteSubscription(blockID, subscriberID);
         } catch (ApiException e) {
             System.err.println("Exception when calling DefaultApi#deleteSubscription");
             e.printStackTrace();
@@ -3053,13 +7007,11 @@ public class DefaultApiExample {
 
 // Create an instance of the API class
 DefaultApi *apiInstance = [[DefaultApi alloc] init];
-String *workspaceID = workspaceID_example; // Workspace ID (default to null)
 String *blockID = blockID_example; // Block ID (default to null)
 String *subscriberID = subscriberID_example; // Subscriber ID (default to null)
 
 // Deletes a subscription a user has for a a block. The user will no longer receive change notifications for the block.
-[apiInstance deleteSubscriptionWith:workspaceID
-    blockID:blockID
+[apiInstance deleteSubscriptionWith:blockID
     subscriberID:subscriberID
               completionHandler: ^(NSError* error) {
     if (error) {
@@ -3081,7 +7033,6 @@ BearerAuth.apiKey = "YOUR API KEY";
 
 // Create an instance of the API class
 var api = new FocalboardServer.DefaultApi()
-var workspaceID = workspaceID_example; // {String} Workspace ID
 var blockID = blockID_example; // {String} Block ID
 var subscriberID = subscriberID_example; // {String} Subscriber ID
 
@@ -3092,7 +7043,7 @@ var callback = function(error, data, response) {
     console.log('API called successfully.');
   }
 };
-api.deleteSubscription(workspaceID, blockID, subscriberID, callback);
+api.deleteSubscription(blockID, subscriberID, callback);
 </code></pre>
                             </div>
 
@@ -3119,13 +7070,12 @@ namespace Example
 
             // Create an instance of the API class
             var apiInstance = new DefaultApi();
-            var workspaceID = workspaceID_example;  // String | Workspace ID (default to null)
             var blockID = blockID_example;  // String | Block ID (default to null)
             var subscriberID = subscriberID_example;  // String | Subscriber ID (default to null)
 
             try {
                 // Deletes a subscription a user has for a a block. The user will no longer receive change notifications for the block.
-                apiInstance.deleteSubscription(workspaceID, blockID, subscriberID);
+                apiInstance.deleteSubscription(blockID, subscriberID);
             } catch (Exception e) {
                 Debug.Print("Exception when calling DefaultApi.deleteSubscription: " + e.Message );
             }
@@ -3146,12 +7096,11 @@ OpenAPITools\Client\Configuration::getDefaultConfiguration()->setApiKey('Authori
 
 // Create an instance of the API class
 $api_instance = new OpenAPITools\Client\Api\DefaultApi();
-$workspaceID = workspaceID_example; // String | Workspace ID
 $blockID = blockID_example; // String | Block ID
 $subscriberID = subscriberID_example; // String | Subscriber ID
 
 try {
-    $api_instance->deleteSubscription($workspaceID, $blockID, $subscriberID);
+    $api_instance->deleteSubscription($blockID, $subscriberID);
 } catch (Exception $e) {
     echo 'Exception when calling DefaultApi->deleteSubscription: ', $e->getMessage(), PHP_EOL;
 }
@@ -3170,12 +7119,11 @@ $WWW::OPenAPIClient::Configuration::api_key->{'Authorization'} = 'YOUR_API_KEY';
 
 # Create an instance of the API class
 my $api_instance = WWW::OPenAPIClient::DefaultApi->new();
-my $workspaceID = workspaceID_example; # String | Workspace ID
 my $blockID = blockID_example; # String | Block ID
 my $subscriberID = subscriberID_example; # String | Subscriber ID
 
 eval {
-    $api_instance->deleteSubscription(workspaceID => $workspaceID, blockID => $blockID, subscriberID => $subscriberID);
+    $api_instance->deleteSubscription(blockID => $blockID, subscriberID => $subscriberID);
 };
 if ($@) {
     warn "Exception when calling DefaultApi->deleteSubscription: $@\n";
@@ -3196,13 +7144,12 @@ openapi_client.configuration.api_key['Authorization'] = 'YOUR_API_KEY'
 
 # Create an instance of the API class
 api_instance = openapi_client.DefaultApi()
-workspaceID = workspaceID_example # String | Workspace ID (default to null)
 blockID = blockID_example # String | Block ID (default to null)
 subscriberID = subscriberID_example # String | Subscriber ID (default to null)
 
 try:
     # Deletes a subscription a user has for a a block. The user will no longer receive change notifications for the block.
-    api_instance.delete_subscription(workspaceID, blockID, subscriberID)
+    api_instance.delete_subscription(blockID, subscriberID)
 except ApiException as e:
     print("Exception when calling DefaultApi->deleteSubscription: %s\n" % e)</code></pre>
                             </div>
@@ -3211,12 +7158,11 @@ except ApiException as e:
                               <pre class="prettyprint"><code class="language-rust">extern crate DefaultApi;
 
 pub fn main() {
-    let workspaceID = workspaceID_example; // String
     let blockID = blockID_example; // String
     let subscriberID = subscriberID_example; // String
 
     let mut context = DefaultApi::Context::default();
-    let result = client.deleteSubscription(workspaceID, blockID, subscriberID, &context).wait();
+    let result = client.deleteSubscription(blockID, subscriberID, &context).wait();
 
     println!("{:?}", result);
 }
@@ -3237,29 +7183,6 @@ pub fn main() {
                                   <th width="150px">Name</th>
                                   <th>Description</th>
                                 </tr>
-                                  <tr><td style="width:150px;">workspaceID*</td>
-<td>
-
-
-    <div id="d2e199_deleteSubscription_workspaceID">
-        <div class="json-schema-view">
-            <div class="primitive">
-                <span class="type">
-                    String
-                </span>
-
-                    <div class="inner description marked">
-Workspace ID
-                    </div>
-            </div>
-                <div class="inner required">
-                    Required
-                </div>
-        </div>
-    </div>
-</td>
-</tr>
-
                                   <tr><td style="width:150px;">blockID*</td>
 <td>
 
@@ -3404,46 +7327,46 @@ Subscriber ID
                         </article>
                       </div>
                       <hr>
-                    <div id="api-Default-exportBlocks">
-                      <article id="api-Default-exportBlocks-0" data-group="User" data-name="exportBlocks" data-version="0">
+                    <div id="api-Default-duplicateBlock">
+                      <article id="api-Default-duplicateBlock-0" data-group="User" data-name="duplicateBlock" data-version="0">
                         <div class="pull-left">
-                          <h1>exportBlocks</h1>
+                          <h1>duplicateBlock</h1>
                           <p></p>
                         </div>
                         <div class="pull-right"></div>
                         <div class="clearfix"></div>
                         <p></p>
-                        <p class="marked">Returns all blocks</p>
+                        <p class="marked">Returns the new created blocks</p>
                         <p></p>
                         <br />
-                        <pre class="prettyprint language-html prettyprinted" data-type="get"><code><span class="pln">/api/v1/workspaces/{workspaceID}/blocks/export</span></code></pre>
+                        <pre class="prettyprint language-html prettyprinted" data-type="post"><code><span class="pln">/boards/{boardID}/blocks/{blockID}/duplicate</span></code></pre>
                         <p>
                           <h3>Usage and SDK Samples</h3>
                         </p>
                         <ul class="nav nav-tabs nav-tabs-examples">
-                          <li class="active"><a href="#examples-Default-exportBlocks-0-curl">Curl</a></li>
-                          <li class=""><a href="#examples-Default-exportBlocks-0-java">Java</a></li>
-                          <li class=""><a href="#examples-Default-exportBlocks-0-android">Android</a></li>
-                          <!--<li class=""><a href="#examples-Default-exportBlocks-0-groovy">Groovy</a></li>-->
-                          <li class=""><a href="#examples-Default-exportBlocks-0-objc">Obj-C</a></li>
-                          <li class=""><a href="#examples-Default-exportBlocks-0-javascript">JavaScript</a></li>
-                          <!--<li class=""><a href="#examples-Default-exportBlocks-0-angular">Angular</a></li>-->
-                          <li class=""><a href="#examples-Default-exportBlocks-0-csharp">C#</a></li>
-                          <li class=""><a href="#examples-Default-exportBlocks-0-php">PHP</a></li>
-                          <li class=""><a href="#examples-Default-exportBlocks-0-perl">Perl</a></li>
-                          <li class=""><a href="#examples-Default-exportBlocks-0-python">Python</a></li>
-                          <li class=""><a href="#examples-Default-exportBlocks-0-rust">Rust</a></li>
+                          <li class="active"><a href="#examples-Default-duplicateBlock-0-curl">Curl</a></li>
+                          <li class=""><a href="#examples-Default-duplicateBlock-0-java">Java</a></li>
+                          <li class=""><a href="#examples-Default-duplicateBlock-0-android">Android</a></li>
+                          <!--<li class=""><a href="#examples-Default-duplicateBlock-0-groovy">Groovy</a></li>-->
+                          <li class=""><a href="#examples-Default-duplicateBlock-0-objc">Obj-C</a></li>
+                          <li class=""><a href="#examples-Default-duplicateBlock-0-javascript">JavaScript</a></li>
+                          <!--<li class=""><a href="#examples-Default-duplicateBlock-0-angular">Angular</a></li>-->
+                          <li class=""><a href="#examples-Default-duplicateBlock-0-csharp">C#</a></li>
+                          <li class=""><a href="#examples-Default-duplicateBlock-0-php">PHP</a></li>
+                          <li class=""><a href="#examples-Default-duplicateBlock-0-perl">Perl</a></li>
+                          <li class=""><a href="#examples-Default-duplicateBlock-0-python">Python</a></li>
+                          <li class=""><a href="#examples-Default-duplicateBlock-0-rust">Rust</a></li>
                         </ul>
 
                         <div class="tab-content">
-                          <div class="tab-pane active" id="examples-Default-exportBlocks-0-curl">
-                            <pre class="prettyprint"><code class="language-bsh">curl -X GET \
+                          <div class="tab-pane active" id="examples-Default-duplicateBlock-0-curl">
+                            <pre class="prettyprint"><code class="language-bsh">curl -X POST \
 -H "Authorization: [[apiKey]]" \
  -H "Accept: application/json" \
- "http://localhost/api/v1/api/v1/workspaces/{workspaceID}/blocks/export"
+ "http://localhost/api/v2/boards/{boardID}/blocks/{blockID}/duplicate"
 </code></pre>
                           </div>
-                          <div class="tab-pane" id="examples-Default-exportBlocks-0-java">
+                          <div class="tab-pane" id="examples-Default-duplicateBlock-0-java">
                             <pre class="prettyprint"><code class="language-java">import org.openapitools.client.*;
 import org.openapitools.client.auth.*;
 import org.openapitools.client.model.*;
@@ -3464,13 +7387,14 @@ public class DefaultApiExample {
 
         // Create an instance of the API class
         DefaultApi apiInstance = new DefaultApi();
-        String workspaceID = workspaceID_example; // String | Workspace ID
+        String boardID = boardID_example; // String | Board ID
+        String blockID = blockID_example; // String | Block ID
 
         try {
-            array[Block] result = apiInstance.exportBlocks(workspaceID);
+            array[Block] result = apiInstance.duplicateBlock(boardID, blockID);
             System.out.println(result);
         } catch (ApiException e) {
-            System.err.println("Exception when calling DefaultApi#exportBlocks");
+            System.err.println("Exception when calling DefaultApi#duplicateBlock");
             e.printStackTrace();
         }
     }
@@ -3478,29 +7402,30 @@ public class DefaultApiExample {
 </code></pre>
                           </div>
 
-                          <div class="tab-pane" id="examples-Default-exportBlocks-0-android">
+                          <div class="tab-pane" id="examples-Default-duplicateBlock-0-android">
                             <pre class="prettyprint"><code class="language-java">import org.openapitools.client.api.DefaultApi;
 
 public class DefaultApiExample {
     public static void main(String[] args) {
         DefaultApi apiInstance = new DefaultApi();
-        String workspaceID = workspaceID_example; // String | Workspace ID
+        String boardID = boardID_example; // String | Board ID
+        String blockID = blockID_example; // String | Block ID
 
         try {
-            array[Block] result = apiInstance.exportBlocks(workspaceID);
+            array[Block] result = apiInstance.duplicateBlock(boardID, blockID);
             System.out.println(result);
         } catch (ApiException e) {
-            System.err.println("Exception when calling DefaultApi#exportBlocks");
+            System.err.println("Exception when calling DefaultApi#duplicateBlock");
             e.printStackTrace();
         }
     }
 }</code></pre>
                           </div>
   <!--
-  <div class="tab-pane" id="examples-Default-exportBlocks-0-groovy">
+  <div class="tab-pane" id="examples-Default-duplicateBlock-0-groovy">
   <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
   </div> -->
-                            <div class="tab-pane" id="examples-Default-exportBlocks-0-objc">
+                            <div class="tab-pane" id="examples-Default-duplicateBlock-0-objc">
                               <pre class="prettyprint"><code class="language-cpp">Configuration *apiConfig = [Configuration sharedConfig];
 
 // Configure API key authorization: (authentication scheme: BearerAuth)
@@ -3511,9 +7436,11 @@ public class DefaultApiExample {
 
 // Create an instance of the API class
 DefaultApi *apiInstance = [[DefaultApi alloc] init];
-String *workspaceID = workspaceID_example; // Workspace ID (default to null)
+String *boardID = boardID_example; // Board ID (default to null)
+String *blockID = blockID_example; // Block ID (default to null)
 
-[apiInstance exportBlocksWith:workspaceID
+[apiInstance duplicateBlockWith:boardID
+    blockID:blockID
               completionHandler: ^(array[Block] output, NSError* error) {
     if (output) {
         NSLog(@"%@", output);
@@ -3525,7 +7452,7 @@ String *workspaceID = workspaceID_example; // Workspace ID (default to null)
 </code></pre>
                             </div>
 
-                            <div class="tab-pane" id="examples-Default-exportBlocks-0-javascript">
+                            <div class="tab-pane" id="examples-Default-duplicateBlock-0-javascript">
                               <pre class="prettyprint"><code class="language-js">var FocalboardServer = require('focalboard_server');
 var defaultClient = FocalboardServer.ApiClient.instance;
 
@@ -3537,7 +7464,8 @@ BearerAuth.apiKey = "YOUR API KEY";
 
 // Create an instance of the API class
 var api = new FocalboardServer.DefaultApi()
-var workspaceID = workspaceID_example; // {String} Workspace ID
+var boardID = boardID_example; // {String} Board ID
+var blockID = blockID_example; // {String} Block ID
 
 var callback = function(error, data, response) {
   if (error) {
@@ -3546,14 +7474,14 @@ var callback = function(error, data, response) {
     console.log('API called successfully. Returned data: ' + data);
   }
 };
-api.exportBlocks(workspaceID, callback);
+api.duplicateBlock(boardID, blockID, callback);
 </code></pre>
                             </div>
 
-                            <!--<div class="tab-pane" id="examples-Default-exportBlocks-0-angular">
+                            <!--<div class="tab-pane" id="examples-Default-duplicateBlock-0-angular">
               <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
             </div>-->
-                            <div class="tab-pane" id="examples-Default-exportBlocks-0-csharp">
+                            <div class="tab-pane" id="examples-Default-duplicateBlock-0-csharp">
                               <pre class="prettyprint"><code class="language-cs">using System;
 using System.Diagnostics;
 using Org.OpenAPITools.Api;
@@ -3562,7 +7490,7 @@ using Org.OpenAPITools.Model;
 
 namespace Example
 {
-    public class exportBlocksExample
+    public class duplicateBlockExample
     {
         public void main()
         {
@@ -3573,13 +7501,14 @@ namespace Example
 
             // Create an instance of the API class
             var apiInstance = new DefaultApi();
-            var workspaceID = workspaceID_example;  // String | Workspace ID (default to null)
+            var boardID = boardID_example;  // String | Board ID (default to null)
+            var blockID = blockID_example;  // String | Block ID (default to null)
 
             try {
-                array[Block] result = apiInstance.exportBlocks(workspaceID);
+                array[Block] result = apiInstance.duplicateBlock(boardID, blockID);
                 Debug.WriteLine(result);
             } catch (Exception e) {
-                Debug.Print("Exception when calling DefaultApi.exportBlocks: " + e.Message );
+                Debug.Print("Exception when calling DefaultApi.duplicateBlock: " + e.Message );
             }
         }
     }
@@ -3587,7 +7516,7 @@ namespace Example
 </code></pre>
                             </div>
 
-                            <div class="tab-pane" id="examples-Default-exportBlocks-0-php">
+                            <div class="tab-pane" id="examples-Default-duplicateBlock-0-php">
                               <pre class="prettyprint"><code class="language-php"><&#63;php
 require_once(__DIR__ . '/vendor/autoload.php');
 
@@ -3598,18 +7527,19 @@ OpenAPITools\Client\Configuration::getDefaultConfiguration()->setApiKey('Authori
 
 // Create an instance of the API class
 $api_instance = new OpenAPITools\Client\Api\DefaultApi();
-$workspaceID = workspaceID_example; // String | Workspace ID
+$boardID = boardID_example; // String | Board ID
+$blockID = blockID_example; // String | Block ID
 
 try {
-    $result = $api_instance->exportBlocks($workspaceID);
+    $result = $api_instance->duplicateBlock($boardID, $blockID);
     print_r($result);
 } catch (Exception $e) {
-    echo 'Exception when calling DefaultApi->exportBlocks: ', $e->getMessage(), PHP_EOL;
+    echo 'Exception when calling DefaultApi->duplicateBlock: ', $e->getMessage(), PHP_EOL;
 }
 ?></code></pre>
                             </div>
 
-                            <div class="tab-pane" id="examples-Default-exportBlocks-0-perl">
+                            <div class="tab-pane" id="examples-Default-duplicateBlock-0-perl">
                               <pre class="prettyprint"><code class="language-perl">use Data::Dumper;
 use WWW::OPenAPIClient::Configuration;
 use WWW::OPenAPIClient::DefaultApi;
@@ -3621,18 +7551,19 @@ $WWW::OPenAPIClient::Configuration::api_key->{'Authorization'} = 'YOUR_API_KEY';
 
 # Create an instance of the API class
 my $api_instance = WWW::OPenAPIClient::DefaultApi->new();
-my $workspaceID = workspaceID_example; # String | Workspace ID
+my $boardID = boardID_example; # String | Board ID
+my $blockID = blockID_example; # String | Block ID
 
 eval {
-    my $result = $api_instance->exportBlocks(workspaceID => $workspaceID);
+    my $result = $api_instance->duplicateBlock(boardID => $boardID, blockID => $blockID);
     print Dumper($result);
 };
 if ($@) {
-    warn "Exception when calling DefaultApi->exportBlocks: $@\n";
+    warn "Exception when calling DefaultApi->duplicateBlock: $@\n";
 }</code></pre>
                             </div>
 
-                            <div class="tab-pane" id="examples-Default-exportBlocks-0-python">
+                            <div class="tab-pane" id="examples-Default-duplicateBlock-0-python">
                               <pre class="prettyprint"><code class="language-python">from __future__ import print_statement
 import time
 import openapi_client
@@ -3646,23 +7577,25 @@ openapi_client.configuration.api_key['Authorization'] = 'YOUR_API_KEY'
 
 # Create an instance of the API class
 api_instance = openapi_client.DefaultApi()
-workspaceID = workspaceID_example # String | Workspace ID (default to null)
+boardID = boardID_example # String | Board ID (default to null)
+blockID = blockID_example # String | Block ID (default to null)
 
 try:
-    api_response = api_instance.export_blocks(workspaceID)
+    api_response = api_instance.duplicate_block(boardID, blockID)
     pprint(api_response)
 except ApiException as e:
-    print("Exception when calling DefaultApi->exportBlocks: %s\n" % e)</code></pre>
+    print("Exception when calling DefaultApi->duplicateBlock: %s\n" % e)</code></pre>
                             </div>
 
-                            <div class="tab-pane" id="examples-Default-exportBlocks-0-rust">
+                            <div class="tab-pane" id="examples-Default-duplicateBlock-0-rust">
                               <pre class="prettyprint"><code class="language-rust">extern crate DefaultApi;
 
 pub fn main() {
-    let workspaceID = workspaceID_example; // String
+    let boardID = boardID_example; // String
+    let blockID = blockID_example; // String
 
     let mut context = DefaultApi::Context::default();
-    let result = client.exportBlocks(workspaceID, &context).wait();
+    let result = client.duplicateBlock(boardID, blockID, &context).wait();
 
     println!("{:?}", result);
 }
@@ -3683,11 +7616,11 @@ pub fn main() {
                                   <th width="150px">Name</th>
                                   <th>Description</th>
                                 </tr>
-                                  <tr><td style="width:150px;">workspaceID*</td>
+                                  <tr><td style="width:150px;">boardID*</td>
 <td>
 
 
-    <div id="d2e199_exportBlocks_workspaceID">
+    <div id="d2e199_duplicateBlock_boardID">
         <div class="json-schema-view">
             <div class="primitive">
                 <span class="type">
@@ -3695,7 +7628,30 @@ pub fn main() {
                 </span>
 
                     <div class="inner description marked">
-Workspace ID
+Board ID
+                    </div>
+            </div>
+                <div class="inner required">
+                    Required
+                </div>
+        </div>
+    </div>
+</td>
+</tr>
+
+                                  <tr><td style="width:150px;">blockID*</td>
+<td>
+
+
+    <div id="d2e199_duplicateBlock_blockID">
+        <div class="json-schema-view">
+            <div class="primitive">
+                <span class="type">
+                    String
+                </span>
+
+                    <div class="inner description marked">
+Block ID
                     </div>
             </div>
                 <div class="inner required">
@@ -3713,23 +7669,23 @@ Workspace ID
 
 
                           <h2>Responses</h2>
-                            <h3 id="examples-Default-exportBlocks-title-200"></h3>
-                            <p id="examples-Default-exportBlocks-description-200" class="marked"></p>
+                            <h3 id="examples-Default-duplicateBlock-title-200"></h3>
+                            <p id="examples-Default-duplicateBlock-description-200" class="marked"></p>
                             <script>
                               var responseDefault200_description = `success`;
                               var responseDefault200_description_break = responseDefault200_description.indexOf('\n');
                               if (responseDefault200_description_break == -1) {
-                                $("#examples-Default-exportBlocks-title-200").text("Status: 200 - " + responseDefault200_description);
+                                $("#examples-Default-duplicateBlock-title-200").text("Status: 200 - " + responseDefault200_description);
                               } else {
-                                $("#examples-Default-exportBlocks-title-200").text("Status: 200 - " + responseDefault200_description.substring(0, responseDefault200_description_break));
-                                $("#examples-Default-exportBlocks-description-200").html(responseDefault200_description.substring(responseDefault200_description_break));
+                                $("#examples-Default-duplicateBlock-title-200").text("Status: 200 - " + responseDefault200_description.substring(0, responseDefault200_description_break));
+                                $("#examples-Default-duplicateBlock-description-200").html(responseDefault200_description.substring(responseDefault200_description_break));
                               }
                             </script>
 
 
-                            <ul id="responses-detail-Default-exportBlocks-200" class="nav nav-tabs nav-tabs-examples" >
+                            <ul id="responses-detail-Default-duplicateBlock-200" class="nav nav-tabs nav-tabs-examples" >
                                 <li class="active">
-                                  <a data-toggle="tab" href="#responses-Default-exportBlocks-200-schema">Schema</a>
+                                  <a data-toggle="tab" href="#responses-Default-duplicateBlock-200-schema">Schema</a>
                                 </li>
 
 
@@ -3738,9 +7694,9 @@ Workspace ID
                             </ul>
 
 
-                            <div class="tab-content" id="responses-Default-exportBlocks-200-wrapper" style='margin-bottom: 10px;'>
-                                <div class="tab-pane active" id="responses-Default-exportBlocks-200-schema">
-                                  <div id="responses-Default-exportBlocks-schema-200" class="exampleStyle">
+                            <div class="tab-content" id="responses-Default-duplicateBlock-200-wrapper" style='margin-bottom: 10px;'>
+                                <div class="tab-pane active" id="responses-Default-duplicateBlock-200-schema">
+                                  <div id="responses-Default-duplicateBlock-schema-200" class="exampleStyle">
                                     <script>
                                       $(document).ready(function() {
                                         var schemaWrapper = {
@@ -3772,33 +7728,55 @@ Workspace ID
                                         }
 
                                         var view = new JSONSchemaView(schema, 3);
-                                        $('#responses-Default-exportBlocks-200-schema-data').val(JSON.stringify(schema));
-                                        var result = $('#responses-Default-exportBlocks-schema-200');
+                                        $('#responses-Default-duplicateBlock-200-schema-data').val(JSON.stringify(schema));
+                                        var result = $('#responses-Default-duplicateBlock-schema-200');
                                         result.empty();
                                         result.append(view.render());
                                       });
                                     </script>
                                   </div>
-                                  <input id='responses-Default-exportBlocks-200-schema-data' type='hidden' value=''></input>
+                                  <input id='responses-Default-duplicateBlock-200-schema-data' type='hidden' value=''></input>
                                 </div>
                             </div>
-                            <h3 id="examples-Default-exportBlocks-title-default"></h3>
-                            <p id="examples-Default-exportBlocks-description-default" class="marked"></p>
+                            <h3 id="examples-Default-duplicateBlock-title-404"></h3>
+                            <p id="examples-Default-duplicateBlock-description-404" class="marked"></p>
                             <script>
-                              var responseDefaultdefault_description = `internal error`;
-                              var responseDefaultdefault_description_break = responseDefaultdefault_description.indexOf('\n');
-                              if (responseDefaultdefault_description_break == -1) {
-                                $("#examples-Default-exportBlocks-title-default").text("Status: default - " + responseDefaultdefault_description);
+                              var responseDefault404_description = `board or block not found`;
+                              var responseDefault404_description_break = responseDefault404_description.indexOf('\n');
+                              if (responseDefault404_description_break == -1) {
+                                $("#examples-Default-duplicateBlock-title-404").text("Status: 404 - " + responseDefault404_description);
                               } else {
-                                $("#examples-Default-exportBlocks-title-default").text("Status: default - " + responseDefaultdefault_description.substring(0, responseDefaultdefault_description_break));
-                                $("#examples-Default-exportBlocks-description-default").html(responseDefaultdefault_description.substring(responseDefaultdefault_description_break));
+                                $("#examples-Default-duplicateBlock-title-404").text("Status: 404 - " + responseDefault404_description.substring(0, responseDefault404_description_break));
+                                $("#examples-Default-duplicateBlock-description-404").html(responseDefault404_description.substring(responseDefault404_description_break));
                               }
                             </script>
 
 
-                            <ul id="responses-detail-Default-exportBlocks-default" class="nav nav-tabs nav-tabs-examples" >
+                            <ul id="responses-detail-Default-duplicateBlock-404" class="nav nav-tabs nav-tabs-examples" >
+
+
+                            </ul>
+
+
+                            <div class="tab-content" id="responses-Default-duplicateBlock-404-wrapper" style='margin-bottom: 10px;'>
+                            </div>
+                            <h3 id="examples-Default-duplicateBlock-title-default"></h3>
+                            <p id="examples-Default-duplicateBlock-description-default" class="marked"></p>
+                            <script>
+                              var responseDefaultdefault_description = `internal error`;
+                              var responseDefaultdefault_description_break = responseDefaultdefault_description.indexOf('\n');
+                              if (responseDefaultdefault_description_break == -1) {
+                                $("#examples-Default-duplicateBlock-title-default").text("Status: default - " + responseDefaultdefault_description);
+                              } else {
+                                $("#examples-Default-duplicateBlock-title-default").text("Status: default - " + responseDefaultdefault_description.substring(0, responseDefaultdefault_description_break));
+                                $("#examples-Default-duplicateBlock-description-default").html(responseDefaultdefault_description.substring(responseDefaultdefault_description_break));
+                              }
+                            </script>
+
+
+                            <ul id="responses-detail-Default-duplicateBlock-default" class="nav nav-tabs nav-tabs-examples" >
                                 <li class="active">
-                                  <a data-toggle="tab" href="#responses-Default-exportBlocks-default-schema">Schema</a>
+                                  <a data-toggle="tab" href="#responses-Default-duplicateBlock-default-schema">Schema</a>
                                 </li>
 
 
@@ -3807,9 +7785,9 @@ Workspace ID
                             </ul>
 
 
-                            <div class="tab-content" id="responses-Default-exportBlocks-default-wrapper" style='margin-bottom: 10px;'>
-                                <div class="tab-pane active" id="responses-Default-exportBlocks-default-schema">
-                                  <div id="responses-Default-exportBlocks-schema-default" class="exampleStyle">
+                            <div class="tab-content" id="responses-Default-duplicateBlock-default-wrapper" style='margin-bottom: 10px;'>
+                                <div class="tab-pane active" id="responses-Default-duplicateBlock-default-schema">
+                                  <div id="responses-Default-duplicateBlock-schema-default" class="exampleStyle">
                                     <script>
                                       $(document).ready(function() {
                                         var schemaWrapper = {
@@ -3838,14 +7816,480 @@ Workspace ID
                                         }
 
                                         var view = new JSONSchemaView(schema, 3);
-                                        $('#responses-Default-exportBlocks-default-schema-data').val(JSON.stringify(schema));
-                                        var result = $('#responses-Default-exportBlocks-schema-default');
+                                        $('#responses-Default-duplicateBlock-default-schema-data').val(JSON.stringify(schema));
+                                        var result = $('#responses-Default-duplicateBlock-schema-default');
                                         result.empty();
                                         result.append(view.render());
                                       });
                                     </script>
                                   </div>
-                                  <input id='responses-Default-exportBlocks-default-schema-data' type='hidden' value=''></input>
+                                  <input id='responses-Default-duplicateBlock-default-schema-data' type='hidden' value=''></input>
+                                </div>
+                            </div>
+                        </article>
+                      </div>
+                      <hr>
+                    <div id="api-Default-duplicateBoard">
+                      <article id="api-Default-duplicateBoard-0" data-group="User" data-name="duplicateBoard" data-version="0">
+                        <div class="pull-left">
+                          <h1>duplicateBoard</h1>
+                          <p></p>
+                        </div>
+                        <div class="pull-right"></div>
+                        <div class="clearfix"></div>
+                        <p></p>
+                        <p class="marked">Returns the new created board and all the blocks</p>
+                        <p></p>
+                        <br />
+                        <pre class="prettyprint language-html prettyprinted" data-type="post"><code><span class="pln">/boards/{boardID}/duplicate</span></code></pre>
+                        <p>
+                          <h3>Usage and SDK Samples</h3>
+                        </p>
+                        <ul class="nav nav-tabs nav-tabs-examples">
+                          <li class="active"><a href="#examples-Default-duplicateBoard-0-curl">Curl</a></li>
+                          <li class=""><a href="#examples-Default-duplicateBoard-0-java">Java</a></li>
+                          <li class=""><a href="#examples-Default-duplicateBoard-0-android">Android</a></li>
+                          <!--<li class=""><a href="#examples-Default-duplicateBoard-0-groovy">Groovy</a></li>-->
+                          <li class=""><a href="#examples-Default-duplicateBoard-0-objc">Obj-C</a></li>
+                          <li class=""><a href="#examples-Default-duplicateBoard-0-javascript">JavaScript</a></li>
+                          <!--<li class=""><a href="#examples-Default-duplicateBoard-0-angular">Angular</a></li>-->
+                          <li class=""><a href="#examples-Default-duplicateBoard-0-csharp">C#</a></li>
+                          <li class=""><a href="#examples-Default-duplicateBoard-0-php">PHP</a></li>
+                          <li class=""><a href="#examples-Default-duplicateBoard-0-perl">Perl</a></li>
+                          <li class=""><a href="#examples-Default-duplicateBoard-0-python">Python</a></li>
+                          <li class=""><a href="#examples-Default-duplicateBoard-0-rust">Rust</a></li>
+                        </ul>
+
+                        <div class="tab-content">
+                          <div class="tab-pane active" id="examples-Default-duplicateBoard-0-curl">
+                            <pre class="prettyprint"><code class="language-bsh">curl -X POST \
+-H "Authorization: [[apiKey]]" \
+ -H "Accept: application/json" \
+ "http://localhost/api/v2/boards/{boardID}/duplicate"
+</code></pre>
+                          </div>
+                          <div class="tab-pane" id="examples-Default-duplicateBoard-0-java">
+                            <pre class="prettyprint"><code class="language-java">import org.openapitools.client.*;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.model.*;
+import org.openapitools.client.api.DefaultApi;
+
+import java.io.File;
+import java.util.*;
+
+public class DefaultApiExample {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        
+        // Configure API key authorization: BearerAuth
+        ApiKeyAuth BearerAuth = (ApiKeyAuth) defaultClient.getAuthentication("BearerAuth");
+        BearerAuth.setApiKey("YOUR API KEY");
+        // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+        //BearerAuth.setApiKeyPrefix("Token");
+
+        // Create an instance of the API class
+        DefaultApi apiInstance = new DefaultApi();
+        String boardID = boardID_example; // String | Board ID
+
+        try {
+            BoardsAndBlocks result = apiInstance.duplicateBoard(boardID);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling DefaultApi#duplicateBoard");
+            e.printStackTrace();
+        }
+    }
+}
+</code></pre>
+                          </div>
+
+                          <div class="tab-pane" id="examples-Default-duplicateBoard-0-android">
+                            <pre class="prettyprint"><code class="language-java">import org.openapitools.client.api.DefaultApi;
+
+public class DefaultApiExample {
+    public static void main(String[] args) {
+        DefaultApi apiInstance = new DefaultApi();
+        String boardID = boardID_example; // String | Board ID
+
+        try {
+            BoardsAndBlocks result = apiInstance.duplicateBoard(boardID);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling DefaultApi#duplicateBoard");
+            e.printStackTrace();
+        }
+    }
+}</code></pre>
+                          </div>
+  <!--
+  <div class="tab-pane" id="examples-Default-duplicateBoard-0-groovy">
+  <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
+  </div> -->
+                            <div class="tab-pane" id="examples-Default-duplicateBoard-0-objc">
+                              <pre class="prettyprint"><code class="language-cpp">Configuration *apiConfig = [Configuration sharedConfig];
+
+// Configure API key authorization: (authentication scheme: BearerAuth)
+[apiConfig setApiKey:@"YOUR_API_KEY" forApiKeyIdentifier:@"Authorization"];
+// Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+//[apiConfig setApiKeyPrefix:@"Bearer" forApiKeyIdentifier:@"Authorization"];
+
+
+// Create an instance of the API class
+DefaultApi *apiInstance = [[DefaultApi alloc] init];
+String *boardID = boardID_example; // Board ID (default to null)
+
+[apiInstance duplicateBoardWith:boardID
+              completionHandler: ^(BoardsAndBlocks output, NSError* error) {
+    if (output) {
+        NSLog(@"%@", output);
+    }
+    if (error) {
+        NSLog(@"Error: %@", error);
+    }
+}];
+</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-duplicateBoard-0-javascript">
+                              <pre class="prettyprint"><code class="language-js">var FocalboardServer = require('focalboard_server');
+var defaultClient = FocalboardServer.ApiClient.instance;
+
+// Configure API key authorization: BearerAuth
+var BearerAuth = defaultClient.authentications['BearerAuth'];
+BearerAuth.apiKey = "YOUR API KEY";
+// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+//BearerAuth.apiKeyPrefix['Authorization'] = "Token";
+
+// Create an instance of the API class
+var api = new FocalboardServer.DefaultApi()
+var boardID = boardID_example; // {String} Board ID
+
+var callback = function(error, data, response) {
+  if (error) {
+    console.error(error);
+  } else {
+    console.log('API called successfully. Returned data: ' + data);
+  }
+};
+api.duplicateBoard(boardID, callback);
+</code></pre>
+                            </div>
+
+                            <!--<div class="tab-pane" id="examples-Default-duplicateBoard-0-angular">
+              <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
+            </div>-->
+                            <div class="tab-pane" id="examples-Default-duplicateBoard-0-csharp">
+                              <pre class="prettyprint"><code class="language-cs">using System;
+using System.Diagnostics;
+using Org.OpenAPITools.Api;
+using Org.OpenAPITools.Client;
+using Org.OpenAPITools.Model;
+
+namespace Example
+{
+    public class duplicateBoardExample
+    {
+        public void main()
+        {
+            // Configure API key authorization: BearerAuth
+            Configuration.Default.ApiKey.Add("Authorization", "YOUR_API_KEY");
+            // Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+            // Configuration.Default.ApiKeyPrefix.Add("Authorization", "Bearer");
+
+            // Create an instance of the API class
+            var apiInstance = new DefaultApi();
+            var boardID = boardID_example;  // String | Board ID (default to null)
+
+            try {
+                BoardsAndBlocks result = apiInstance.duplicateBoard(boardID);
+                Debug.WriteLine(result);
+            } catch (Exception e) {
+                Debug.Print("Exception when calling DefaultApi.duplicateBoard: " + e.Message );
+            }
+        }
+    }
+}
+</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-duplicateBoard-0-php">
+                              <pre class="prettyprint"><code class="language-php"><&#63;php
+require_once(__DIR__ . '/vendor/autoload.php');
+
+// Configure API key authorization: BearerAuth
+OpenAPITools\Client\Configuration::getDefaultConfiguration()->setApiKey('Authorization', 'YOUR_API_KEY');
+// Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+// OpenAPITools\Client\Configuration::getDefaultConfiguration()->setApiKeyPrefix('Authorization', 'Bearer');
+
+// Create an instance of the API class
+$api_instance = new OpenAPITools\Client\Api\DefaultApi();
+$boardID = boardID_example; // String | Board ID
+
+try {
+    $result = $api_instance->duplicateBoard($boardID);
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling DefaultApi->duplicateBoard: ', $e->getMessage(), PHP_EOL;
+}
+?></code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-duplicateBoard-0-perl">
+                              <pre class="prettyprint"><code class="language-perl">use Data::Dumper;
+use WWW::OPenAPIClient::Configuration;
+use WWW::OPenAPIClient::DefaultApi;
+
+# Configure API key authorization: BearerAuth
+$WWW::OPenAPIClient::Configuration::api_key->{'Authorization'} = 'YOUR_API_KEY';
+# uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+#$WWW::OPenAPIClient::Configuration::api_key_prefix->{'Authorization'} = "Bearer";
+
+# Create an instance of the API class
+my $api_instance = WWW::OPenAPIClient::DefaultApi->new();
+my $boardID = boardID_example; # String | Board ID
+
+eval {
+    my $result = $api_instance->duplicateBoard(boardID => $boardID);
+    print Dumper($result);
+};
+if ($@) {
+    warn "Exception when calling DefaultApi->duplicateBoard: $@\n";
+}</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-duplicateBoard-0-python">
+                              <pre class="prettyprint"><code class="language-python">from __future__ import print_statement
+import time
+import openapi_client
+from openapi_client.rest import ApiException
+from pprint import pprint
+
+# Configure API key authorization: BearerAuth
+openapi_client.configuration.api_key['Authorization'] = 'YOUR_API_KEY'
+# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+# openapi_client.configuration.api_key_prefix['Authorization'] = 'Bearer'
+
+# Create an instance of the API class
+api_instance = openapi_client.DefaultApi()
+boardID = boardID_example # String | Board ID (default to null)
+
+try:
+    api_response = api_instance.duplicate_board(boardID)
+    pprint(api_response)
+except ApiException as e:
+    print("Exception when calling DefaultApi->duplicateBoard: %s\n" % e)</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-duplicateBoard-0-rust">
+                              <pre class="prettyprint"><code class="language-rust">extern crate DefaultApi;
+
+pub fn main() {
+    let boardID = boardID_example; // String
+
+    let mut context = DefaultApi::Context::default();
+    let result = client.duplicateBoard(boardID, &context).wait();
+
+    println!("{:?}", result);
+}
+</code></pre>
+                            </div>
+                          </div>
+
+                          <h2>Scopes</h2>
+                          <table>
+                            
+                          </table>
+
+                          <h2>Parameters</h2>
+
+                            <div class="methodsubtabletitle">Path parameters</div>
+                            <table id="methodsubtable">
+                                <tr>
+                                  <th width="150px">Name</th>
+                                  <th>Description</th>
+                                </tr>
+                                  <tr><td style="width:150px;">boardID*</td>
+<td>
+
+
+    <div id="d2e199_duplicateBoard_boardID">
+        <div class="json-schema-view">
+            <div class="primitive">
+                <span class="type">
+                    String
+                </span>
+
+                    <div class="inner description marked">
+Board ID
+                    </div>
+            </div>
+                <div class="inner required">
+                    Required
+                </div>
+        </div>
+    </div>
+</td>
+</tr>
+
+                            </table>
+
+
+
+
+
+                          <h2>Responses</h2>
+                            <h3 id="examples-Default-duplicateBoard-title-200"></h3>
+                            <p id="examples-Default-duplicateBoard-description-200" class="marked"></p>
+                            <script>
+                              var responseDefault200_description = `success`;
+                              var responseDefault200_description_break = responseDefault200_description.indexOf('\n');
+                              if (responseDefault200_description_break == -1) {
+                                $("#examples-Default-duplicateBoard-title-200").text("Status: 200 - " + responseDefault200_description);
+                              } else {
+                                $("#examples-Default-duplicateBoard-title-200").text("Status: 200 - " + responseDefault200_description.substring(0, responseDefault200_description_break));
+                                $("#examples-Default-duplicateBoard-description-200").html(responseDefault200_description.substring(responseDefault200_description_break));
+                              }
+                            </script>
+
+
+                            <ul id="responses-detail-Default-duplicateBoard-200" class="nav nav-tabs nav-tabs-examples" >
+                                <li class="active">
+                                  <a data-toggle="tab" href="#responses-Default-duplicateBoard-200-schema">Schema</a>
+                                </li>
+
+
+
+
+                            </ul>
+
+
+                            <div class="tab-content" id="responses-Default-duplicateBoard-200-wrapper" style='margin-bottom: 10px;'>
+                                <div class="tab-pane active" id="responses-Default-duplicateBoard-200-schema">
+                                  <div id="responses-Default-duplicateBoard-schema-200" class="exampleStyle">
+                                    <script>
+                                      $(document).ready(function() {
+                                        var schemaWrapper = {
+  "description" : "success",
+  "content" : {
+    "application/json" : {
+      "schema" : {
+        "$ref" : "#/components/schemas/BoardsAndBlocks"
+      }
+    }
+  }
+};
+                                        var schema = findNode('schema',schemaWrapper).schema;
+                                        if (!schema) {
+                                          schema = schemaWrapper.schema;
+                                        }
+                                        if (schema.$ref != null) {
+                                          schema = defsParser.$refs.get(schema.$ref);
+                                        } else if (schema.items != null && schema.items.$ref != null) {
+                                            schema.items = defsParser.$refs.get(schema.items.$ref);
+                                        } else {
+                                          schemaWrapper.definitions = Object.assign({}, defs);
+                                          $RefParser.dereference(schemaWrapper).catch(function(err) {
+                                            console.log(err);
+                                          });
+                                        }
+
+                                        var view = new JSONSchemaView(schema, 3);
+                                        $('#responses-Default-duplicateBoard-200-schema-data').val(JSON.stringify(schema));
+                                        var result = $('#responses-Default-duplicateBoard-schema-200');
+                                        result.empty();
+                                        result.append(view.render());
+                                      });
+                                    </script>
+                                  </div>
+                                  <input id='responses-Default-duplicateBoard-200-schema-data' type='hidden' value=''></input>
+                                </div>
+                            </div>
+                            <h3 id="examples-Default-duplicateBoard-title-404"></h3>
+                            <p id="examples-Default-duplicateBoard-description-404" class="marked"></p>
+                            <script>
+                              var responseDefault404_description = `board not found`;
+                              var responseDefault404_description_break = responseDefault404_description.indexOf('\n');
+                              if (responseDefault404_description_break == -1) {
+                                $("#examples-Default-duplicateBoard-title-404").text("Status: 404 - " + responseDefault404_description);
+                              } else {
+                                $("#examples-Default-duplicateBoard-title-404").text("Status: 404 - " + responseDefault404_description.substring(0, responseDefault404_description_break));
+                                $("#examples-Default-duplicateBoard-description-404").html(responseDefault404_description.substring(responseDefault404_description_break));
+                              }
+                            </script>
+
+
+                            <ul id="responses-detail-Default-duplicateBoard-404" class="nav nav-tabs nav-tabs-examples" >
+
+
+                            </ul>
+
+
+                            <div class="tab-content" id="responses-Default-duplicateBoard-404-wrapper" style='margin-bottom: 10px;'>
+                            </div>
+                            <h3 id="examples-Default-duplicateBoard-title-default"></h3>
+                            <p id="examples-Default-duplicateBoard-description-default" class="marked"></p>
+                            <script>
+                              var responseDefaultdefault_description = `internal error`;
+                              var responseDefaultdefault_description_break = responseDefaultdefault_description.indexOf('\n');
+                              if (responseDefaultdefault_description_break == -1) {
+                                $("#examples-Default-duplicateBoard-title-default").text("Status: default - " + responseDefaultdefault_description);
+                              } else {
+                                $("#examples-Default-duplicateBoard-title-default").text("Status: default - " + responseDefaultdefault_description.substring(0, responseDefaultdefault_description_break));
+                                $("#examples-Default-duplicateBoard-description-default").html(responseDefaultdefault_description.substring(responseDefaultdefault_description_break));
+                              }
+                            </script>
+
+
+                            <ul id="responses-detail-Default-duplicateBoard-default" class="nav nav-tabs nav-tabs-examples" >
+                                <li class="active">
+                                  <a data-toggle="tab" href="#responses-Default-duplicateBoard-default-schema">Schema</a>
+                                </li>
+
+
+
+
+                            </ul>
+
+
+                            <div class="tab-content" id="responses-Default-duplicateBoard-default-wrapper" style='margin-bottom: 10px;'>
+                                <div class="tab-pane active" id="responses-Default-duplicateBoard-default-schema">
+                                  <div id="responses-Default-duplicateBoard-schema-default" class="exampleStyle">
+                                    <script>
+                                      $(document).ready(function() {
+                                        var schemaWrapper = {
+  "description" : "internal error",
+  "content" : {
+    "application/json" : {
+      "schema" : {
+        "$ref" : "#/components/schemas/ErrorResponse"
+      }
+    }
+  }
+};
+                                        var schema = findNode('schema',schemaWrapper).schema;
+                                        if (!schema) {
+                                          schema = schemaWrapper.schema;
+                                        }
+                                        if (schema.$ref != null) {
+                                          schema = defsParser.$refs.get(schema.$ref);
+                                        } else if (schema.items != null && schema.items.$ref != null) {
+                                            schema.items = defsParser.$refs.get(schema.items.$ref);
+                                        } else {
+                                          schemaWrapper.definitions = Object.assign({}, defs);
+                                          $RefParser.dereference(schemaWrapper).catch(function(err) {
+                                            console.log(err);
+                                          });
+                                        }
+
+                                        var view = new JSONSchemaView(schema, 3);
+                                        $('#responses-Default-duplicateBoard-default-schema-data').val(JSON.stringify(schema));
+                                        var result = $('#responses-Default-duplicateBoard-schema-default');
+                                        result.empty();
+                                        result.append(view.render());
+                                      });
+                                    </script>
+                                  </div>
+                                  <input id='responses-Default-duplicateBoard-default-schema-data' type='hidden' value=''></input>
                                 </div>
                             </div>
                         </article>
@@ -3863,7 +8307,7 @@ Workspace ID
                         <p class="marked">Returns blocks</p>
                         <p></p>
                         <br />
-                        <pre class="prettyprint language-html prettyprinted" data-type="get"><code><span class="pln">/api/v1/workspaces/{workspaceID}/blocks</span></code></pre>
+                        <pre class="prettyprint language-html prettyprinted" data-type="get"><code><span class="pln">/boards/{boardID}/blocks</span></code></pre>
                         <p>
                           <h3>Usage and SDK Samples</h3>
                         </p>
@@ -3887,7 +8331,7 @@ Workspace ID
                             <pre class="prettyprint"><code class="language-bsh">curl -X GET \
 -H "Authorization: [[apiKey]]" \
  -H "Accept: application/json" \
- "http://localhost/api/v1/api/v1/workspaces/{workspaceID}/blocks?parent_id=parentId_example&type=type_example"
+ "http://localhost/api/v2/boards/{boardID}/blocks?parent_id=parentId_example&type=type_example"
 </code></pre>
                           </div>
                           <div class="tab-pane" id="examples-Default-getBlocks-0-java">
@@ -3911,12 +8355,12 @@ public class DefaultApiExample {
 
         // Create an instance of the API class
         DefaultApi apiInstance = new DefaultApi();
-        String workspaceID = workspaceID_example; // String | Workspace ID
+        String boardID = boardID_example; // String | Board ID
         String parentId = parentId_example; // String | ID of parent block, omit to specify all blocks
         String type = type_example; // String | Type of blocks to return, omit to specify all types
 
         try {
-            array[Block] result = apiInstance.getBlocks(workspaceID, parentId, type);
+            array[Block] result = apiInstance.getBlocks(boardID, parentId, type);
             System.out.println(result);
         } catch (ApiException e) {
             System.err.println("Exception when calling DefaultApi#getBlocks");
@@ -3933,12 +8377,12 @@ public class DefaultApiExample {
 public class DefaultApiExample {
     public static void main(String[] args) {
         DefaultApi apiInstance = new DefaultApi();
-        String workspaceID = workspaceID_example; // String | Workspace ID
+        String boardID = boardID_example; // String | Board ID
         String parentId = parentId_example; // String | ID of parent block, omit to specify all blocks
         String type = type_example; // String | Type of blocks to return, omit to specify all types
 
         try {
-            array[Block] result = apiInstance.getBlocks(workspaceID, parentId, type);
+            array[Block] result = apiInstance.getBlocks(boardID, parentId, type);
             System.out.println(result);
         } catch (ApiException e) {
             System.err.println("Exception when calling DefaultApi#getBlocks");
@@ -3962,11 +8406,11 @@ public class DefaultApiExample {
 
 // Create an instance of the API class
 DefaultApi *apiInstance = [[DefaultApi alloc] init];
-String *workspaceID = workspaceID_example; // Workspace ID (default to null)
+String *boardID = boardID_example; // Board ID (default to null)
 String *parentId = parentId_example; // ID of parent block, omit to specify all blocks (optional) (default to null)
 String *type = type_example; // Type of blocks to return, omit to specify all types (optional) (default to null)
 
-[apiInstance getBlocksWith:workspaceID
+[apiInstance getBlocksWith:boardID
     parentId:parentId
     type:type
               completionHandler: ^(array[Block] output, NSError* error) {
@@ -3992,7 +8436,7 @@ BearerAuth.apiKey = "YOUR API KEY";
 
 // Create an instance of the API class
 var api = new FocalboardServer.DefaultApi()
-var workspaceID = workspaceID_example; // {String} Workspace ID
+var boardID = boardID_example; // {String} Board ID
 var opts = {
   'parentId': parentId_example, // {String} ID of parent block, omit to specify all blocks
   'type': type_example // {String} Type of blocks to return, omit to specify all types
@@ -4005,7 +8449,7 @@ var callback = function(error, data, response) {
     console.log('API called successfully. Returned data: ' + data);
   }
 };
-api.getBlocks(workspaceID, opts, callback);
+api.getBlocks(boardID, opts, callback);
 </code></pre>
                             </div>
 
@@ -4032,12 +8476,12 @@ namespace Example
 
             // Create an instance of the API class
             var apiInstance = new DefaultApi();
-            var workspaceID = workspaceID_example;  // String | Workspace ID (default to null)
+            var boardID = boardID_example;  // String | Board ID (default to null)
             var parentId = parentId_example;  // String | ID of parent block, omit to specify all blocks (optional)  (default to null)
             var type = type_example;  // String | Type of blocks to return, omit to specify all types (optional)  (default to null)
 
             try {
-                array[Block] result = apiInstance.getBlocks(workspaceID, parentId, type);
+                array[Block] result = apiInstance.getBlocks(boardID, parentId, type);
                 Debug.WriteLine(result);
             } catch (Exception e) {
                 Debug.Print("Exception when calling DefaultApi.getBlocks: " + e.Message );
@@ -4059,12 +8503,12 @@ OpenAPITools\Client\Configuration::getDefaultConfiguration()->setApiKey('Authori
 
 // Create an instance of the API class
 $api_instance = new OpenAPITools\Client\Api\DefaultApi();
-$workspaceID = workspaceID_example; // String | Workspace ID
+$boardID = boardID_example; // String | Board ID
 $parentId = parentId_example; // String | ID of parent block, omit to specify all blocks
 $type = type_example; // String | Type of blocks to return, omit to specify all types
 
 try {
-    $result = $api_instance->getBlocks($workspaceID, $parentId, $type);
+    $result = $api_instance->getBlocks($boardID, $parentId, $type);
     print_r($result);
 } catch (Exception $e) {
     echo 'Exception when calling DefaultApi->getBlocks: ', $e->getMessage(), PHP_EOL;
@@ -4084,12 +8528,12 @@ $WWW::OPenAPIClient::Configuration::api_key->{'Authorization'} = 'YOUR_API_KEY';
 
 # Create an instance of the API class
 my $api_instance = WWW::OPenAPIClient::DefaultApi->new();
-my $workspaceID = workspaceID_example; # String | Workspace ID
+my $boardID = boardID_example; # String | Board ID
 my $parentId = parentId_example; # String | ID of parent block, omit to specify all blocks
 my $type = type_example; # String | Type of blocks to return, omit to specify all types
 
 eval {
-    my $result = $api_instance->getBlocks(workspaceID => $workspaceID, parentId => $parentId, type => $type);
+    my $result = $api_instance->getBlocks(boardID => $boardID, parentId => $parentId, type => $type);
     print Dumper($result);
 };
 if ($@) {
@@ -4111,12 +8555,12 @@ openapi_client.configuration.api_key['Authorization'] = 'YOUR_API_KEY'
 
 # Create an instance of the API class
 api_instance = openapi_client.DefaultApi()
-workspaceID = workspaceID_example # String | Workspace ID (default to null)
+boardID = boardID_example # String | Board ID (default to null)
 parentId = parentId_example # String | ID of parent block, omit to specify all blocks (optional) (default to null)
 type = type_example # String | Type of blocks to return, omit to specify all types (optional) (default to null)
 
 try:
-    api_response = api_instance.get_blocks(workspaceID, parentId=parentId, type=type)
+    api_response = api_instance.get_blocks(boardID, parentId=parentId, type=type)
     pprint(api_response)
 except ApiException as e:
     print("Exception when calling DefaultApi->getBlocks: %s\n" % e)</code></pre>
@@ -4126,12 +8570,12 @@ except ApiException as e:
                               <pre class="prettyprint"><code class="language-rust">extern crate DefaultApi;
 
 pub fn main() {
-    let workspaceID = workspaceID_example; // String
+    let boardID = boardID_example; // String
     let parentId = parentId_example; // String
     let type = type_example; // String
 
     let mut context = DefaultApi::Context::default();
-    let result = client.getBlocks(workspaceID, parentId, type, &context).wait();
+    let result = client.getBlocks(boardID, parentId, type, &context).wait();
 
     println!("{:?}", result);
 }
@@ -4152,11 +8596,11 @@ pub fn main() {
                                   <th width="150px">Name</th>
                                   <th>Description</th>
                                 </tr>
-                                  <tr><td style="width:150px;">workspaceID*</td>
+                                  <tr><td style="width:150px;">boardID*</td>
 <td>
 
 
-    <div id="d2e199_getBlocks_workspaceID">
+    <div id="d2e199_getBlocks_boardID">
         <div class="json-schema-view">
             <div class="primitive">
                 <span class="type">
@@ -4164,7 +8608,7 @@ pub fn main() {
                 </span>
 
                     <div class="inner description marked">
-Workspace ID
+Board ID
                     </div>
             </div>
                 <div class="inner required">
@@ -4298,6 +8742,28 @@ Type of blocks to return, omit to specify all types
                                   <input id='responses-Default-getBlocks-200-schema-data' type='hidden' value=''></input>
                                 </div>
                             </div>
+                            <h3 id="examples-Default-getBlocks-title-404"></h3>
+                            <p id="examples-Default-getBlocks-description-404" class="marked"></p>
+                            <script>
+                              var responseDefault404_description = `board not found`;
+                              var responseDefault404_description_break = responseDefault404_description.indexOf('\n');
+                              if (responseDefault404_description_break == -1) {
+                                $("#examples-Default-getBlocks-title-404").text("Status: 404 - " + responseDefault404_description);
+                              } else {
+                                $("#examples-Default-getBlocks-title-404").text("Status: 404 - " + responseDefault404_description.substring(0, responseDefault404_description_break));
+                                $("#examples-Default-getBlocks-description-404").html(responseDefault404_description.substring(responseDefault404_description_break));
+                              }
+                            </script>
+
+
+                            <ul id="responses-detail-Default-getBlocks-404" class="nav nav-tabs nav-tabs-examples" >
+
+
+                            </ul>
+
+
+                            <div class="tab-content" id="responses-Default-getBlocks-404-wrapper" style='margin-bottom: 10px;'>
+                            </div>
                             <h3 id="examples-Default-getBlocks-title-default"></h3>
                             <p id="examples-Default-getBlocks-description-default" class="marked"></p>
                             <script>
@@ -4367,46 +8833,46 @@ Type of blocks to return, omit to specify all types
                         </article>
                       </div>
                       <hr>
-                    <div id="api-Default-getFile">
-                      <article id="api-Default-getFile-0" data-group="User" data-name="getFile" data-version="0">
+                    <div id="api-Default-getBoard">
+                      <article id="api-Default-getBoard-0" data-group="User" data-name="getBoard" data-version="0">
                         <div class="pull-left">
-                          <h1>getFile</h1>
+                          <h1>getBoard</h1>
                           <p></p>
                         </div>
                         <div class="pull-right"></div>
                         <div class="clearfix"></div>
                         <p></p>
-                        <p class="marked">Returns the contents of an uploaded file</p>
+                        <p class="marked">Returns a board</p>
                         <p></p>
                         <br />
-                        <pre class="prettyprint language-html prettyprinted" data-type="get"><code><span class="pln">/workspaces/{workspaceID}/{rootID}/{fileID}</span></code></pre>
+                        <pre class="prettyprint language-html prettyprinted" data-type="get"><code><span class="pln">/boards/{boardID}</span></code></pre>
                         <p>
                           <h3>Usage and SDK Samples</h3>
                         </p>
                         <ul class="nav nav-tabs nav-tabs-examples">
-                          <li class="active"><a href="#examples-Default-getFile-0-curl">Curl</a></li>
-                          <li class=""><a href="#examples-Default-getFile-0-java">Java</a></li>
-                          <li class=""><a href="#examples-Default-getFile-0-android">Android</a></li>
-                          <!--<li class=""><a href="#examples-Default-getFile-0-groovy">Groovy</a></li>-->
-                          <li class=""><a href="#examples-Default-getFile-0-objc">Obj-C</a></li>
-                          <li class=""><a href="#examples-Default-getFile-0-javascript">JavaScript</a></li>
-                          <!--<li class=""><a href="#examples-Default-getFile-0-angular">Angular</a></li>-->
-                          <li class=""><a href="#examples-Default-getFile-0-csharp">C#</a></li>
-                          <li class=""><a href="#examples-Default-getFile-0-php">PHP</a></li>
-                          <li class=""><a href="#examples-Default-getFile-0-perl">Perl</a></li>
-                          <li class=""><a href="#examples-Default-getFile-0-python">Python</a></li>
-                          <li class=""><a href="#examples-Default-getFile-0-rust">Rust</a></li>
+                          <li class="active"><a href="#examples-Default-getBoard-0-curl">Curl</a></li>
+                          <li class=""><a href="#examples-Default-getBoard-0-java">Java</a></li>
+                          <li class=""><a href="#examples-Default-getBoard-0-android">Android</a></li>
+                          <!--<li class=""><a href="#examples-Default-getBoard-0-groovy">Groovy</a></li>-->
+                          <li class=""><a href="#examples-Default-getBoard-0-objc">Obj-C</a></li>
+                          <li class=""><a href="#examples-Default-getBoard-0-javascript">JavaScript</a></li>
+                          <!--<li class=""><a href="#examples-Default-getBoard-0-angular">Angular</a></li>-->
+                          <li class=""><a href="#examples-Default-getBoard-0-csharp">C#</a></li>
+                          <li class=""><a href="#examples-Default-getBoard-0-php">PHP</a></li>
+                          <li class=""><a href="#examples-Default-getBoard-0-perl">Perl</a></li>
+                          <li class=""><a href="#examples-Default-getBoard-0-python">Python</a></li>
+                          <li class=""><a href="#examples-Default-getBoard-0-rust">Rust</a></li>
                         </ul>
 
                         <div class="tab-content">
-                          <div class="tab-pane active" id="examples-Default-getFile-0-curl">
+                          <div class="tab-pane active" id="examples-Default-getBoard-0-curl">
                             <pre class="prettyprint"><code class="language-bsh">curl -X GET \
 -H "Authorization: [[apiKey]]" \
- -H "Accept: application/json,image/jpg,image/png" \
- "http://localhost/api/v1/workspaces/{workspaceID}/{rootID}/{fileID}"
+ -H "Accept: application/json" \
+ "http://localhost/api/v2/boards/{boardID}"
 </code></pre>
                           </div>
-                          <div class="tab-pane" id="examples-Default-getFile-0-java">
+                          <div class="tab-pane" id="examples-Default-getBoard-0-java">
                             <pre class="prettyprint"><code class="language-java">import org.openapitools.client.*;
 import org.openapitools.client.auth.*;
 import org.openapitools.client.model.*;
@@ -4427,14 +8893,13 @@ public class DefaultApiExample {
 
         // Create an instance of the API class
         DefaultApi apiInstance = new DefaultApi();
-        String workspaceID = workspaceID_example; // String | Workspace ID
-        String rootID = rootID_example; // String | ID of the root block
-        String fileID = fileID_example; // String | ID of the file
+        String boardID = boardID_example; // String | Board ID
 
         try {
-            apiInstance.getFile(workspaceID, rootID, fileID);
+            Board result = apiInstance.getBoard(boardID);
+            System.out.println(result);
         } catch (ApiException e) {
-            System.err.println("Exception when calling DefaultApi#getFile");
+            System.err.println("Exception when calling DefaultApi#getBoard");
             e.printStackTrace();
         }
     }
@@ -4442,30 +8907,29 @@ public class DefaultApiExample {
 </code></pre>
                           </div>
 
-                          <div class="tab-pane" id="examples-Default-getFile-0-android">
+                          <div class="tab-pane" id="examples-Default-getBoard-0-android">
                             <pre class="prettyprint"><code class="language-java">import org.openapitools.client.api.DefaultApi;
 
 public class DefaultApiExample {
     public static void main(String[] args) {
         DefaultApi apiInstance = new DefaultApi();
-        String workspaceID = workspaceID_example; // String | Workspace ID
-        String rootID = rootID_example; // String | ID of the root block
-        String fileID = fileID_example; // String | ID of the file
+        String boardID = boardID_example; // String | Board ID
 
         try {
-            apiInstance.getFile(workspaceID, rootID, fileID);
+            Board result = apiInstance.getBoard(boardID);
+            System.out.println(result);
         } catch (ApiException e) {
-            System.err.println("Exception when calling DefaultApi#getFile");
+            System.err.println("Exception when calling DefaultApi#getBoard");
             e.printStackTrace();
         }
     }
 }</code></pre>
                           </div>
   <!--
-  <div class="tab-pane" id="examples-Default-getFile-0-groovy">
+  <div class="tab-pane" id="examples-Default-getBoard-0-groovy">
   <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
   </div> -->
-                            <div class="tab-pane" id="examples-Default-getFile-0-objc">
+                            <div class="tab-pane" id="examples-Default-getBoard-0-objc">
                               <pre class="prettyprint"><code class="language-cpp">Configuration *apiConfig = [Configuration sharedConfig];
 
 // Configure API key authorization: (authentication scheme: BearerAuth)
@@ -4476,14 +8940,13 @@ public class DefaultApiExample {
 
 // Create an instance of the API class
 DefaultApi *apiInstance = [[DefaultApi alloc] init];
-String *workspaceID = workspaceID_example; // Workspace ID (default to null)
-String *rootID = rootID_example; // ID of the root block (default to null)
-String *fileID = fileID_example; // ID of the file (default to null)
+String *boardID = boardID_example; // Board ID (default to null)
 
-[apiInstance getFileWith:workspaceID
-    rootID:rootID
-    fileID:fileID
-              completionHandler: ^(NSError* error) {
+[apiInstance getBoardWith:boardID
+              completionHandler: ^(Board output, NSError* error) {
+    if (output) {
+        NSLog(@"%@", output);
+    }
     if (error) {
         NSLog(@"Error: %@", error);
     }
@@ -4491,7 +8954,7 @@ String *fileID = fileID_example; // ID of the file (default to null)
 </code></pre>
                             </div>
 
-                            <div class="tab-pane" id="examples-Default-getFile-0-javascript">
+                            <div class="tab-pane" id="examples-Default-getBoard-0-javascript">
                               <pre class="prettyprint"><code class="language-js">var FocalboardServer = require('focalboard_server');
 var defaultClient = FocalboardServer.ApiClient.instance;
 
@@ -4503,25 +8966,23 @@ BearerAuth.apiKey = "YOUR API KEY";
 
 // Create an instance of the API class
 var api = new FocalboardServer.DefaultApi()
-var workspaceID = workspaceID_example; // {String} Workspace ID
-var rootID = rootID_example; // {String} ID of the root block
-var fileID = fileID_example; // {String} ID of the file
+var boardID = boardID_example; // {String} Board ID
 
 var callback = function(error, data, response) {
   if (error) {
     console.error(error);
   } else {
-    console.log('API called successfully.');
+    console.log('API called successfully. Returned data: ' + data);
   }
 };
-api.getFile(workspaceID, rootID, fileID, callback);
+api.getBoard(boardID, callback);
 </code></pre>
                             </div>
 
-                            <!--<div class="tab-pane" id="examples-Default-getFile-0-angular">
+                            <!--<div class="tab-pane" id="examples-Default-getBoard-0-angular">
               <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
             </div>-->
-                            <div class="tab-pane" id="examples-Default-getFile-0-csharp">
+                            <div class="tab-pane" id="examples-Default-getBoard-0-csharp">
                               <pre class="prettyprint"><code class="language-cs">using System;
 using System.Diagnostics;
 using Org.OpenAPITools.Api;
@@ -4530,7 +8991,7 @@ using Org.OpenAPITools.Model;
 
 namespace Example
 {
-    public class getFileExample
+    public class getBoardExample
     {
         public void main()
         {
@@ -4541,14 +9002,13 @@ namespace Example
 
             // Create an instance of the API class
             var apiInstance = new DefaultApi();
-            var workspaceID = workspaceID_example;  // String | Workspace ID (default to null)
-            var rootID = rootID_example;  // String | ID of the root block (default to null)
-            var fileID = fileID_example;  // String | ID of the file (default to null)
+            var boardID = boardID_example;  // String | Board ID (default to null)
 
             try {
-                apiInstance.getFile(workspaceID, rootID, fileID);
+                Board result = apiInstance.getBoard(boardID);
+                Debug.WriteLine(result);
             } catch (Exception e) {
-                Debug.Print("Exception when calling DefaultApi.getFile: " + e.Message );
+                Debug.Print("Exception when calling DefaultApi.getBoard: " + e.Message );
             }
         }
     }
@@ -4556,7 +9016,7 @@ namespace Example
 </code></pre>
                             </div>
 
-                            <div class="tab-pane" id="examples-Default-getFile-0-php">
+                            <div class="tab-pane" id="examples-Default-getBoard-0-php">
                               <pre class="prettyprint"><code class="language-php"><&#63;php
 require_once(__DIR__ . '/vendor/autoload.php');
 
@@ -4567,19 +9027,18 @@ OpenAPITools\Client\Configuration::getDefaultConfiguration()->setApiKey('Authori
 
 // Create an instance of the API class
 $api_instance = new OpenAPITools\Client\Api\DefaultApi();
-$workspaceID = workspaceID_example; // String | Workspace ID
-$rootID = rootID_example; // String | ID of the root block
-$fileID = fileID_example; // String | ID of the file
+$boardID = boardID_example; // String | Board ID
 
 try {
-    $api_instance->getFile($workspaceID, $rootID, $fileID);
+    $result = $api_instance->getBoard($boardID);
+    print_r($result);
 } catch (Exception $e) {
-    echo 'Exception when calling DefaultApi->getFile: ', $e->getMessage(), PHP_EOL;
+    echo 'Exception when calling DefaultApi->getBoard: ', $e->getMessage(), PHP_EOL;
 }
 ?></code></pre>
                             </div>
 
-                            <div class="tab-pane" id="examples-Default-getFile-0-perl">
+                            <div class="tab-pane" id="examples-Default-getBoard-0-perl">
                               <pre class="prettyprint"><code class="language-perl">use Data::Dumper;
 use WWW::OPenAPIClient::Configuration;
 use WWW::OPenAPIClient::DefaultApi;
@@ -4591,19 +9050,18 @@ $WWW::OPenAPIClient::Configuration::api_key->{'Authorization'} = 'YOUR_API_KEY';
 
 # Create an instance of the API class
 my $api_instance = WWW::OPenAPIClient::DefaultApi->new();
-my $workspaceID = workspaceID_example; # String | Workspace ID
-my $rootID = rootID_example; # String | ID of the root block
-my $fileID = fileID_example; # String | ID of the file
+my $boardID = boardID_example; # String | Board ID
 
 eval {
-    $api_instance->getFile(workspaceID => $workspaceID, rootID => $rootID, fileID => $fileID);
+    my $result = $api_instance->getBoard(boardID => $boardID);
+    print Dumper($result);
 };
 if ($@) {
-    warn "Exception when calling DefaultApi->getFile: $@\n";
+    warn "Exception when calling DefaultApi->getBoard: $@\n";
 }</code></pre>
                             </div>
 
-                            <div class="tab-pane" id="examples-Default-getFile-0-python">
+                            <div class="tab-pane" id="examples-Default-getBoard-0-python">
                               <pre class="prettyprint"><code class="language-python">from __future__ import print_statement
 import time
 import openapi_client
@@ -4617,26 +9075,23 @@ openapi_client.configuration.api_key['Authorization'] = 'YOUR_API_KEY'
 
 # Create an instance of the API class
 api_instance = openapi_client.DefaultApi()
-workspaceID = workspaceID_example # String | Workspace ID (default to null)
-rootID = rootID_example # String | ID of the root block (default to null)
-fileID = fileID_example # String | ID of the file (default to null)
+boardID = boardID_example # String | Board ID (default to null)
 
 try:
-    api_instance.get_file(workspaceID, rootID, fileID)
+    api_response = api_instance.get_board(boardID)
+    pprint(api_response)
 except ApiException as e:
-    print("Exception when calling DefaultApi->getFile: %s\n" % e)</code></pre>
+    print("Exception when calling DefaultApi->getBoard: %s\n" % e)</code></pre>
                             </div>
 
-                            <div class="tab-pane" id="examples-Default-getFile-0-rust">
+                            <div class="tab-pane" id="examples-Default-getBoard-0-rust">
                               <pre class="prettyprint"><code class="language-rust">extern crate DefaultApi;
 
 pub fn main() {
-    let workspaceID = workspaceID_example; // String
-    let rootID = rootID_example; // String
-    let fileID = fileID_example; // String
+    let boardID = boardID_example; // String
 
     let mut context = DefaultApi::Context::default();
-    let result = client.getFile(workspaceID, rootID, fileID, &context).wait();
+    let result = client.getBoard(boardID, &context).wait();
 
     println!("{:?}", result);
 }
@@ -4657,11 +9112,11 @@ pub fn main() {
                                   <th width="150px">Name</th>
                                   <th>Description</th>
                                 </tr>
-                                  <tr><td style="width:150px;">workspaceID*</td>
+                                  <tr><td style="width:150px;">boardID*</td>
 <td>
 
 
-    <div id="d2e199_getFile_workspaceID">
+    <div id="d2e199_getBoard_boardID">
         <div class="json-schema-view">
             <div class="primitive">
                 <span class="type">
@@ -4669,53 +9124,7 @@ pub fn main() {
                 </span>
 
                     <div class="inner description marked">
-Workspace ID
-                    </div>
-            </div>
-                <div class="inner required">
-                    Required
-                </div>
-        </div>
-    </div>
-</td>
-</tr>
-
-                                  <tr><td style="width:150px;">rootID*</td>
-<td>
-
-
-    <div id="d2e199_getFile_rootID">
-        <div class="json-schema-view">
-            <div class="primitive">
-                <span class="type">
-                    String
-                </span>
-
-                    <div class="inner description marked">
-ID of the root block
-                    </div>
-            </div>
-                <div class="inner required">
-                    Required
-                </div>
-        </div>
-    </div>
-</td>
-</tr>
-
-                                  <tr><td style="width:150px;">fileID*</td>
-<td>
-
-
-    <div id="d2e199_getFile_fileID">
-        <div class="json-schema-view">
-            <div class="primitive">
-                <span class="type">
-                    String
-                </span>
-
-                    <div class="inner description marked">
-ID of the file
+Board ID
                     </div>
             </div>
                 <div class="inner required">
@@ -4733,45 +9142,23 @@ ID of the file
 
 
                           <h2>Responses</h2>
-                            <h3 id="examples-Default-getFile-title-200"></h3>
-                            <p id="examples-Default-getFile-description-200" class="marked"></p>
+                            <h3 id="examples-Default-getBoard-title-200"></h3>
+                            <p id="examples-Default-getBoard-description-200" class="marked"></p>
                             <script>
                               var responseDefault200_description = `success`;
                               var responseDefault200_description_break = responseDefault200_description.indexOf('\n');
                               if (responseDefault200_description_break == -1) {
-                                $("#examples-Default-getFile-title-200").text("Status: 200 - " + responseDefault200_description);
+                                $("#examples-Default-getBoard-title-200").text("Status: 200 - " + responseDefault200_description);
                               } else {
-                                $("#examples-Default-getFile-title-200").text("Status: 200 - " + responseDefault200_description.substring(0, responseDefault200_description_break));
-                                $("#examples-Default-getFile-description-200").html(responseDefault200_description.substring(responseDefault200_description_break));
+                                $("#examples-Default-getBoard-title-200").text("Status: 200 - " + responseDefault200_description.substring(0, responseDefault200_description_break));
+                                $("#examples-Default-getBoard-description-200").html(responseDefault200_description.substring(responseDefault200_description_break));
                               }
                             </script>
 
 
-                            <ul id="responses-detail-Default-getFile-200" class="nav nav-tabs nav-tabs-examples" >
-
-
-                            </ul>
-
-
-                            <div class="tab-content" id="responses-Default-getFile-200-wrapper" style='margin-bottom: 10px;'>
-                            </div>
-                            <h3 id="examples-Default-getFile-title-default"></h3>
-                            <p id="examples-Default-getFile-description-default" class="marked"></p>
-                            <script>
-                              var responseDefaultdefault_description = `internal error`;
-                              var responseDefaultdefault_description_break = responseDefaultdefault_description.indexOf('\n');
-                              if (responseDefaultdefault_description_break == -1) {
-                                $("#examples-Default-getFile-title-default").text("Status: default - " + responseDefaultdefault_description);
-                              } else {
-                                $("#examples-Default-getFile-title-default").text("Status: default - " + responseDefaultdefault_description.substring(0, responseDefaultdefault_description_break));
-                                $("#examples-Default-getFile-description-default").html(responseDefaultdefault_description.substring(responseDefaultdefault_description_break));
-                              }
-                            </script>
-
-
-                            <ul id="responses-detail-Default-getFile-default" class="nav nav-tabs nav-tabs-examples" >
+                            <ul id="responses-detail-Default-getBoard-200" class="nav nav-tabs nav-tabs-examples" >
                                 <li class="active">
-                                  <a data-toggle="tab" href="#responses-Default-getFile-default-schema">Schema</a>
+                                  <a data-toggle="tab" href="#responses-Default-getBoard-200-schema">Schema</a>
                                 </li>
 
 
@@ -4780,25 +9167,103 @@ ID of the file
                             </ul>
 
 
-                            <div class="tab-content" id="responses-Default-getFile-default-wrapper" style='margin-bottom: 10px;'>
-                                <div class="tab-pane active" id="responses-Default-getFile-default-schema">
-                                  <div id="responses-Default-getFile-schema-default" class="exampleStyle">
+                            <div class="tab-content" id="responses-Default-getBoard-200-wrapper" style='margin-bottom: 10px;'>
+                                <div class="tab-pane active" id="responses-Default-getBoard-200-schema">
+                                  <div id="responses-Default-getBoard-schema-200" class="exampleStyle">
+                                    <script>
+                                      $(document).ready(function() {
+                                        var schemaWrapper = {
+  "description" : "success",
+  "content" : {
+    "application/json" : {
+      "schema" : {
+        "$ref" : "#/components/schemas/Board"
+      }
+    }
+  }
+};
+                                        var schema = findNode('schema',schemaWrapper).schema;
+                                        if (!schema) {
+                                          schema = schemaWrapper.schema;
+                                        }
+                                        if (schema.$ref != null) {
+                                          schema = defsParser.$refs.get(schema.$ref);
+                                        } else if (schema.items != null && schema.items.$ref != null) {
+                                            schema.items = defsParser.$refs.get(schema.items.$ref);
+                                        } else {
+                                          schemaWrapper.definitions = Object.assign({}, defs);
+                                          $RefParser.dereference(schemaWrapper).catch(function(err) {
+                                            console.log(err);
+                                          });
+                                        }
+
+                                        var view = new JSONSchemaView(schema, 3);
+                                        $('#responses-Default-getBoard-200-schema-data').val(JSON.stringify(schema));
+                                        var result = $('#responses-Default-getBoard-schema-200');
+                                        result.empty();
+                                        result.append(view.render());
+                                      });
+                                    </script>
+                                  </div>
+                                  <input id='responses-Default-getBoard-200-schema-data' type='hidden' value=''></input>
+                                </div>
+                            </div>
+                            <h3 id="examples-Default-getBoard-title-404"></h3>
+                            <p id="examples-Default-getBoard-description-404" class="marked"></p>
+                            <script>
+                              var responseDefault404_description = `board not found`;
+                              var responseDefault404_description_break = responseDefault404_description.indexOf('\n');
+                              if (responseDefault404_description_break == -1) {
+                                $("#examples-Default-getBoard-title-404").text("Status: 404 - " + responseDefault404_description);
+                              } else {
+                                $("#examples-Default-getBoard-title-404").text("Status: 404 - " + responseDefault404_description.substring(0, responseDefault404_description_break));
+                                $("#examples-Default-getBoard-description-404").html(responseDefault404_description.substring(responseDefault404_description_break));
+                              }
+                            </script>
+
+
+                            <ul id="responses-detail-Default-getBoard-404" class="nav nav-tabs nav-tabs-examples" >
+
+
+                            </ul>
+
+
+                            <div class="tab-content" id="responses-Default-getBoard-404-wrapper" style='margin-bottom: 10px;'>
+                            </div>
+                            <h3 id="examples-Default-getBoard-title-default"></h3>
+                            <p id="examples-Default-getBoard-description-default" class="marked"></p>
+                            <script>
+                              var responseDefaultdefault_description = `internal error`;
+                              var responseDefaultdefault_description_break = responseDefaultdefault_description.indexOf('\n');
+                              if (responseDefaultdefault_description_break == -1) {
+                                $("#examples-Default-getBoard-title-default").text("Status: default - " + responseDefaultdefault_description);
+                              } else {
+                                $("#examples-Default-getBoard-title-default").text("Status: default - " + responseDefaultdefault_description.substring(0, responseDefaultdefault_description_break));
+                                $("#examples-Default-getBoard-description-default").html(responseDefaultdefault_description.substring(responseDefaultdefault_description_break));
+                              }
+                            </script>
+
+
+                            <ul id="responses-detail-Default-getBoard-default" class="nav nav-tabs nav-tabs-examples" >
+                                <li class="active">
+                                  <a data-toggle="tab" href="#responses-Default-getBoard-default-schema">Schema</a>
+                                </li>
+
+
+
+
+                            </ul>
+
+
+                            <div class="tab-content" id="responses-Default-getBoard-default-wrapper" style='margin-bottom: 10px;'>
+                                <div class="tab-pane active" id="responses-Default-getBoard-default-schema">
+                                  <div id="responses-Default-getBoard-schema-default" class="exampleStyle">
                                     <script>
                                       $(document).ready(function() {
                                         var schemaWrapper = {
   "description" : "internal error",
   "content" : {
     "application/json" : {
-      "schema" : {
-        "$ref" : "#/components/schemas/ErrorResponse"
-      }
-    },
-    "image/jpg" : {
-      "schema" : {
-        "$ref" : "#/components/schemas/ErrorResponse"
-      }
-    },
-    "image/png" : {
       "schema" : {
         "$ref" : "#/components/schemas/ErrorResponse"
       }
@@ -4821,14 +9286,949 @@ ID of the file
                                         }
 
                                         var view = new JSONSchemaView(schema, 3);
-                                        $('#responses-Default-getFile-default-schema-data').val(JSON.stringify(schema));
-                                        var result = $('#responses-Default-getFile-schema-default');
+                                        $('#responses-Default-getBoard-default-schema-data').val(JSON.stringify(schema));
+                                        var result = $('#responses-Default-getBoard-schema-default');
                                         result.empty();
                                         result.append(view.render());
                                       });
                                     </script>
                                   </div>
-                                  <input id='responses-Default-getFile-default-schema-data' type='hidden' value=''></input>
+                                  <input id='responses-Default-getBoard-default-schema-data' type='hidden' value=''></input>
+                                </div>
+                            </div>
+                        </article>
+                      </div>
+                      <hr>
+                    <div id="api-Default-getBoardMetadata">
+                      <article id="api-Default-getBoardMetadata-0" data-group="User" data-name="getBoardMetadata" data-version="0">
+                        <div class="pull-left">
+                          <h1>getBoardMetadata</h1>
+                          <p></p>
+                        </div>
+                        <div class="pull-right"></div>
+                        <div class="clearfix"></div>
+                        <p></p>
+                        <p class="marked">Returns a board&#39;s metadata</p>
+                        <p></p>
+                        <br />
+                        <pre class="prettyprint language-html prettyprinted" data-type="get"><code><span class="pln">/boards/{boardID}/metadata</span></code></pre>
+                        <p>
+                          <h3>Usage and SDK Samples</h3>
+                        </p>
+                        <ul class="nav nav-tabs nav-tabs-examples">
+                          <li class="active"><a href="#examples-Default-getBoardMetadata-0-curl">Curl</a></li>
+                          <li class=""><a href="#examples-Default-getBoardMetadata-0-java">Java</a></li>
+                          <li class=""><a href="#examples-Default-getBoardMetadata-0-android">Android</a></li>
+                          <!--<li class=""><a href="#examples-Default-getBoardMetadata-0-groovy">Groovy</a></li>-->
+                          <li class=""><a href="#examples-Default-getBoardMetadata-0-objc">Obj-C</a></li>
+                          <li class=""><a href="#examples-Default-getBoardMetadata-0-javascript">JavaScript</a></li>
+                          <!--<li class=""><a href="#examples-Default-getBoardMetadata-0-angular">Angular</a></li>-->
+                          <li class=""><a href="#examples-Default-getBoardMetadata-0-csharp">C#</a></li>
+                          <li class=""><a href="#examples-Default-getBoardMetadata-0-php">PHP</a></li>
+                          <li class=""><a href="#examples-Default-getBoardMetadata-0-perl">Perl</a></li>
+                          <li class=""><a href="#examples-Default-getBoardMetadata-0-python">Python</a></li>
+                          <li class=""><a href="#examples-Default-getBoardMetadata-0-rust">Rust</a></li>
+                        </ul>
+
+                        <div class="tab-content">
+                          <div class="tab-pane active" id="examples-Default-getBoardMetadata-0-curl">
+                            <pre class="prettyprint"><code class="language-bsh">curl -X GET \
+-H "Authorization: [[apiKey]]" \
+ -H "Accept: application/json" \
+ "http://localhost/api/v2/boards/{boardID}/metadata"
+</code></pre>
+                          </div>
+                          <div class="tab-pane" id="examples-Default-getBoardMetadata-0-java">
+                            <pre class="prettyprint"><code class="language-java">import org.openapitools.client.*;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.model.*;
+import org.openapitools.client.api.DefaultApi;
+
+import java.io.File;
+import java.util.*;
+
+public class DefaultApiExample {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        
+        // Configure API key authorization: BearerAuth
+        ApiKeyAuth BearerAuth = (ApiKeyAuth) defaultClient.getAuthentication("BearerAuth");
+        BearerAuth.setApiKey("YOUR API KEY");
+        // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+        //BearerAuth.setApiKeyPrefix("Token");
+
+        // Create an instance of the API class
+        DefaultApi apiInstance = new DefaultApi();
+        String boardID = boardID_example; // String | Board ID
+
+        try {
+            BoardMetadata result = apiInstance.getBoardMetadata(boardID);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling DefaultApi#getBoardMetadata");
+            e.printStackTrace();
+        }
+    }
+}
+</code></pre>
+                          </div>
+
+                          <div class="tab-pane" id="examples-Default-getBoardMetadata-0-android">
+                            <pre class="prettyprint"><code class="language-java">import org.openapitools.client.api.DefaultApi;
+
+public class DefaultApiExample {
+    public static void main(String[] args) {
+        DefaultApi apiInstance = new DefaultApi();
+        String boardID = boardID_example; // String | Board ID
+
+        try {
+            BoardMetadata result = apiInstance.getBoardMetadata(boardID);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling DefaultApi#getBoardMetadata");
+            e.printStackTrace();
+        }
+    }
+}</code></pre>
+                          </div>
+  <!--
+  <div class="tab-pane" id="examples-Default-getBoardMetadata-0-groovy">
+  <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
+  </div> -->
+                            <div class="tab-pane" id="examples-Default-getBoardMetadata-0-objc">
+                              <pre class="prettyprint"><code class="language-cpp">Configuration *apiConfig = [Configuration sharedConfig];
+
+// Configure API key authorization: (authentication scheme: BearerAuth)
+[apiConfig setApiKey:@"YOUR_API_KEY" forApiKeyIdentifier:@"Authorization"];
+// Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+//[apiConfig setApiKeyPrefix:@"Bearer" forApiKeyIdentifier:@"Authorization"];
+
+
+// Create an instance of the API class
+DefaultApi *apiInstance = [[DefaultApi alloc] init];
+String *boardID = boardID_example; // Board ID (default to null)
+
+[apiInstance getBoardMetadataWith:boardID
+              completionHandler: ^(BoardMetadata output, NSError* error) {
+    if (output) {
+        NSLog(@"%@", output);
+    }
+    if (error) {
+        NSLog(@"Error: %@", error);
+    }
+}];
+</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-getBoardMetadata-0-javascript">
+                              <pre class="prettyprint"><code class="language-js">var FocalboardServer = require('focalboard_server');
+var defaultClient = FocalboardServer.ApiClient.instance;
+
+// Configure API key authorization: BearerAuth
+var BearerAuth = defaultClient.authentications['BearerAuth'];
+BearerAuth.apiKey = "YOUR API KEY";
+// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+//BearerAuth.apiKeyPrefix['Authorization'] = "Token";
+
+// Create an instance of the API class
+var api = new FocalboardServer.DefaultApi()
+var boardID = boardID_example; // {String} Board ID
+
+var callback = function(error, data, response) {
+  if (error) {
+    console.error(error);
+  } else {
+    console.log('API called successfully. Returned data: ' + data);
+  }
+};
+api.getBoardMetadata(boardID, callback);
+</code></pre>
+                            </div>
+
+                            <!--<div class="tab-pane" id="examples-Default-getBoardMetadata-0-angular">
+              <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
+            </div>-->
+                            <div class="tab-pane" id="examples-Default-getBoardMetadata-0-csharp">
+                              <pre class="prettyprint"><code class="language-cs">using System;
+using System.Diagnostics;
+using Org.OpenAPITools.Api;
+using Org.OpenAPITools.Client;
+using Org.OpenAPITools.Model;
+
+namespace Example
+{
+    public class getBoardMetadataExample
+    {
+        public void main()
+        {
+            // Configure API key authorization: BearerAuth
+            Configuration.Default.ApiKey.Add("Authorization", "YOUR_API_KEY");
+            // Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+            // Configuration.Default.ApiKeyPrefix.Add("Authorization", "Bearer");
+
+            // Create an instance of the API class
+            var apiInstance = new DefaultApi();
+            var boardID = boardID_example;  // String | Board ID (default to null)
+
+            try {
+                BoardMetadata result = apiInstance.getBoardMetadata(boardID);
+                Debug.WriteLine(result);
+            } catch (Exception e) {
+                Debug.Print("Exception when calling DefaultApi.getBoardMetadata: " + e.Message );
+            }
+        }
+    }
+}
+</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-getBoardMetadata-0-php">
+                              <pre class="prettyprint"><code class="language-php"><&#63;php
+require_once(__DIR__ . '/vendor/autoload.php');
+
+// Configure API key authorization: BearerAuth
+OpenAPITools\Client\Configuration::getDefaultConfiguration()->setApiKey('Authorization', 'YOUR_API_KEY');
+// Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+// OpenAPITools\Client\Configuration::getDefaultConfiguration()->setApiKeyPrefix('Authorization', 'Bearer');
+
+// Create an instance of the API class
+$api_instance = new OpenAPITools\Client\Api\DefaultApi();
+$boardID = boardID_example; // String | Board ID
+
+try {
+    $result = $api_instance->getBoardMetadata($boardID);
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling DefaultApi->getBoardMetadata: ', $e->getMessage(), PHP_EOL;
+}
+?></code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-getBoardMetadata-0-perl">
+                              <pre class="prettyprint"><code class="language-perl">use Data::Dumper;
+use WWW::OPenAPIClient::Configuration;
+use WWW::OPenAPIClient::DefaultApi;
+
+# Configure API key authorization: BearerAuth
+$WWW::OPenAPIClient::Configuration::api_key->{'Authorization'} = 'YOUR_API_KEY';
+# uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+#$WWW::OPenAPIClient::Configuration::api_key_prefix->{'Authorization'} = "Bearer";
+
+# Create an instance of the API class
+my $api_instance = WWW::OPenAPIClient::DefaultApi->new();
+my $boardID = boardID_example; # String | Board ID
+
+eval {
+    my $result = $api_instance->getBoardMetadata(boardID => $boardID);
+    print Dumper($result);
+};
+if ($@) {
+    warn "Exception when calling DefaultApi->getBoardMetadata: $@\n";
+}</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-getBoardMetadata-0-python">
+                              <pre class="prettyprint"><code class="language-python">from __future__ import print_statement
+import time
+import openapi_client
+from openapi_client.rest import ApiException
+from pprint import pprint
+
+# Configure API key authorization: BearerAuth
+openapi_client.configuration.api_key['Authorization'] = 'YOUR_API_KEY'
+# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+# openapi_client.configuration.api_key_prefix['Authorization'] = 'Bearer'
+
+# Create an instance of the API class
+api_instance = openapi_client.DefaultApi()
+boardID = boardID_example # String | Board ID (default to null)
+
+try:
+    api_response = api_instance.get_board_metadata(boardID)
+    pprint(api_response)
+except ApiException as e:
+    print("Exception when calling DefaultApi->getBoardMetadata: %s\n" % e)</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-getBoardMetadata-0-rust">
+                              <pre class="prettyprint"><code class="language-rust">extern crate DefaultApi;
+
+pub fn main() {
+    let boardID = boardID_example; // String
+
+    let mut context = DefaultApi::Context::default();
+    let result = client.getBoardMetadata(boardID, &context).wait();
+
+    println!("{:?}", result);
+}
+</code></pre>
+                            </div>
+                          </div>
+
+                          <h2>Scopes</h2>
+                          <table>
+                            
+                          </table>
+
+                          <h2>Parameters</h2>
+
+                            <div class="methodsubtabletitle">Path parameters</div>
+                            <table id="methodsubtable">
+                                <tr>
+                                  <th width="150px">Name</th>
+                                  <th>Description</th>
+                                </tr>
+                                  <tr><td style="width:150px;">boardID*</td>
+<td>
+
+
+    <div id="d2e199_getBoardMetadata_boardID">
+        <div class="json-schema-view">
+            <div class="primitive">
+                <span class="type">
+                    String
+                </span>
+
+                    <div class="inner description marked">
+Board ID
+                    </div>
+            </div>
+                <div class="inner required">
+                    Required
+                </div>
+        </div>
+    </div>
+</td>
+</tr>
+
+                            </table>
+
+
+
+
+
+                          <h2>Responses</h2>
+                            <h3 id="examples-Default-getBoardMetadata-title-200"></h3>
+                            <p id="examples-Default-getBoardMetadata-description-200" class="marked"></p>
+                            <script>
+                              var responseDefault200_description = `success`;
+                              var responseDefault200_description_break = responseDefault200_description.indexOf('\n');
+                              if (responseDefault200_description_break == -1) {
+                                $("#examples-Default-getBoardMetadata-title-200").text("Status: 200 - " + responseDefault200_description);
+                              } else {
+                                $("#examples-Default-getBoardMetadata-title-200").text("Status: 200 - " + responseDefault200_description.substring(0, responseDefault200_description_break));
+                                $("#examples-Default-getBoardMetadata-description-200").html(responseDefault200_description.substring(responseDefault200_description_break));
+                              }
+                            </script>
+
+
+                            <ul id="responses-detail-Default-getBoardMetadata-200" class="nav nav-tabs nav-tabs-examples" >
+                                <li class="active">
+                                  <a data-toggle="tab" href="#responses-Default-getBoardMetadata-200-schema">Schema</a>
+                                </li>
+
+
+
+
+                            </ul>
+
+
+                            <div class="tab-content" id="responses-Default-getBoardMetadata-200-wrapper" style='margin-bottom: 10px;'>
+                                <div class="tab-pane active" id="responses-Default-getBoardMetadata-200-schema">
+                                  <div id="responses-Default-getBoardMetadata-schema-200" class="exampleStyle">
+                                    <script>
+                                      $(document).ready(function() {
+                                        var schemaWrapper = {
+  "description" : "success",
+  "content" : {
+    "application/json" : {
+      "schema" : {
+        "$ref" : "#/components/schemas/BoardMetadata"
+      }
+    }
+  }
+};
+                                        var schema = findNode('schema',schemaWrapper).schema;
+                                        if (!schema) {
+                                          schema = schemaWrapper.schema;
+                                        }
+                                        if (schema.$ref != null) {
+                                          schema = defsParser.$refs.get(schema.$ref);
+                                        } else if (schema.items != null && schema.items.$ref != null) {
+                                            schema.items = defsParser.$refs.get(schema.items.$ref);
+                                        } else {
+                                          schemaWrapper.definitions = Object.assign({}, defs);
+                                          $RefParser.dereference(schemaWrapper).catch(function(err) {
+                                            console.log(err);
+                                          });
+                                        }
+
+                                        var view = new JSONSchemaView(schema, 3);
+                                        $('#responses-Default-getBoardMetadata-200-schema-data').val(JSON.stringify(schema));
+                                        var result = $('#responses-Default-getBoardMetadata-schema-200');
+                                        result.empty();
+                                        result.append(view.render());
+                                      });
+                                    </script>
+                                  </div>
+                                  <input id='responses-Default-getBoardMetadata-200-schema-data' type='hidden' value=''></input>
+                                </div>
+                            </div>
+                            <h3 id="examples-Default-getBoardMetadata-title-404"></h3>
+                            <p id="examples-Default-getBoardMetadata-description-404" class="marked"></p>
+                            <script>
+                              var responseDefault404_description = `board not found`;
+                              var responseDefault404_description_break = responseDefault404_description.indexOf('\n');
+                              if (responseDefault404_description_break == -1) {
+                                $("#examples-Default-getBoardMetadata-title-404").text("Status: 404 - " + responseDefault404_description);
+                              } else {
+                                $("#examples-Default-getBoardMetadata-title-404").text("Status: 404 - " + responseDefault404_description.substring(0, responseDefault404_description_break));
+                                $("#examples-Default-getBoardMetadata-description-404").html(responseDefault404_description.substring(responseDefault404_description_break));
+                              }
+                            </script>
+
+
+                            <ul id="responses-detail-Default-getBoardMetadata-404" class="nav nav-tabs nav-tabs-examples" >
+
+
+                            </ul>
+
+
+                            <div class="tab-content" id="responses-Default-getBoardMetadata-404-wrapper" style='margin-bottom: 10px;'>
+                            </div>
+                            <h3 id="examples-Default-getBoardMetadata-title-501"></h3>
+                            <p id="examples-Default-getBoardMetadata-description-501" class="marked"></p>
+                            <script>
+                              var responseDefault501_description = `required license not found`;
+                              var responseDefault501_description_break = responseDefault501_description.indexOf('\n');
+                              if (responseDefault501_description_break == -1) {
+                                $("#examples-Default-getBoardMetadata-title-501").text("Status: 501 - " + responseDefault501_description);
+                              } else {
+                                $("#examples-Default-getBoardMetadata-title-501").text("Status: 501 - " + responseDefault501_description.substring(0, responseDefault501_description_break));
+                                $("#examples-Default-getBoardMetadata-description-501").html(responseDefault501_description.substring(responseDefault501_description_break));
+                              }
+                            </script>
+
+
+                            <ul id="responses-detail-Default-getBoardMetadata-501" class="nav nav-tabs nav-tabs-examples" >
+
+
+                            </ul>
+
+
+                            <div class="tab-content" id="responses-Default-getBoardMetadata-501-wrapper" style='margin-bottom: 10px;'>
+                            </div>
+                            <h3 id="examples-Default-getBoardMetadata-title-default"></h3>
+                            <p id="examples-Default-getBoardMetadata-description-default" class="marked"></p>
+                            <script>
+                              var responseDefaultdefault_description = `internal error`;
+                              var responseDefaultdefault_description_break = responseDefaultdefault_description.indexOf('\n');
+                              if (responseDefaultdefault_description_break == -1) {
+                                $("#examples-Default-getBoardMetadata-title-default").text("Status: default - " + responseDefaultdefault_description);
+                              } else {
+                                $("#examples-Default-getBoardMetadata-title-default").text("Status: default - " + responseDefaultdefault_description.substring(0, responseDefaultdefault_description_break));
+                                $("#examples-Default-getBoardMetadata-description-default").html(responseDefaultdefault_description.substring(responseDefaultdefault_description_break));
+                              }
+                            </script>
+
+
+                            <ul id="responses-detail-Default-getBoardMetadata-default" class="nav nav-tabs nav-tabs-examples" >
+                                <li class="active">
+                                  <a data-toggle="tab" href="#responses-Default-getBoardMetadata-default-schema">Schema</a>
+                                </li>
+
+
+
+
+                            </ul>
+
+
+                            <div class="tab-content" id="responses-Default-getBoardMetadata-default-wrapper" style='margin-bottom: 10px;'>
+                                <div class="tab-pane active" id="responses-Default-getBoardMetadata-default-schema">
+                                  <div id="responses-Default-getBoardMetadata-schema-default" class="exampleStyle">
+                                    <script>
+                                      $(document).ready(function() {
+                                        var schemaWrapper = {
+  "description" : "internal error",
+  "content" : {
+    "application/json" : {
+      "schema" : {
+        "$ref" : "#/components/schemas/ErrorResponse"
+      }
+    }
+  }
+};
+                                        var schema = findNode('schema',schemaWrapper).schema;
+                                        if (!schema) {
+                                          schema = schemaWrapper.schema;
+                                        }
+                                        if (schema.$ref != null) {
+                                          schema = defsParser.$refs.get(schema.$ref);
+                                        } else if (schema.items != null && schema.items.$ref != null) {
+                                            schema.items = defsParser.$refs.get(schema.items.$ref);
+                                        } else {
+                                          schemaWrapper.definitions = Object.assign({}, defs);
+                                          $RefParser.dereference(schemaWrapper).catch(function(err) {
+                                            console.log(err);
+                                          });
+                                        }
+
+                                        var view = new JSONSchemaView(schema, 3);
+                                        $('#responses-Default-getBoardMetadata-default-schema-data').val(JSON.stringify(schema));
+                                        var result = $('#responses-Default-getBoardMetadata-schema-default');
+                                        result.empty();
+                                        result.append(view.render());
+                                      });
+                                    </script>
+                                  </div>
+                                  <input id='responses-Default-getBoardMetadata-default-schema-data' type='hidden' value=''></input>
+                                </div>
+                            </div>
+                        </article>
+                      </div>
+                      <hr>
+                    <div id="api-Default-getBoards">
+                      <article id="api-Default-getBoards-0" data-group="User" data-name="getBoards" data-version="0">
+                        <div class="pull-left">
+                          <h1>getBoards</h1>
+                          <p></p>
+                        </div>
+                        <div class="pull-right"></div>
+                        <div class="clearfix"></div>
+                        <p></p>
+                        <p class="marked">Returns team boards</p>
+                        <p></p>
+                        <br />
+                        <pre class="prettyprint language-html prettyprinted" data-type="get"><code><span class="pln">/teams/{teamID}/boards</span></code></pre>
+                        <p>
+                          <h3>Usage and SDK Samples</h3>
+                        </p>
+                        <ul class="nav nav-tabs nav-tabs-examples">
+                          <li class="active"><a href="#examples-Default-getBoards-0-curl">Curl</a></li>
+                          <li class=""><a href="#examples-Default-getBoards-0-java">Java</a></li>
+                          <li class=""><a href="#examples-Default-getBoards-0-android">Android</a></li>
+                          <!--<li class=""><a href="#examples-Default-getBoards-0-groovy">Groovy</a></li>-->
+                          <li class=""><a href="#examples-Default-getBoards-0-objc">Obj-C</a></li>
+                          <li class=""><a href="#examples-Default-getBoards-0-javascript">JavaScript</a></li>
+                          <!--<li class=""><a href="#examples-Default-getBoards-0-angular">Angular</a></li>-->
+                          <li class=""><a href="#examples-Default-getBoards-0-csharp">C#</a></li>
+                          <li class=""><a href="#examples-Default-getBoards-0-php">PHP</a></li>
+                          <li class=""><a href="#examples-Default-getBoards-0-perl">Perl</a></li>
+                          <li class=""><a href="#examples-Default-getBoards-0-python">Python</a></li>
+                          <li class=""><a href="#examples-Default-getBoards-0-rust">Rust</a></li>
+                        </ul>
+
+                        <div class="tab-content">
+                          <div class="tab-pane active" id="examples-Default-getBoards-0-curl">
+                            <pre class="prettyprint"><code class="language-bsh">curl -X GET \
+-H "Authorization: [[apiKey]]" \
+ -H "Accept: application/json" \
+ "http://localhost/api/v2/teams/{teamID}/boards"
+</code></pre>
+                          </div>
+                          <div class="tab-pane" id="examples-Default-getBoards-0-java">
+                            <pre class="prettyprint"><code class="language-java">import org.openapitools.client.*;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.model.*;
+import org.openapitools.client.api.DefaultApi;
+
+import java.io.File;
+import java.util.*;
+
+public class DefaultApiExample {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        
+        // Configure API key authorization: BearerAuth
+        ApiKeyAuth BearerAuth = (ApiKeyAuth) defaultClient.getAuthentication("BearerAuth");
+        BearerAuth.setApiKey("YOUR API KEY");
+        // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+        //BearerAuth.setApiKeyPrefix("Token");
+
+        // Create an instance of the API class
+        DefaultApi apiInstance = new DefaultApi();
+        String teamID = teamID_example; // String | Team ID
+
+        try {
+            array[Board] result = apiInstance.getBoards(teamID);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling DefaultApi#getBoards");
+            e.printStackTrace();
+        }
+    }
+}
+</code></pre>
+                          </div>
+
+                          <div class="tab-pane" id="examples-Default-getBoards-0-android">
+                            <pre class="prettyprint"><code class="language-java">import org.openapitools.client.api.DefaultApi;
+
+public class DefaultApiExample {
+    public static void main(String[] args) {
+        DefaultApi apiInstance = new DefaultApi();
+        String teamID = teamID_example; // String | Team ID
+
+        try {
+            array[Board] result = apiInstance.getBoards(teamID);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling DefaultApi#getBoards");
+            e.printStackTrace();
+        }
+    }
+}</code></pre>
+                          </div>
+  <!--
+  <div class="tab-pane" id="examples-Default-getBoards-0-groovy">
+  <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
+  </div> -->
+                            <div class="tab-pane" id="examples-Default-getBoards-0-objc">
+                              <pre class="prettyprint"><code class="language-cpp">Configuration *apiConfig = [Configuration sharedConfig];
+
+// Configure API key authorization: (authentication scheme: BearerAuth)
+[apiConfig setApiKey:@"YOUR_API_KEY" forApiKeyIdentifier:@"Authorization"];
+// Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+//[apiConfig setApiKeyPrefix:@"Bearer" forApiKeyIdentifier:@"Authorization"];
+
+
+// Create an instance of the API class
+DefaultApi *apiInstance = [[DefaultApi alloc] init];
+String *teamID = teamID_example; // Team ID (default to null)
+
+[apiInstance getBoardsWith:teamID
+              completionHandler: ^(array[Board] output, NSError* error) {
+    if (output) {
+        NSLog(@"%@", output);
+    }
+    if (error) {
+        NSLog(@"Error: %@", error);
+    }
+}];
+</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-getBoards-0-javascript">
+                              <pre class="prettyprint"><code class="language-js">var FocalboardServer = require('focalboard_server');
+var defaultClient = FocalboardServer.ApiClient.instance;
+
+// Configure API key authorization: BearerAuth
+var BearerAuth = defaultClient.authentications['BearerAuth'];
+BearerAuth.apiKey = "YOUR API KEY";
+// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+//BearerAuth.apiKeyPrefix['Authorization'] = "Token";
+
+// Create an instance of the API class
+var api = new FocalboardServer.DefaultApi()
+var teamID = teamID_example; // {String} Team ID
+
+var callback = function(error, data, response) {
+  if (error) {
+    console.error(error);
+  } else {
+    console.log('API called successfully. Returned data: ' + data);
+  }
+};
+api.getBoards(teamID, callback);
+</code></pre>
+                            </div>
+
+                            <!--<div class="tab-pane" id="examples-Default-getBoards-0-angular">
+              <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
+            </div>-->
+                            <div class="tab-pane" id="examples-Default-getBoards-0-csharp">
+                              <pre class="prettyprint"><code class="language-cs">using System;
+using System.Diagnostics;
+using Org.OpenAPITools.Api;
+using Org.OpenAPITools.Client;
+using Org.OpenAPITools.Model;
+
+namespace Example
+{
+    public class getBoardsExample
+    {
+        public void main()
+        {
+            // Configure API key authorization: BearerAuth
+            Configuration.Default.ApiKey.Add("Authorization", "YOUR_API_KEY");
+            // Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+            // Configuration.Default.ApiKeyPrefix.Add("Authorization", "Bearer");
+
+            // Create an instance of the API class
+            var apiInstance = new DefaultApi();
+            var teamID = teamID_example;  // String | Team ID (default to null)
+
+            try {
+                array[Board] result = apiInstance.getBoards(teamID);
+                Debug.WriteLine(result);
+            } catch (Exception e) {
+                Debug.Print("Exception when calling DefaultApi.getBoards: " + e.Message );
+            }
+        }
+    }
+}
+</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-getBoards-0-php">
+                              <pre class="prettyprint"><code class="language-php"><&#63;php
+require_once(__DIR__ . '/vendor/autoload.php');
+
+// Configure API key authorization: BearerAuth
+OpenAPITools\Client\Configuration::getDefaultConfiguration()->setApiKey('Authorization', 'YOUR_API_KEY');
+// Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+// OpenAPITools\Client\Configuration::getDefaultConfiguration()->setApiKeyPrefix('Authorization', 'Bearer');
+
+// Create an instance of the API class
+$api_instance = new OpenAPITools\Client\Api\DefaultApi();
+$teamID = teamID_example; // String | Team ID
+
+try {
+    $result = $api_instance->getBoards($teamID);
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling DefaultApi->getBoards: ', $e->getMessage(), PHP_EOL;
+}
+?></code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-getBoards-0-perl">
+                              <pre class="prettyprint"><code class="language-perl">use Data::Dumper;
+use WWW::OPenAPIClient::Configuration;
+use WWW::OPenAPIClient::DefaultApi;
+
+# Configure API key authorization: BearerAuth
+$WWW::OPenAPIClient::Configuration::api_key->{'Authorization'} = 'YOUR_API_KEY';
+# uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+#$WWW::OPenAPIClient::Configuration::api_key_prefix->{'Authorization'} = "Bearer";
+
+# Create an instance of the API class
+my $api_instance = WWW::OPenAPIClient::DefaultApi->new();
+my $teamID = teamID_example; # String | Team ID
+
+eval {
+    my $result = $api_instance->getBoards(teamID => $teamID);
+    print Dumper($result);
+};
+if ($@) {
+    warn "Exception when calling DefaultApi->getBoards: $@\n";
+}</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-getBoards-0-python">
+                              <pre class="prettyprint"><code class="language-python">from __future__ import print_statement
+import time
+import openapi_client
+from openapi_client.rest import ApiException
+from pprint import pprint
+
+# Configure API key authorization: BearerAuth
+openapi_client.configuration.api_key['Authorization'] = 'YOUR_API_KEY'
+# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+# openapi_client.configuration.api_key_prefix['Authorization'] = 'Bearer'
+
+# Create an instance of the API class
+api_instance = openapi_client.DefaultApi()
+teamID = teamID_example # String | Team ID (default to null)
+
+try:
+    api_response = api_instance.get_boards(teamID)
+    pprint(api_response)
+except ApiException as e:
+    print("Exception when calling DefaultApi->getBoards: %s\n" % e)</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-getBoards-0-rust">
+                              <pre class="prettyprint"><code class="language-rust">extern crate DefaultApi;
+
+pub fn main() {
+    let teamID = teamID_example; // String
+
+    let mut context = DefaultApi::Context::default();
+    let result = client.getBoards(teamID, &context).wait();
+
+    println!("{:?}", result);
+}
+</code></pre>
+                            </div>
+                          </div>
+
+                          <h2>Scopes</h2>
+                          <table>
+                            
+                          </table>
+
+                          <h2>Parameters</h2>
+
+                            <div class="methodsubtabletitle">Path parameters</div>
+                            <table id="methodsubtable">
+                                <tr>
+                                  <th width="150px">Name</th>
+                                  <th>Description</th>
+                                </tr>
+                                  <tr><td style="width:150px;">teamID*</td>
+<td>
+
+
+    <div id="d2e199_getBoards_teamID">
+        <div class="json-schema-view">
+            <div class="primitive">
+                <span class="type">
+                    String
+                </span>
+
+                    <div class="inner description marked">
+Team ID
+                    </div>
+            </div>
+                <div class="inner required">
+                    Required
+                </div>
+        </div>
+    </div>
+</td>
+</tr>
+
+                            </table>
+
+
+
+
+
+                          <h2>Responses</h2>
+                            <h3 id="examples-Default-getBoards-title-200"></h3>
+                            <p id="examples-Default-getBoards-description-200" class="marked"></p>
+                            <script>
+                              var responseDefault200_description = `success`;
+                              var responseDefault200_description_break = responseDefault200_description.indexOf('\n');
+                              if (responseDefault200_description_break == -1) {
+                                $("#examples-Default-getBoards-title-200").text("Status: 200 - " + responseDefault200_description);
+                              } else {
+                                $("#examples-Default-getBoards-title-200").text("Status: 200 - " + responseDefault200_description.substring(0, responseDefault200_description_break));
+                                $("#examples-Default-getBoards-description-200").html(responseDefault200_description.substring(responseDefault200_description_break));
+                              }
+                            </script>
+
+
+                            <ul id="responses-detail-Default-getBoards-200" class="nav nav-tabs nav-tabs-examples" >
+                                <li class="active">
+                                  <a data-toggle="tab" href="#responses-Default-getBoards-200-schema">Schema</a>
+                                </li>
+
+
+
+
+                            </ul>
+
+
+                            <div class="tab-content" id="responses-Default-getBoards-200-wrapper" style='margin-bottom: 10px;'>
+                                <div class="tab-pane active" id="responses-Default-getBoards-200-schema">
+                                  <div id="responses-Default-getBoards-schema-200" class="exampleStyle">
+                                    <script>
+                                      $(document).ready(function() {
+                                        var schemaWrapper = {
+  "description" : "success",
+  "content" : {
+    "application/json" : {
+      "schema" : {
+        "type" : "array",
+        "items" : {
+          "$ref" : "#/components/schemas/Board"
+        }
+      }
+    }
+  }
+};
+                                        var schema = findNode('schema',schemaWrapper).schema;
+                                        if (!schema) {
+                                          schema = schemaWrapper.schema;
+                                        }
+                                        if (schema.$ref != null) {
+                                          schema = defsParser.$refs.get(schema.$ref);
+                                        } else if (schema.items != null && schema.items.$ref != null) {
+                                            schema.items = defsParser.$refs.get(schema.items.$ref);
+                                        } else {
+                                          schemaWrapper.definitions = Object.assign({}, defs);
+                                          $RefParser.dereference(schemaWrapper).catch(function(err) {
+                                            console.log(err);
+                                          });
+                                        }
+
+                                        var view = new JSONSchemaView(schema, 3);
+                                        $('#responses-Default-getBoards-200-schema-data').val(JSON.stringify(schema));
+                                        var result = $('#responses-Default-getBoards-schema-200');
+                                        result.empty();
+                                        result.append(view.render());
+                                      });
+                                    </script>
+                                  </div>
+                                  <input id='responses-Default-getBoards-200-schema-data' type='hidden' value=''></input>
+                                </div>
+                            </div>
+                            <h3 id="examples-Default-getBoards-title-default"></h3>
+                            <p id="examples-Default-getBoards-description-default" class="marked"></p>
+                            <script>
+                              var responseDefaultdefault_description = `internal error`;
+                              var responseDefaultdefault_description_break = responseDefaultdefault_description.indexOf('\n');
+                              if (responseDefaultdefault_description_break == -1) {
+                                $("#examples-Default-getBoards-title-default").text("Status: default - " + responseDefaultdefault_description);
+                              } else {
+                                $("#examples-Default-getBoards-title-default").text("Status: default - " + responseDefaultdefault_description.substring(0, responseDefaultdefault_description_break));
+                                $("#examples-Default-getBoards-description-default").html(responseDefaultdefault_description.substring(responseDefaultdefault_description_break));
+                              }
+                            </script>
+
+
+                            <ul id="responses-detail-Default-getBoards-default" class="nav nav-tabs nav-tabs-examples" >
+                                <li class="active">
+                                  <a data-toggle="tab" href="#responses-Default-getBoards-default-schema">Schema</a>
+                                </li>
+
+
+
+
+                            </ul>
+
+
+                            <div class="tab-content" id="responses-Default-getBoards-default-wrapper" style='margin-bottom: 10px;'>
+                                <div class="tab-pane active" id="responses-Default-getBoards-default-schema">
+                                  <div id="responses-Default-getBoards-schema-default" class="exampleStyle">
+                                    <script>
+                                      $(document).ready(function() {
+                                        var schemaWrapper = {
+  "description" : "internal error",
+  "content" : {
+    "application/json" : {
+      "schema" : {
+        "$ref" : "#/components/schemas/ErrorResponse"
+      }
+    }
+  }
+};
+                                        var schema = findNode('schema',schemaWrapper).schema;
+                                        if (!schema) {
+                                          schema = schemaWrapper.schema;
+                                        }
+                                        if (schema.$ref != null) {
+                                          schema = defsParser.$refs.get(schema.$ref);
+                                        } else if (schema.items != null && schema.items.$ref != null) {
+                                            schema.items = defsParser.$refs.get(schema.items.$ref);
+                                        } else {
+                                          schemaWrapper.definitions = Object.assign({}, defs);
+                                          $RefParser.dereference(schemaWrapper).catch(function(err) {
+                                            console.log(err);
+                                          });
+                                        }
+
+                                        var view = new JSONSchemaView(schema, 3);
+                                        $('#responses-Default-getBoards-default-schema-data').val(JSON.stringify(schema));
+                                        var result = $('#responses-Default-getBoards-schema-default');
+                                        result.empty();
+                                        result.append(view.render());
+                                      });
+                                    </script>
+                                  </div>
+                                  <input id='responses-Default-getBoards-default-schema-data' type='hidden' value=''></input>
                                 </div>
                             </div>
                         </article>
@@ -4846,7 +10246,7 @@ ID of the file
                         <p class="marked">Returns the currently logged-in user</p>
                         <p></p>
                         <br />
-                        <pre class="prettyprint language-html prettyprinted" data-type="get"><code><span class="pln">/api/v1/users/me</span></code></pre>
+                        <pre class="prettyprint language-html prettyprinted" data-type="get"><code><span class="pln">/users/me</span></code></pre>
                         <p>
                           <h3>Usage and SDK Samples</h3>
                         </p>
@@ -4870,7 +10270,7 @@ ID of the file
                             <pre class="prettyprint"><code class="language-bsh">curl -X GET \
 -H "Authorization: [[apiKey]]" \
  -H "Accept: application/json" \
- "http://localhost/api/v1/api/v1/users/me"
+ "http://localhost/api/v2/users/me"
 </code></pre>
                           </div>
                           <div class="tab-pane" id="examples-Default-getMe-0-java">
@@ -5238,6 +10638,860 @@ pub fn main() {
                         </article>
                       </div>
                       <hr>
+                    <div id="api-Default-getMembersForBoard">
+                      <article id="api-Default-getMembersForBoard-0" data-group="User" data-name="getMembersForBoard" data-version="0">
+                        <div class="pull-left">
+                          <h1>getMembersForBoard</h1>
+                          <p></p>
+                        </div>
+                        <div class="pull-right"></div>
+                        <div class="clearfix"></div>
+                        <p></p>
+                        <p class="marked">Returns the members of the board</p>
+                        <p></p>
+                        <br />
+                        <pre class="prettyprint language-html prettyprinted" data-type="get"><code><span class="pln">/boards/{boardID}/members</span></code></pre>
+                        <p>
+                          <h3>Usage and SDK Samples</h3>
+                        </p>
+                        <ul class="nav nav-tabs nav-tabs-examples">
+                          <li class="active"><a href="#examples-Default-getMembersForBoard-0-curl">Curl</a></li>
+                          <li class=""><a href="#examples-Default-getMembersForBoard-0-java">Java</a></li>
+                          <li class=""><a href="#examples-Default-getMembersForBoard-0-android">Android</a></li>
+                          <!--<li class=""><a href="#examples-Default-getMembersForBoard-0-groovy">Groovy</a></li>-->
+                          <li class=""><a href="#examples-Default-getMembersForBoard-0-objc">Obj-C</a></li>
+                          <li class=""><a href="#examples-Default-getMembersForBoard-0-javascript">JavaScript</a></li>
+                          <!--<li class=""><a href="#examples-Default-getMembersForBoard-0-angular">Angular</a></li>-->
+                          <li class=""><a href="#examples-Default-getMembersForBoard-0-csharp">C#</a></li>
+                          <li class=""><a href="#examples-Default-getMembersForBoard-0-php">PHP</a></li>
+                          <li class=""><a href="#examples-Default-getMembersForBoard-0-perl">Perl</a></li>
+                          <li class=""><a href="#examples-Default-getMembersForBoard-0-python">Python</a></li>
+                          <li class=""><a href="#examples-Default-getMembersForBoard-0-rust">Rust</a></li>
+                        </ul>
+
+                        <div class="tab-content">
+                          <div class="tab-pane active" id="examples-Default-getMembersForBoard-0-curl">
+                            <pre class="prettyprint"><code class="language-bsh">curl -X GET \
+-H "Authorization: [[apiKey]]" \
+ -H "Accept: application/json" \
+ "http://localhost/api/v2/boards/{boardID}/members"
+</code></pre>
+                          </div>
+                          <div class="tab-pane" id="examples-Default-getMembersForBoard-0-java">
+                            <pre class="prettyprint"><code class="language-java">import org.openapitools.client.*;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.model.*;
+import org.openapitools.client.api.DefaultApi;
+
+import java.io.File;
+import java.util.*;
+
+public class DefaultApiExample {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        
+        // Configure API key authorization: BearerAuth
+        ApiKeyAuth BearerAuth = (ApiKeyAuth) defaultClient.getAuthentication("BearerAuth");
+        BearerAuth.setApiKey("YOUR API KEY");
+        // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+        //BearerAuth.setApiKeyPrefix("Token");
+
+        // Create an instance of the API class
+        DefaultApi apiInstance = new DefaultApi();
+        String boardID = boardID_example; // String | Board ID
+
+        try {
+            array[BoardMember] result = apiInstance.getMembersForBoard(boardID);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling DefaultApi#getMembersForBoard");
+            e.printStackTrace();
+        }
+    }
+}
+</code></pre>
+                          </div>
+
+                          <div class="tab-pane" id="examples-Default-getMembersForBoard-0-android">
+                            <pre class="prettyprint"><code class="language-java">import org.openapitools.client.api.DefaultApi;
+
+public class DefaultApiExample {
+    public static void main(String[] args) {
+        DefaultApi apiInstance = new DefaultApi();
+        String boardID = boardID_example; // String | Board ID
+
+        try {
+            array[BoardMember] result = apiInstance.getMembersForBoard(boardID);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling DefaultApi#getMembersForBoard");
+            e.printStackTrace();
+        }
+    }
+}</code></pre>
+                          </div>
+  <!--
+  <div class="tab-pane" id="examples-Default-getMembersForBoard-0-groovy">
+  <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
+  </div> -->
+                            <div class="tab-pane" id="examples-Default-getMembersForBoard-0-objc">
+                              <pre class="prettyprint"><code class="language-cpp">Configuration *apiConfig = [Configuration sharedConfig];
+
+// Configure API key authorization: (authentication scheme: BearerAuth)
+[apiConfig setApiKey:@"YOUR_API_KEY" forApiKeyIdentifier:@"Authorization"];
+// Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+//[apiConfig setApiKeyPrefix:@"Bearer" forApiKeyIdentifier:@"Authorization"];
+
+
+// Create an instance of the API class
+DefaultApi *apiInstance = [[DefaultApi alloc] init];
+String *boardID = boardID_example; // Board ID (default to null)
+
+[apiInstance getMembersForBoardWith:boardID
+              completionHandler: ^(array[BoardMember] output, NSError* error) {
+    if (output) {
+        NSLog(@"%@", output);
+    }
+    if (error) {
+        NSLog(@"Error: %@", error);
+    }
+}];
+</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-getMembersForBoard-0-javascript">
+                              <pre class="prettyprint"><code class="language-js">var FocalboardServer = require('focalboard_server');
+var defaultClient = FocalboardServer.ApiClient.instance;
+
+// Configure API key authorization: BearerAuth
+var BearerAuth = defaultClient.authentications['BearerAuth'];
+BearerAuth.apiKey = "YOUR API KEY";
+// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+//BearerAuth.apiKeyPrefix['Authorization'] = "Token";
+
+// Create an instance of the API class
+var api = new FocalboardServer.DefaultApi()
+var boardID = boardID_example; // {String} Board ID
+
+var callback = function(error, data, response) {
+  if (error) {
+    console.error(error);
+  } else {
+    console.log('API called successfully. Returned data: ' + data);
+  }
+};
+api.getMembersForBoard(boardID, callback);
+</code></pre>
+                            </div>
+
+                            <!--<div class="tab-pane" id="examples-Default-getMembersForBoard-0-angular">
+              <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
+            </div>-->
+                            <div class="tab-pane" id="examples-Default-getMembersForBoard-0-csharp">
+                              <pre class="prettyprint"><code class="language-cs">using System;
+using System.Diagnostics;
+using Org.OpenAPITools.Api;
+using Org.OpenAPITools.Client;
+using Org.OpenAPITools.Model;
+
+namespace Example
+{
+    public class getMembersForBoardExample
+    {
+        public void main()
+        {
+            // Configure API key authorization: BearerAuth
+            Configuration.Default.ApiKey.Add("Authorization", "YOUR_API_KEY");
+            // Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+            // Configuration.Default.ApiKeyPrefix.Add("Authorization", "Bearer");
+
+            // Create an instance of the API class
+            var apiInstance = new DefaultApi();
+            var boardID = boardID_example;  // String | Board ID (default to null)
+
+            try {
+                array[BoardMember] result = apiInstance.getMembersForBoard(boardID);
+                Debug.WriteLine(result);
+            } catch (Exception e) {
+                Debug.Print("Exception when calling DefaultApi.getMembersForBoard: " + e.Message );
+            }
+        }
+    }
+}
+</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-getMembersForBoard-0-php">
+                              <pre class="prettyprint"><code class="language-php"><&#63;php
+require_once(__DIR__ . '/vendor/autoload.php');
+
+// Configure API key authorization: BearerAuth
+OpenAPITools\Client\Configuration::getDefaultConfiguration()->setApiKey('Authorization', 'YOUR_API_KEY');
+// Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+// OpenAPITools\Client\Configuration::getDefaultConfiguration()->setApiKeyPrefix('Authorization', 'Bearer');
+
+// Create an instance of the API class
+$api_instance = new OpenAPITools\Client\Api\DefaultApi();
+$boardID = boardID_example; // String | Board ID
+
+try {
+    $result = $api_instance->getMembersForBoard($boardID);
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling DefaultApi->getMembersForBoard: ', $e->getMessage(), PHP_EOL;
+}
+?></code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-getMembersForBoard-0-perl">
+                              <pre class="prettyprint"><code class="language-perl">use Data::Dumper;
+use WWW::OPenAPIClient::Configuration;
+use WWW::OPenAPIClient::DefaultApi;
+
+# Configure API key authorization: BearerAuth
+$WWW::OPenAPIClient::Configuration::api_key->{'Authorization'} = 'YOUR_API_KEY';
+# uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+#$WWW::OPenAPIClient::Configuration::api_key_prefix->{'Authorization'} = "Bearer";
+
+# Create an instance of the API class
+my $api_instance = WWW::OPenAPIClient::DefaultApi->new();
+my $boardID = boardID_example; # String | Board ID
+
+eval {
+    my $result = $api_instance->getMembersForBoard(boardID => $boardID);
+    print Dumper($result);
+};
+if ($@) {
+    warn "Exception when calling DefaultApi->getMembersForBoard: $@\n";
+}</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-getMembersForBoard-0-python">
+                              <pre class="prettyprint"><code class="language-python">from __future__ import print_statement
+import time
+import openapi_client
+from openapi_client.rest import ApiException
+from pprint import pprint
+
+# Configure API key authorization: BearerAuth
+openapi_client.configuration.api_key['Authorization'] = 'YOUR_API_KEY'
+# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+# openapi_client.configuration.api_key_prefix['Authorization'] = 'Bearer'
+
+# Create an instance of the API class
+api_instance = openapi_client.DefaultApi()
+boardID = boardID_example # String | Board ID (default to null)
+
+try:
+    api_response = api_instance.get_members_for_board(boardID)
+    pprint(api_response)
+except ApiException as e:
+    print("Exception when calling DefaultApi->getMembersForBoard: %s\n" % e)</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-getMembersForBoard-0-rust">
+                              <pre class="prettyprint"><code class="language-rust">extern crate DefaultApi;
+
+pub fn main() {
+    let boardID = boardID_example; // String
+
+    let mut context = DefaultApi::Context::default();
+    let result = client.getMembersForBoard(boardID, &context).wait();
+
+    println!("{:?}", result);
+}
+</code></pre>
+                            </div>
+                          </div>
+
+                          <h2>Scopes</h2>
+                          <table>
+                            
+                          </table>
+
+                          <h2>Parameters</h2>
+
+                            <div class="methodsubtabletitle">Path parameters</div>
+                            <table id="methodsubtable">
+                                <tr>
+                                  <th width="150px">Name</th>
+                                  <th>Description</th>
+                                </tr>
+                                  <tr><td style="width:150px;">boardID*</td>
+<td>
+
+
+    <div id="d2e199_getMembersForBoard_boardID">
+        <div class="json-schema-view">
+            <div class="primitive">
+                <span class="type">
+                    String
+                </span>
+
+                    <div class="inner description marked">
+Board ID
+                    </div>
+            </div>
+                <div class="inner required">
+                    Required
+                </div>
+        </div>
+    </div>
+</td>
+</tr>
+
+                            </table>
+
+
+
+
+
+                          <h2>Responses</h2>
+                            <h3 id="examples-Default-getMembersForBoard-title-200"></h3>
+                            <p id="examples-Default-getMembersForBoard-description-200" class="marked"></p>
+                            <script>
+                              var responseDefault200_description = `success`;
+                              var responseDefault200_description_break = responseDefault200_description.indexOf('\n');
+                              if (responseDefault200_description_break == -1) {
+                                $("#examples-Default-getMembersForBoard-title-200").text("Status: 200 - " + responseDefault200_description);
+                              } else {
+                                $("#examples-Default-getMembersForBoard-title-200").text("Status: 200 - " + responseDefault200_description.substring(0, responseDefault200_description_break));
+                                $("#examples-Default-getMembersForBoard-description-200").html(responseDefault200_description.substring(responseDefault200_description_break));
+                              }
+                            </script>
+
+
+                            <ul id="responses-detail-Default-getMembersForBoard-200" class="nav nav-tabs nav-tabs-examples" >
+                                <li class="active">
+                                  <a data-toggle="tab" href="#responses-Default-getMembersForBoard-200-schema">Schema</a>
+                                </li>
+
+
+
+
+                            </ul>
+
+
+                            <div class="tab-content" id="responses-Default-getMembersForBoard-200-wrapper" style='margin-bottom: 10px;'>
+                                <div class="tab-pane active" id="responses-Default-getMembersForBoard-200-schema">
+                                  <div id="responses-Default-getMembersForBoard-schema-200" class="exampleStyle">
+                                    <script>
+                                      $(document).ready(function() {
+                                        var schemaWrapper = {
+  "description" : "success",
+  "content" : {
+    "application/json" : {
+      "schema" : {
+        "type" : "array",
+        "items" : {
+          "$ref" : "#/components/schemas/BoardMember"
+        }
+      }
+    }
+  }
+};
+                                        var schema = findNode('schema',schemaWrapper).schema;
+                                        if (!schema) {
+                                          schema = schemaWrapper.schema;
+                                        }
+                                        if (schema.$ref != null) {
+                                          schema = defsParser.$refs.get(schema.$ref);
+                                        } else if (schema.items != null && schema.items.$ref != null) {
+                                            schema.items = defsParser.$refs.get(schema.items.$ref);
+                                        } else {
+                                          schemaWrapper.definitions = Object.assign({}, defs);
+                                          $RefParser.dereference(schemaWrapper).catch(function(err) {
+                                            console.log(err);
+                                          });
+                                        }
+
+                                        var view = new JSONSchemaView(schema, 3);
+                                        $('#responses-Default-getMembersForBoard-200-schema-data').val(JSON.stringify(schema));
+                                        var result = $('#responses-Default-getMembersForBoard-schema-200');
+                                        result.empty();
+                                        result.append(view.render());
+                                      });
+                                    </script>
+                                  </div>
+                                  <input id='responses-Default-getMembersForBoard-200-schema-data' type='hidden' value=''></input>
+                                </div>
+                            </div>
+                            <h3 id="examples-Default-getMembersForBoard-title-default"></h3>
+                            <p id="examples-Default-getMembersForBoard-description-default" class="marked"></p>
+                            <script>
+                              var responseDefaultdefault_description = `internal error`;
+                              var responseDefaultdefault_description_break = responseDefaultdefault_description.indexOf('\n');
+                              if (responseDefaultdefault_description_break == -1) {
+                                $("#examples-Default-getMembersForBoard-title-default").text("Status: default - " + responseDefaultdefault_description);
+                              } else {
+                                $("#examples-Default-getMembersForBoard-title-default").text("Status: default - " + responseDefaultdefault_description.substring(0, responseDefaultdefault_description_break));
+                                $("#examples-Default-getMembersForBoard-description-default").html(responseDefaultdefault_description.substring(responseDefaultdefault_description_break));
+                              }
+                            </script>
+
+
+                            <ul id="responses-detail-Default-getMembersForBoard-default" class="nav nav-tabs nav-tabs-examples" >
+                                <li class="active">
+                                  <a data-toggle="tab" href="#responses-Default-getMembersForBoard-default-schema">Schema</a>
+                                </li>
+
+
+
+
+                            </ul>
+
+
+                            <div class="tab-content" id="responses-Default-getMembersForBoard-default-wrapper" style='margin-bottom: 10px;'>
+                                <div class="tab-pane active" id="responses-Default-getMembersForBoard-default-schema">
+                                  <div id="responses-Default-getMembersForBoard-schema-default" class="exampleStyle">
+                                    <script>
+                                      $(document).ready(function() {
+                                        var schemaWrapper = {
+  "description" : "internal error",
+  "content" : {
+    "application/json" : {
+      "schema" : {
+        "$ref" : "#/components/schemas/ErrorResponse"
+      }
+    }
+  }
+};
+                                        var schema = findNode('schema',schemaWrapper).schema;
+                                        if (!schema) {
+                                          schema = schemaWrapper.schema;
+                                        }
+                                        if (schema.$ref != null) {
+                                          schema = defsParser.$refs.get(schema.$ref);
+                                        } else if (schema.items != null && schema.items.$ref != null) {
+                                            schema.items = defsParser.$refs.get(schema.items.$ref);
+                                        } else {
+                                          schemaWrapper.definitions = Object.assign({}, defs);
+                                          $RefParser.dereference(schemaWrapper).catch(function(err) {
+                                            console.log(err);
+                                          });
+                                        }
+
+                                        var view = new JSONSchemaView(schema, 3);
+                                        $('#responses-Default-getMembersForBoard-default-schema-data').val(JSON.stringify(schema));
+                                        var result = $('#responses-Default-getMembersForBoard-schema-default');
+                                        result.empty();
+                                        result.append(view.render());
+                                      });
+                                    </script>
+                                  </div>
+                                  <input id='responses-Default-getMembersForBoard-default-schema-data' type='hidden' value=''></input>
+                                </div>
+                            </div>
+                        </article>
+                      </div>
+                      <hr>
+                    <div id="api-Default-getMyMemberships">
+                      <article id="api-Default-getMyMemberships-0" data-group="User" data-name="getMyMemberships" data-version="0">
+                        <div class="pull-left">
+                          <h1>getMyMemberships</h1>
+                          <p></p>
+                        </div>
+                        <div class="pull-right"></div>
+                        <div class="clearfix"></div>
+                        <p></p>
+                        <p class="marked">Returns the currently users board memberships</p>
+                        <p></p>
+                        <br />
+                        <pre class="prettyprint language-html prettyprinted" data-type="get"><code><span class="pln">/users/me/memberships</span></code></pre>
+                        <p>
+                          <h3>Usage and SDK Samples</h3>
+                        </p>
+                        <ul class="nav nav-tabs nav-tabs-examples">
+                          <li class="active"><a href="#examples-Default-getMyMemberships-0-curl">Curl</a></li>
+                          <li class=""><a href="#examples-Default-getMyMemberships-0-java">Java</a></li>
+                          <li class=""><a href="#examples-Default-getMyMemberships-0-android">Android</a></li>
+                          <!--<li class=""><a href="#examples-Default-getMyMemberships-0-groovy">Groovy</a></li>-->
+                          <li class=""><a href="#examples-Default-getMyMemberships-0-objc">Obj-C</a></li>
+                          <li class=""><a href="#examples-Default-getMyMemberships-0-javascript">JavaScript</a></li>
+                          <!--<li class=""><a href="#examples-Default-getMyMemberships-0-angular">Angular</a></li>-->
+                          <li class=""><a href="#examples-Default-getMyMemberships-0-csharp">C#</a></li>
+                          <li class=""><a href="#examples-Default-getMyMemberships-0-php">PHP</a></li>
+                          <li class=""><a href="#examples-Default-getMyMemberships-0-perl">Perl</a></li>
+                          <li class=""><a href="#examples-Default-getMyMemberships-0-python">Python</a></li>
+                          <li class=""><a href="#examples-Default-getMyMemberships-0-rust">Rust</a></li>
+                        </ul>
+
+                        <div class="tab-content">
+                          <div class="tab-pane active" id="examples-Default-getMyMemberships-0-curl">
+                            <pre class="prettyprint"><code class="language-bsh">curl -X GET \
+-H "Authorization: [[apiKey]]" \
+ -H "Accept: application/json" \
+ "http://localhost/api/v2/users/me/memberships"
+</code></pre>
+                          </div>
+                          <div class="tab-pane" id="examples-Default-getMyMemberships-0-java">
+                            <pre class="prettyprint"><code class="language-java">import org.openapitools.client.*;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.model.*;
+import org.openapitools.client.api.DefaultApi;
+
+import java.io.File;
+import java.util.*;
+
+public class DefaultApiExample {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        
+        // Configure API key authorization: BearerAuth
+        ApiKeyAuth BearerAuth = (ApiKeyAuth) defaultClient.getAuthentication("BearerAuth");
+        BearerAuth.setApiKey("YOUR API KEY");
+        // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+        //BearerAuth.setApiKeyPrefix("Token");
+
+        // Create an instance of the API class
+        DefaultApi apiInstance = new DefaultApi();
+
+        try {
+            array[BoardMember] result = apiInstance.getMyMemberships();
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling DefaultApi#getMyMemberships");
+            e.printStackTrace();
+        }
+    }
+}
+</code></pre>
+                          </div>
+
+                          <div class="tab-pane" id="examples-Default-getMyMemberships-0-android">
+                            <pre class="prettyprint"><code class="language-java">import org.openapitools.client.api.DefaultApi;
+
+public class DefaultApiExample {
+    public static void main(String[] args) {
+        DefaultApi apiInstance = new DefaultApi();
+
+        try {
+            array[BoardMember] result = apiInstance.getMyMemberships();
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling DefaultApi#getMyMemberships");
+            e.printStackTrace();
+        }
+    }
+}</code></pre>
+                          </div>
+  <!--
+  <div class="tab-pane" id="examples-Default-getMyMemberships-0-groovy">
+  <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
+  </div> -->
+                            <div class="tab-pane" id="examples-Default-getMyMemberships-0-objc">
+                              <pre class="prettyprint"><code class="language-cpp">Configuration *apiConfig = [Configuration sharedConfig];
+
+// Configure API key authorization: (authentication scheme: BearerAuth)
+[apiConfig setApiKey:@"YOUR_API_KEY" forApiKeyIdentifier:@"Authorization"];
+// Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+//[apiConfig setApiKeyPrefix:@"Bearer" forApiKeyIdentifier:@"Authorization"];
+
+
+// Create an instance of the API class
+DefaultApi *apiInstance = [[DefaultApi alloc] init];
+
+[apiInstance getMyMembershipsWithCompletionHandler: 
+              ^(array[BoardMember] output, NSError* error) {
+    if (output) {
+        NSLog(@"%@", output);
+    }
+    if (error) {
+        NSLog(@"Error: %@", error);
+    }
+}];
+</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-getMyMemberships-0-javascript">
+                              <pre class="prettyprint"><code class="language-js">var FocalboardServer = require('focalboard_server');
+var defaultClient = FocalboardServer.ApiClient.instance;
+
+// Configure API key authorization: BearerAuth
+var BearerAuth = defaultClient.authentications['BearerAuth'];
+BearerAuth.apiKey = "YOUR API KEY";
+// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+//BearerAuth.apiKeyPrefix['Authorization'] = "Token";
+
+// Create an instance of the API class
+var api = new FocalboardServer.DefaultApi()
+var callback = function(error, data, response) {
+  if (error) {
+    console.error(error);
+  } else {
+    console.log('API called successfully. Returned data: ' + data);
+  }
+};
+api.getMyMemberships(callback);
+</code></pre>
+                            </div>
+
+                            <!--<div class="tab-pane" id="examples-Default-getMyMemberships-0-angular">
+              <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
+            </div>-->
+                            <div class="tab-pane" id="examples-Default-getMyMemberships-0-csharp">
+                              <pre class="prettyprint"><code class="language-cs">using System;
+using System.Diagnostics;
+using Org.OpenAPITools.Api;
+using Org.OpenAPITools.Client;
+using Org.OpenAPITools.Model;
+
+namespace Example
+{
+    public class getMyMembershipsExample
+    {
+        public void main()
+        {
+            // Configure API key authorization: BearerAuth
+            Configuration.Default.ApiKey.Add("Authorization", "YOUR_API_KEY");
+            // Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+            // Configuration.Default.ApiKeyPrefix.Add("Authorization", "Bearer");
+
+            // Create an instance of the API class
+            var apiInstance = new DefaultApi();
+
+            try {
+                array[BoardMember] result = apiInstance.getMyMemberships();
+                Debug.WriteLine(result);
+            } catch (Exception e) {
+                Debug.Print("Exception when calling DefaultApi.getMyMemberships: " + e.Message );
+            }
+        }
+    }
+}
+</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-getMyMemberships-0-php">
+                              <pre class="prettyprint"><code class="language-php"><&#63;php
+require_once(__DIR__ . '/vendor/autoload.php');
+
+// Configure API key authorization: BearerAuth
+OpenAPITools\Client\Configuration::getDefaultConfiguration()->setApiKey('Authorization', 'YOUR_API_KEY');
+// Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+// OpenAPITools\Client\Configuration::getDefaultConfiguration()->setApiKeyPrefix('Authorization', 'Bearer');
+
+// Create an instance of the API class
+$api_instance = new OpenAPITools\Client\Api\DefaultApi();
+
+try {
+    $result = $api_instance->getMyMemberships();
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling DefaultApi->getMyMemberships: ', $e->getMessage(), PHP_EOL;
+}
+?></code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-getMyMemberships-0-perl">
+                              <pre class="prettyprint"><code class="language-perl">use Data::Dumper;
+use WWW::OPenAPIClient::Configuration;
+use WWW::OPenAPIClient::DefaultApi;
+
+# Configure API key authorization: BearerAuth
+$WWW::OPenAPIClient::Configuration::api_key->{'Authorization'} = 'YOUR_API_KEY';
+# uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+#$WWW::OPenAPIClient::Configuration::api_key_prefix->{'Authorization'} = "Bearer";
+
+# Create an instance of the API class
+my $api_instance = WWW::OPenAPIClient::DefaultApi->new();
+
+eval {
+    my $result = $api_instance->getMyMemberships();
+    print Dumper($result);
+};
+if ($@) {
+    warn "Exception when calling DefaultApi->getMyMemberships: $@\n";
+}</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-getMyMemberships-0-python">
+                              <pre class="prettyprint"><code class="language-python">from __future__ import print_statement
+import time
+import openapi_client
+from openapi_client.rest import ApiException
+from pprint import pprint
+
+# Configure API key authorization: BearerAuth
+openapi_client.configuration.api_key['Authorization'] = 'YOUR_API_KEY'
+# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+# openapi_client.configuration.api_key_prefix['Authorization'] = 'Bearer'
+
+# Create an instance of the API class
+api_instance = openapi_client.DefaultApi()
+
+try:
+    api_response = api_instance.get_my_memberships()
+    pprint(api_response)
+except ApiException as e:
+    print("Exception when calling DefaultApi->getMyMemberships: %s\n" % e)</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-getMyMemberships-0-rust">
+                              <pre class="prettyprint"><code class="language-rust">extern crate DefaultApi;
+
+pub fn main() {
+
+    let mut context = DefaultApi::Context::default();
+    let result = client.getMyMemberships(&context).wait();
+
+    println!("{:?}", result);
+}
+</code></pre>
+                            </div>
+                          </div>
+
+                          <h2>Scopes</h2>
+                          <table>
+                            
+                          </table>
+
+                          <h2>Parameters</h2>
+
+
+
+
+
+
+                          <h2>Responses</h2>
+                            <h3 id="examples-Default-getMyMemberships-title-200"></h3>
+                            <p id="examples-Default-getMyMemberships-description-200" class="marked"></p>
+                            <script>
+                              var responseDefault200_description = `success`;
+                              var responseDefault200_description_break = responseDefault200_description.indexOf('\n');
+                              if (responseDefault200_description_break == -1) {
+                                $("#examples-Default-getMyMemberships-title-200").text("Status: 200 - " + responseDefault200_description);
+                              } else {
+                                $("#examples-Default-getMyMemberships-title-200").text("Status: 200 - " + responseDefault200_description.substring(0, responseDefault200_description_break));
+                                $("#examples-Default-getMyMemberships-description-200").html(responseDefault200_description.substring(responseDefault200_description_break));
+                              }
+                            </script>
+
+
+                            <ul id="responses-detail-Default-getMyMemberships-200" class="nav nav-tabs nav-tabs-examples" >
+                                <li class="active">
+                                  <a data-toggle="tab" href="#responses-Default-getMyMemberships-200-schema">Schema</a>
+                                </li>
+
+
+
+
+                            </ul>
+
+
+                            <div class="tab-content" id="responses-Default-getMyMemberships-200-wrapper" style='margin-bottom: 10px;'>
+                                <div class="tab-pane active" id="responses-Default-getMyMemberships-200-schema">
+                                  <div id="responses-Default-getMyMemberships-schema-200" class="exampleStyle">
+                                    <script>
+                                      $(document).ready(function() {
+                                        var schemaWrapper = {
+  "description" : "success",
+  "content" : {
+    "application/json" : {
+      "schema" : {
+        "type" : "array",
+        "items" : {
+          "$ref" : "#/components/schemas/BoardMember"
+        }
+      }
+    }
+  }
+};
+                                        var schema = findNode('schema',schemaWrapper).schema;
+                                        if (!schema) {
+                                          schema = schemaWrapper.schema;
+                                        }
+                                        if (schema.$ref != null) {
+                                          schema = defsParser.$refs.get(schema.$ref);
+                                        } else if (schema.items != null && schema.items.$ref != null) {
+                                            schema.items = defsParser.$refs.get(schema.items.$ref);
+                                        } else {
+                                          schemaWrapper.definitions = Object.assign({}, defs);
+                                          $RefParser.dereference(schemaWrapper).catch(function(err) {
+                                            console.log(err);
+                                          });
+                                        }
+
+                                        var view = new JSONSchemaView(schema, 3);
+                                        $('#responses-Default-getMyMemberships-200-schema-data').val(JSON.stringify(schema));
+                                        var result = $('#responses-Default-getMyMemberships-schema-200');
+                                        result.empty();
+                                        result.append(view.render());
+                                      });
+                                    </script>
+                                  </div>
+                                  <input id='responses-Default-getMyMemberships-200-schema-data' type='hidden' value=''></input>
+                                </div>
+                            </div>
+                            <h3 id="examples-Default-getMyMemberships-title-default"></h3>
+                            <p id="examples-Default-getMyMemberships-description-default" class="marked"></p>
+                            <script>
+                              var responseDefaultdefault_description = `internal error`;
+                              var responseDefaultdefault_description_break = responseDefaultdefault_description.indexOf('\n');
+                              if (responseDefaultdefault_description_break == -1) {
+                                $("#examples-Default-getMyMemberships-title-default").text("Status: default - " + responseDefaultdefault_description);
+                              } else {
+                                $("#examples-Default-getMyMemberships-title-default").text("Status: default - " + responseDefaultdefault_description.substring(0, responseDefaultdefault_description_break));
+                                $("#examples-Default-getMyMemberships-description-default").html(responseDefaultdefault_description.substring(responseDefaultdefault_description_break));
+                              }
+                            </script>
+
+
+                            <ul id="responses-detail-Default-getMyMemberships-default" class="nav nav-tabs nav-tabs-examples" >
+                                <li class="active">
+                                  <a data-toggle="tab" href="#responses-Default-getMyMemberships-default-schema">Schema</a>
+                                </li>
+
+
+
+
+                            </ul>
+
+
+                            <div class="tab-content" id="responses-Default-getMyMemberships-default-wrapper" style='margin-bottom: 10px;'>
+                                <div class="tab-pane active" id="responses-Default-getMyMemberships-default-schema">
+                                  <div id="responses-Default-getMyMemberships-schema-default" class="exampleStyle">
+                                    <script>
+                                      $(document).ready(function() {
+                                        var schemaWrapper = {
+  "description" : "internal error",
+  "content" : {
+    "application/json" : {
+      "schema" : {
+        "$ref" : "#/components/schemas/ErrorResponse"
+      }
+    }
+  }
+};
+                                        var schema = findNode('schema',schemaWrapper).schema;
+                                        if (!schema) {
+                                          schema = schemaWrapper.schema;
+                                        }
+                                        if (schema.$ref != null) {
+                                          schema = defsParser.$refs.get(schema.$ref);
+                                        } else if (schema.items != null && schema.items.$ref != null) {
+                                            schema.items = defsParser.$refs.get(schema.items.$ref);
+                                        } else {
+                                          schemaWrapper.definitions = Object.assign({}, defs);
+                                          $RefParser.dereference(schemaWrapper).catch(function(err) {
+                                            console.log(err);
+                                          });
+                                        }
+
+                                        var view = new JSONSchemaView(schema, 3);
+                                        $('#responses-Default-getMyMemberships-default-schema-data').val(JSON.stringify(schema));
+                                        var result = $('#responses-Default-getMyMemberships-schema-default');
+                                        result.empty();
+                                        result.append(view.render());
+                                      });
+                                    </script>
+                                  </div>
+                                  <input id='responses-Default-getMyMemberships-default-schema-data' type='hidden' value=''></input>
+                                </div>
+                            </div>
+                        </article>
+                      </div>
+                      <hr>
                     <div id="api-Default-getSharing">
                       <article id="api-Default-getSharing-0" data-group="User" data-name="getSharing" data-version="0">
                         <div class="pull-left">
@@ -5247,10 +11501,10 @@ pub fn main() {
                         <div class="pull-right"></div>
                         <div class="clearfix"></div>
                         <p></p>
-                        <p class="marked">Returns sharing information for a root block</p>
+                        <p class="marked">Returns sharing information for a board</p>
                         <p></p>
                         <br />
-                        <pre class="prettyprint language-html prettyprinted" data-type="get"><code><span class="pln">/api/v1/workspaces/{workspaceID}/sharing/{rootID}</span></code></pre>
+                        <pre class="prettyprint language-html prettyprinted" data-type="get"><code><span class="pln">/boards/{boardID}/sharing</span></code></pre>
                         <p>
                           <h3>Usage and SDK Samples</h3>
                         </p>
@@ -5274,7 +11528,7 @@ pub fn main() {
                             <pre class="prettyprint"><code class="language-bsh">curl -X GET \
 -H "Authorization: [[apiKey]]" \
  -H "Accept: application/json" \
- "http://localhost/api/v1/api/v1/workspaces/{workspaceID}/sharing/{rootID}"
+ "http://localhost/api/v2/boards/{boardID}/sharing"
 </code></pre>
                           </div>
                           <div class="tab-pane" id="examples-Default-getSharing-0-java">
@@ -5298,11 +11552,10 @@ public class DefaultApiExample {
 
         // Create an instance of the API class
         DefaultApi apiInstance = new DefaultApi();
-        String workspaceID = workspaceID_example; // String | Workspace ID
-        String rootID = rootID_example; // String | ID of the root block
+        String boardID = boardID_example; // String | Board ID
 
         try {
-            Sharing result = apiInstance.getSharing(workspaceID, rootID);
+            Sharing result = apiInstance.getSharing(boardID);
             System.out.println(result);
         } catch (ApiException e) {
             System.err.println("Exception when calling DefaultApi#getSharing");
@@ -5319,11 +11572,10 @@ public class DefaultApiExample {
 public class DefaultApiExample {
     public static void main(String[] args) {
         DefaultApi apiInstance = new DefaultApi();
-        String workspaceID = workspaceID_example; // String | Workspace ID
-        String rootID = rootID_example; // String | ID of the root block
+        String boardID = boardID_example; // String | Board ID
 
         try {
-            Sharing result = apiInstance.getSharing(workspaceID, rootID);
+            Sharing result = apiInstance.getSharing(boardID);
             System.out.println(result);
         } catch (ApiException e) {
             System.err.println("Exception when calling DefaultApi#getSharing");
@@ -5347,11 +11599,9 @@ public class DefaultApiExample {
 
 // Create an instance of the API class
 DefaultApi *apiInstance = [[DefaultApi alloc] init];
-String *workspaceID = workspaceID_example; // Workspace ID (default to null)
-String *rootID = rootID_example; // ID of the root block (default to null)
+String *boardID = boardID_example; // Board ID (default to null)
 
-[apiInstance getSharingWith:workspaceID
-    rootID:rootID
+[apiInstance getSharingWith:boardID
               completionHandler: ^(Sharing output, NSError* error) {
     if (output) {
         NSLog(@"%@", output);
@@ -5375,8 +11625,7 @@ BearerAuth.apiKey = "YOUR API KEY";
 
 // Create an instance of the API class
 var api = new FocalboardServer.DefaultApi()
-var workspaceID = workspaceID_example; // {String} Workspace ID
-var rootID = rootID_example; // {String} ID of the root block
+var boardID = boardID_example; // {String} Board ID
 
 var callback = function(error, data, response) {
   if (error) {
@@ -5385,7 +11634,7 @@ var callback = function(error, data, response) {
     console.log('API called successfully. Returned data: ' + data);
   }
 };
-api.getSharing(workspaceID, rootID, callback);
+api.getSharing(boardID, callback);
 </code></pre>
                             </div>
 
@@ -5412,11 +11661,10 @@ namespace Example
 
             // Create an instance of the API class
             var apiInstance = new DefaultApi();
-            var workspaceID = workspaceID_example;  // String | Workspace ID (default to null)
-            var rootID = rootID_example;  // String | ID of the root block (default to null)
+            var boardID = boardID_example;  // String | Board ID (default to null)
 
             try {
-                Sharing result = apiInstance.getSharing(workspaceID, rootID);
+                Sharing result = apiInstance.getSharing(boardID);
                 Debug.WriteLine(result);
             } catch (Exception e) {
                 Debug.Print("Exception when calling DefaultApi.getSharing: " + e.Message );
@@ -5438,11 +11686,10 @@ OpenAPITools\Client\Configuration::getDefaultConfiguration()->setApiKey('Authori
 
 // Create an instance of the API class
 $api_instance = new OpenAPITools\Client\Api\DefaultApi();
-$workspaceID = workspaceID_example; // String | Workspace ID
-$rootID = rootID_example; // String | ID of the root block
+$boardID = boardID_example; // String | Board ID
 
 try {
-    $result = $api_instance->getSharing($workspaceID, $rootID);
+    $result = $api_instance->getSharing($boardID);
     print_r($result);
 } catch (Exception $e) {
     echo 'Exception when calling DefaultApi->getSharing: ', $e->getMessage(), PHP_EOL;
@@ -5462,11 +11709,10 @@ $WWW::OPenAPIClient::Configuration::api_key->{'Authorization'} = 'YOUR_API_KEY';
 
 # Create an instance of the API class
 my $api_instance = WWW::OPenAPIClient::DefaultApi->new();
-my $workspaceID = workspaceID_example; # String | Workspace ID
-my $rootID = rootID_example; # String | ID of the root block
+my $boardID = boardID_example; # String | Board ID
 
 eval {
-    my $result = $api_instance->getSharing(workspaceID => $workspaceID, rootID => $rootID);
+    my $result = $api_instance->getSharing(boardID => $boardID);
     print Dumper($result);
 };
 if ($@) {
@@ -5488,11 +11734,10 @@ openapi_client.configuration.api_key['Authorization'] = 'YOUR_API_KEY'
 
 # Create an instance of the API class
 api_instance = openapi_client.DefaultApi()
-workspaceID = workspaceID_example # String | Workspace ID (default to null)
-rootID = rootID_example # String | ID of the root block (default to null)
+boardID = boardID_example # String | Board ID (default to null)
 
 try:
-    api_response = api_instance.get_sharing(workspaceID, rootID)
+    api_response = api_instance.get_sharing(boardID)
     pprint(api_response)
 except ApiException as e:
     print("Exception when calling DefaultApi->getSharing: %s\n" % e)</code></pre>
@@ -5502,11 +11747,10 @@ except ApiException as e:
                               <pre class="prettyprint"><code class="language-rust">extern crate DefaultApi;
 
 pub fn main() {
-    let workspaceID = workspaceID_example; // String
-    let rootID = rootID_example; // String
+    let boardID = boardID_example; // String
 
     let mut context = DefaultApi::Context::default();
-    let result = client.getSharing(workspaceID, rootID, &context).wait();
+    let result = client.getSharing(boardID, &context).wait();
 
     println!("{:?}", result);
 }
@@ -5527,11 +11771,11 @@ pub fn main() {
                                   <th width="150px">Name</th>
                                   <th>Description</th>
                                 </tr>
-                                  <tr><td style="width:150px;">workspaceID*</td>
+                                  <tr><td style="width:150px;">boardID*</td>
 <td>
 
 
-    <div id="d2e199_getSharing_workspaceID">
+    <div id="d2e199_getSharing_boardID">
         <div class="json-schema-view">
             <div class="primitive">
                 <span class="type">
@@ -5539,30 +11783,7 @@ pub fn main() {
                 </span>
 
                     <div class="inner description marked">
-Workspace ID
-                    </div>
-            </div>
-                <div class="inner required">
-                    Required
-                </div>
-        </div>
-    </div>
-</td>
-</tr>
-
-                                  <tr><td style="width:150px;">rootID*</td>
-<td>
-
-
-    <div id="d2e199_getSharing_rootID">
-        <div class="json-schema-view">
-            <div class="primitive">
-                <span class="type">
-                    String
-                </span>
-
-                    <div class="inner description marked">
-ID of the root block
+Board ID
                     </div>
             </div>
                 <div class="inner required">
@@ -5646,6 +11867,28 @@ ID of the root block
                                   <input id='responses-Default-getSharing-200-schema-data' type='hidden' value=''></input>
                                 </div>
                             </div>
+                            <h3 id="examples-Default-getSharing-title-404"></h3>
+                            <p id="examples-Default-getSharing-description-404" class="marked"></p>
+                            <script>
+                              var responseDefault404_description = `board not found`;
+                              var responseDefault404_description_break = responseDefault404_description.indexOf('\n');
+                              if (responseDefault404_description_break == -1) {
+                                $("#examples-Default-getSharing-title-404").text("Status: 404 - " + responseDefault404_description);
+                              } else {
+                                $("#examples-Default-getSharing-title-404").text("Status: 404 - " + responseDefault404_description.substring(0, responseDefault404_description_break));
+                                $("#examples-Default-getSharing-description-404").html(responseDefault404_description.substring(responseDefault404_description_break));
+                              }
+                            </script>
+
+
+                            <ul id="responses-detail-Default-getSharing-404" class="nav nav-tabs nav-tabs-examples" >
+
+
+                            </ul>
+
+
+                            <div class="tab-content" id="responses-Default-getSharing-404-wrapper" style='margin-bottom: 10px;'>
+                            </div>
                             <h3 id="examples-Default-getSharing-title-default"></h3>
                             <p id="examples-Default-getSharing-description-default" class="marked"></p>
                             <script>
@@ -5715,525 +11958,6 @@ ID of the root block
                         </article>
                       </div>
                       <hr>
-                    <div id="api-Default-getSubTree">
-                      <article id="api-Default-getSubTree-0" data-group="User" data-name="getSubTree" data-version="0">
-                        <div class="pull-left">
-                          <h1>getSubTree</h1>
-                          <p></p>
-                        </div>
-                        <div class="pull-right"></div>
-                        <div class="clearfix"></div>
-                        <p></p>
-                        <p class="marked">Returns the blocks of a subtree</p>
-                        <p></p>
-                        <br />
-                        <pre class="prettyprint language-html prettyprinted" data-type="get"><code><span class="pln">/api/v1/workspaces/{workspaceID}/blocks/{blockID}/subtree</span></code></pre>
-                        <p>
-                          <h3>Usage and SDK Samples</h3>
-                        </p>
-                        <ul class="nav nav-tabs nav-tabs-examples">
-                          <li class="active"><a href="#examples-Default-getSubTree-0-curl">Curl</a></li>
-                          <li class=""><a href="#examples-Default-getSubTree-0-java">Java</a></li>
-                          <li class=""><a href="#examples-Default-getSubTree-0-android">Android</a></li>
-                          <!--<li class=""><a href="#examples-Default-getSubTree-0-groovy">Groovy</a></li>-->
-                          <li class=""><a href="#examples-Default-getSubTree-0-objc">Obj-C</a></li>
-                          <li class=""><a href="#examples-Default-getSubTree-0-javascript">JavaScript</a></li>
-                          <!--<li class=""><a href="#examples-Default-getSubTree-0-angular">Angular</a></li>-->
-                          <li class=""><a href="#examples-Default-getSubTree-0-csharp">C#</a></li>
-                          <li class=""><a href="#examples-Default-getSubTree-0-php">PHP</a></li>
-                          <li class=""><a href="#examples-Default-getSubTree-0-perl">Perl</a></li>
-                          <li class=""><a href="#examples-Default-getSubTree-0-python">Python</a></li>
-                          <li class=""><a href="#examples-Default-getSubTree-0-rust">Rust</a></li>
-                        </ul>
-
-                        <div class="tab-content">
-                          <div class="tab-pane active" id="examples-Default-getSubTree-0-curl">
-                            <pre class="prettyprint"><code class="language-bsh">curl -X GET \
--H "Authorization: [[apiKey]]" \
- -H "Accept: application/json" \
- "http://localhost/api/v1/api/v1/workspaces/{workspaceID}/blocks/{blockID}/subtree?l=56"
-</code></pre>
-                          </div>
-                          <div class="tab-pane" id="examples-Default-getSubTree-0-java">
-                            <pre class="prettyprint"><code class="language-java">import org.openapitools.client.*;
-import org.openapitools.client.auth.*;
-import org.openapitools.client.model.*;
-import org.openapitools.client.api.DefaultApi;
-
-import java.io.File;
-import java.util.*;
-
-public class DefaultApiExample {
-    public static void main(String[] args) {
-        ApiClient defaultClient = Configuration.getDefaultApiClient();
-        
-        // Configure API key authorization: BearerAuth
-        ApiKeyAuth BearerAuth = (ApiKeyAuth) defaultClient.getAuthentication("BearerAuth");
-        BearerAuth.setApiKey("YOUR API KEY");
-        // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
-        //BearerAuth.setApiKeyPrefix("Token");
-
-        // Create an instance of the API class
-        DefaultApi apiInstance = new DefaultApi();
-        String workspaceID = workspaceID_example; // String | Workspace ID
-        String blockID = blockID_example; // String | The ID of the root block of the subtree
-        Integer l = 56; // Integer | The number of levels to return. 2 or 3. Defaults to 2.
-
-        try {
-            array[Block] result = apiInstance.getSubTree(workspaceID, blockID, l);
-            System.out.println(result);
-        } catch (ApiException e) {
-            System.err.println("Exception when calling DefaultApi#getSubTree");
-            e.printStackTrace();
-        }
-    }
-}
-</code></pre>
-                          </div>
-
-                          <div class="tab-pane" id="examples-Default-getSubTree-0-android">
-                            <pre class="prettyprint"><code class="language-java">import org.openapitools.client.api.DefaultApi;
-
-public class DefaultApiExample {
-    public static void main(String[] args) {
-        DefaultApi apiInstance = new DefaultApi();
-        String workspaceID = workspaceID_example; // String | Workspace ID
-        String blockID = blockID_example; // String | The ID of the root block of the subtree
-        Integer l = 56; // Integer | The number of levels to return. 2 or 3. Defaults to 2.
-
-        try {
-            array[Block] result = apiInstance.getSubTree(workspaceID, blockID, l);
-            System.out.println(result);
-        } catch (ApiException e) {
-            System.err.println("Exception when calling DefaultApi#getSubTree");
-            e.printStackTrace();
-        }
-    }
-}</code></pre>
-                          </div>
-  <!--
-  <div class="tab-pane" id="examples-Default-getSubTree-0-groovy">
-  <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
-  </div> -->
-                            <div class="tab-pane" id="examples-Default-getSubTree-0-objc">
-                              <pre class="prettyprint"><code class="language-cpp">Configuration *apiConfig = [Configuration sharedConfig];
-
-// Configure API key authorization: (authentication scheme: BearerAuth)
-[apiConfig setApiKey:@"YOUR_API_KEY" forApiKeyIdentifier:@"Authorization"];
-// Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
-//[apiConfig setApiKeyPrefix:@"Bearer" forApiKeyIdentifier:@"Authorization"];
-
-
-// Create an instance of the API class
-DefaultApi *apiInstance = [[DefaultApi alloc] init];
-String *workspaceID = workspaceID_example; // Workspace ID (default to null)
-String *blockID = blockID_example; // The ID of the root block of the subtree (default to null)
-Integer *l = 56; // The number of levels to return. 2 or 3. Defaults to 2. (optional) (default to null)
-
-[apiInstance getSubTreeWith:workspaceID
-    blockID:blockID
-    l:l
-              completionHandler: ^(array[Block] output, NSError* error) {
-    if (output) {
-        NSLog(@"%@", output);
-    }
-    if (error) {
-        NSLog(@"Error: %@", error);
-    }
-}];
-</code></pre>
-                            </div>
-
-                            <div class="tab-pane" id="examples-Default-getSubTree-0-javascript">
-                              <pre class="prettyprint"><code class="language-js">var FocalboardServer = require('focalboard_server');
-var defaultClient = FocalboardServer.ApiClient.instance;
-
-// Configure API key authorization: BearerAuth
-var BearerAuth = defaultClient.authentications['BearerAuth'];
-BearerAuth.apiKey = "YOUR API KEY";
-// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
-//BearerAuth.apiKeyPrefix['Authorization'] = "Token";
-
-// Create an instance of the API class
-var api = new FocalboardServer.DefaultApi()
-var workspaceID = workspaceID_example; // {String} Workspace ID
-var blockID = blockID_example; // {String} The ID of the root block of the subtree
-var opts = {
-  'l': 56 // {Integer} The number of levels to return. 2 or 3. Defaults to 2.
-};
-
-var callback = function(error, data, response) {
-  if (error) {
-    console.error(error);
-  } else {
-    console.log('API called successfully. Returned data: ' + data);
-  }
-};
-api.getSubTree(workspaceID, blockID, opts, callback);
-</code></pre>
-                            </div>
-
-                            <!--<div class="tab-pane" id="examples-Default-getSubTree-0-angular">
-              <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
-            </div>-->
-                            <div class="tab-pane" id="examples-Default-getSubTree-0-csharp">
-                              <pre class="prettyprint"><code class="language-cs">using System;
-using System.Diagnostics;
-using Org.OpenAPITools.Api;
-using Org.OpenAPITools.Client;
-using Org.OpenAPITools.Model;
-
-namespace Example
-{
-    public class getSubTreeExample
-    {
-        public void main()
-        {
-            // Configure API key authorization: BearerAuth
-            Configuration.Default.ApiKey.Add("Authorization", "YOUR_API_KEY");
-            // Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
-            // Configuration.Default.ApiKeyPrefix.Add("Authorization", "Bearer");
-
-            // Create an instance of the API class
-            var apiInstance = new DefaultApi();
-            var workspaceID = workspaceID_example;  // String | Workspace ID (default to null)
-            var blockID = blockID_example;  // String | The ID of the root block of the subtree (default to null)
-            var l = 56;  // Integer | The number of levels to return. 2 or 3. Defaults to 2. (optional)  (default to null)
-
-            try {
-                array[Block] result = apiInstance.getSubTree(workspaceID, blockID, l);
-                Debug.WriteLine(result);
-            } catch (Exception e) {
-                Debug.Print("Exception when calling DefaultApi.getSubTree: " + e.Message );
-            }
-        }
-    }
-}
-</code></pre>
-                            </div>
-
-                            <div class="tab-pane" id="examples-Default-getSubTree-0-php">
-                              <pre class="prettyprint"><code class="language-php"><&#63;php
-require_once(__DIR__ . '/vendor/autoload.php');
-
-// Configure API key authorization: BearerAuth
-OpenAPITools\Client\Configuration::getDefaultConfiguration()->setApiKey('Authorization', 'YOUR_API_KEY');
-// Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
-// OpenAPITools\Client\Configuration::getDefaultConfiguration()->setApiKeyPrefix('Authorization', 'Bearer');
-
-// Create an instance of the API class
-$api_instance = new OpenAPITools\Client\Api\DefaultApi();
-$workspaceID = workspaceID_example; // String | Workspace ID
-$blockID = blockID_example; // String | The ID of the root block of the subtree
-$l = 56; // Integer | The number of levels to return. 2 or 3. Defaults to 2.
-
-try {
-    $result = $api_instance->getSubTree($workspaceID, $blockID, $l);
-    print_r($result);
-} catch (Exception $e) {
-    echo 'Exception when calling DefaultApi->getSubTree: ', $e->getMessage(), PHP_EOL;
-}
-?></code></pre>
-                            </div>
-
-                            <div class="tab-pane" id="examples-Default-getSubTree-0-perl">
-                              <pre class="prettyprint"><code class="language-perl">use Data::Dumper;
-use WWW::OPenAPIClient::Configuration;
-use WWW::OPenAPIClient::DefaultApi;
-
-# Configure API key authorization: BearerAuth
-$WWW::OPenAPIClient::Configuration::api_key->{'Authorization'} = 'YOUR_API_KEY';
-# uncomment below to setup prefix (e.g. Bearer) for API key, if needed
-#$WWW::OPenAPIClient::Configuration::api_key_prefix->{'Authorization'} = "Bearer";
-
-# Create an instance of the API class
-my $api_instance = WWW::OPenAPIClient::DefaultApi->new();
-my $workspaceID = workspaceID_example; # String | Workspace ID
-my $blockID = blockID_example; # String | The ID of the root block of the subtree
-my $l = 56; # Integer | The number of levels to return. 2 or 3. Defaults to 2.
-
-eval {
-    my $result = $api_instance->getSubTree(workspaceID => $workspaceID, blockID => $blockID, l => $l);
-    print Dumper($result);
-};
-if ($@) {
-    warn "Exception when calling DefaultApi->getSubTree: $@\n";
-}</code></pre>
-                            </div>
-
-                            <div class="tab-pane" id="examples-Default-getSubTree-0-python">
-                              <pre class="prettyprint"><code class="language-python">from __future__ import print_statement
-import time
-import openapi_client
-from openapi_client.rest import ApiException
-from pprint import pprint
-
-# Configure API key authorization: BearerAuth
-openapi_client.configuration.api_key['Authorization'] = 'YOUR_API_KEY'
-# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
-# openapi_client.configuration.api_key_prefix['Authorization'] = 'Bearer'
-
-# Create an instance of the API class
-api_instance = openapi_client.DefaultApi()
-workspaceID = workspaceID_example # String | Workspace ID (default to null)
-blockID = blockID_example # String | The ID of the root block of the subtree (default to null)
-l = 56 # Integer | The number of levels to return. 2 or 3. Defaults to 2. (optional) (default to null)
-
-try:
-    api_response = api_instance.get_sub_tree(workspaceID, blockID, l=l)
-    pprint(api_response)
-except ApiException as e:
-    print("Exception when calling DefaultApi->getSubTree: %s\n" % e)</code></pre>
-                            </div>
-
-                            <div class="tab-pane" id="examples-Default-getSubTree-0-rust">
-                              <pre class="prettyprint"><code class="language-rust">extern crate DefaultApi;
-
-pub fn main() {
-    let workspaceID = workspaceID_example; // String
-    let blockID = blockID_example; // String
-    let l = 56; // Integer
-
-    let mut context = DefaultApi::Context::default();
-    let result = client.getSubTree(workspaceID, blockID, l, &context).wait();
-
-    println!("{:?}", result);
-}
-</code></pre>
-                            </div>
-                          </div>
-
-                          <h2>Scopes</h2>
-                          <table>
-                            
-                          </table>
-
-                          <h2>Parameters</h2>
-
-                            <div class="methodsubtabletitle">Path parameters</div>
-                            <table id="methodsubtable">
-                                <tr>
-                                  <th width="150px">Name</th>
-                                  <th>Description</th>
-                                </tr>
-                                  <tr><td style="width:150px;">workspaceID*</td>
-<td>
-
-
-    <div id="d2e199_getSubTree_workspaceID">
-        <div class="json-schema-view">
-            <div class="primitive">
-                <span class="type">
-                    String
-                </span>
-
-                    <div class="inner description marked">
-Workspace ID
-                    </div>
-            </div>
-                <div class="inner required">
-                    Required
-                </div>
-        </div>
-    </div>
-</td>
-</tr>
-
-                                  <tr><td style="width:150px;">blockID*</td>
-<td>
-
-
-    <div id="d2e199_getSubTree_blockID">
-        <div class="json-schema-view">
-            <div class="primitive">
-                <span class="type">
-                    String
-                </span>
-
-                    <div class="inner description marked">
-The ID of the root block of the subtree
-                    </div>
-            </div>
-                <div class="inner required">
-                    Required
-                </div>
-        </div>
-    </div>
-</td>
-</tr>
-
-                            </table>
-
-
-
-
-                            <div class="methodsubtabletitle">Query parameters</div>
-                            <table id="methodsubtable">
-                              <tr>
-                                <th width="150px">Name</th>
-                                <th>Description</th>
-                              </tr>
-                                <tr><td style="width:150px;">l</td>
-<td>
-
-
-    <div id="d2e199_getSubTree_l">
-        <div class="json-schema-view">
-            <div class="primitive">
-                <span class="type">
-                    Integer
-                </span>
-
-                    <div class="inner description marked">
-The number of levels to return. 2 or 3. Defaults to 2.
-                    </div>
-            </div>
-        </div>
-    </div>
-</td>
-</tr>
-
-                            </table>
-
-                          <h2>Responses</h2>
-                            <h3 id="examples-Default-getSubTree-title-200"></h3>
-                            <p id="examples-Default-getSubTree-description-200" class="marked"></p>
-                            <script>
-                              var responseDefault200_description = `success`;
-                              var responseDefault200_description_break = responseDefault200_description.indexOf('\n');
-                              if (responseDefault200_description_break == -1) {
-                                $("#examples-Default-getSubTree-title-200").text("Status: 200 - " + responseDefault200_description);
-                              } else {
-                                $("#examples-Default-getSubTree-title-200").text("Status: 200 - " + responseDefault200_description.substring(0, responseDefault200_description_break));
-                                $("#examples-Default-getSubTree-description-200").html(responseDefault200_description.substring(responseDefault200_description_break));
-                              }
-                            </script>
-
-
-                            <ul id="responses-detail-Default-getSubTree-200" class="nav nav-tabs nav-tabs-examples" >
-                                <li class="active">
-                                  <a data-toggle="tab" href="#responses-Default-getSubTree-200-schema">Schema</a>
-                                </li>
-
-
-
-
-                            </ul>
-
-
-                            <div class="tab-content" id="responses-Default-getSubTree-200-wrapper" style='margin-bottom: 10px;'>
-                                <div class="tab-pane active" id="responses-Default-getSubTree-200-schema">
-                                  <div id="responses-Default-getSubTree-schema-200" class="exampleStyle">
-                                    <script>
-                                      $(document).ready(function() {
-                                        var schemaWrapper = {
-  "description" : "success",
-  "content" : {
-    "application/json" : {
-      "schema" : {
-        "type" : "array",
-        "items" : {
-          "$ref" : "#/components/schemas/Block"
-        }
-      }
-    }
-  }
-};
-                                        var schema = findNode('schema',schemaWrapper).schema;
-                                        if (!schema) {
-                                          schema = schemaWrapper.schema;
-                                        }
-                                        if (schema.$ref != null) {
-                                          schema = defsParser.$refs.get(schema.$ref);
-                                        } else if (schema.items != null && schema.items.$ref != null) {
-                                            schema.items = defsParser.$refs.get(schema.items.$ref);
-                                        } else {
-                                          schemaWrapper.definitions = Object.assign({}, defs);
-                                          $RefParser.dereference(schemaWrapper).catch(function(err) {
-                                            console.log(err);
-                                          });
-                                        }
-
-                                        var view = new JSONSchemaView(schema, 3);
-                                        $('#responses-Default-getSubTree-200-schema-data').val(JSON.stringify(schema));
-                                        var result = $('#responses-Default-getSubTree-schema-200');
-                                        result.empty();
-                                        result.append(view.render());
-                                      });
-                                    </script>
-                                  </div>
-                                  <input id='responses-Default-getSubTree-200-schema-data' type='hidden' value=''></input>
-                                </div>
-                            </div>
-                            <h3 id="examples-Default-getSubTree-title-default"></h3>
-                            <p id="examples-Default-getSubTree-description-default" class="marked"></p>
-                            <script>
-                              var responseDefaultdefault_description = `internal error`;
-                              var responseDefaultdefault_description_break = responseDefaultdefault_description.indexOf('\n');
-                              if (responseDefaultdefault_description_break == -1) {
-                                $("#examples-Default-getSubTree-title-default").text("Status: default - " + responseDefaultdefault_description);
-                              } else {
-                                $("#examples-Default-getSubTree-title-default").text("Status: default - " + responseDefaultdefault_description.substring(0, responseDefaultdefault_description_break));
-                                $("#examples-Default-getSubTree-description-default").html(responseDefaultdefault_description.substring(responseDefaultdefault_description_break));
-                              }
-                            </script>
-
-
-                            <ul id="responses-detail-Default-getSubTree-default" class="nav nav-tabs nav-tabs-examples" >
-                                <li class="active">
-                                  <a data-toggle="tab" href="#responses-Default-getSubTree-default-schema">Schema</a>
-                                </li>
-
-
-
-
-                            </ul>
-
-
-                            <div class="tab-content" id="responses-Default-getSubTree-default-wrapper" style='margin-bottom: 10px;'>
-                                <div class="tab-pane active" id="responses-Default-getSubTree-default-schema">
-                                  <div id="responses-Default-getSubTree-schema-default" class="exampleStyle">
-                                    <script>
-                                      $(document).ready(function() {
-                                        var schemaWrapper = {
-  "description" : "internal error",
-  "content" : {
-    "application/json" : {
-      "schema" : {
-        "$ref" : "#/components/schemas/ErrorResponse"
-      }
-    }
-  }
-};
-                                        var schema = findNode('schema',schemaWrapper).schema;
-                                        if (!schema) {
-                                          schema = schemaWrapper.schema;
-                                        }
-                                        if (schema.$ref != null) {
-                                          schema = defsParser.$refs.get(schema.$ref);
-                                        } else if (schema.items != null && schema.items.$ref != null) {
-                                            schema.items = defsParser.$refs.get(schema.items.$ref);
-                                        } else {
-                                          schemaWrapper.definitions = Object.assign({}, defs);
-                                          $RefParser.dereference(schemaWrapper).catch(function(err) {
-                                            console.log(err);
-                                          });
-                                        }
-
-                                        var view = new JSONSchemaView(schema, 3);
-                                        $('#responses-Default-getSubTree-default-schema-data').val(JSON.stringify(schema));
-                                        var result = $('#responses-Default-getSubTree-schema-default');
-                                        result.empty();
-                                        result.append(view.render());
-                                      });
-                                    </script>
-                                  </div>
-                                  <input id='responses-Default-getSubTree-default-schema-data' type='hidden' value=''></input>
-                                </div>
-                            </div>
-                        </article>
-                      </div>
-                      <hr>
                     <div id="api-Default-getSubscriptions">
                       <article id="api-Default-getSubscriptions-0" data-group="User" data-name="getSubscriptions" data-version="0">
                         <div class="pull-left">
@@ -6246,7 +11970,7 @@ The number of levels to return. 2 or 3. Defaults to 2.
                         <p class="marked"></p>
                         <p></p>
                         <br />
-                        <pre class="prettyprint language-html prettyprinted" data-type="get"><code><span class="pln">/api/v1/workspaces/{workspaceID}/subscriptions/{subscriberID}</span></code></pre>
+                        <pre class="prettyprint language-html prettyprinted" data-type="get"><code><span class="pln">/subscriptions/{subscriberID}</span></code></pre>
                         <p>
                           <h3>Usage and SDK Samples</h3>
                         </p>
@@ -6270,7 +11994,7 @@ The number of levels to return. 2 or 3. Defaults to 2.
                             <pre class="prettyprint"><code class="language-bsh">curl -X GET \
 -H "Authorization: [[apiKey]]" \
  -H "Accept: application/json" \
- "http://localhost/api/v1/api/v1/workspaces/{workspaceID}/subscriptions/{subscriberID}"
+ "http://localhost/api/v2/subscriptions/{subscriberID}"
 </code></pre>
                           </div>
                           <div class="tab-pane" id="examples-Default-getSubscriptions-0-java">
@@ -6294,11 +12018,10 @@ public class DefaultApiExample {
 
         // Create an instance of the API class
         DefaultApi apiInstance = new DefaultApi();
-        String workspaceID = workspaceID_example; // String | Workspace ID
         String subscriberID = subscriberID_example; // String | Subscriber ID
 
         try {
-            array[User] result = apiInstance.getSubscriptions(workspaceID, subscriberID);
+            array[User] result = apiInstance.getSubscriptions(subscriberID);
             System.out.println(result);
         } catch (ApiException e) {
             System.err.println("Exception when calling DefaultApi#getSubscriptions");
@@ -6315,11 +12038,10 @@ public class DefaultApiExample {
 public class DefaultApiExample {
     public static void main(String[] args) {
         DefaultApi apiInstance = new DefaultApi();
-        String workspaceID = workspaceID_example; // String | Workspace ID
         String subscriberID = subscriberID_example; // String | Subscriber ID
 
         try {
-            array[User] result = apiInstance.getSubscriptions(workspaceID, subscriberID);
+            array[User] result = apiInstance.getSubscriptions(subscriberID);
             System.out.println(result);
         } catch (ApiException e) {
             System.err.println("Exception when calling DefaultApi#getSubscriptions");
@@ -6343,12 +12065,10 @@ public class DefaultApiExample {
 
 // Create an instance of the API class
 DefaultApi *apiInstance = [[DefaultApi alloc] init];
-String *workspaceID = workspaceID_example; // Workspace ID (default to null)
 String *subscriberID = subscriberID_example; // Subscriber ID (default to null)
 
 // Gets subscriptions for a user.
-[apiInstance getSubscriptionsWith:workspaceID
-    subscriberID:subscriberID
+[apiInstance getSubscriptionsWith:subscriberID
               completionHandler: ^(array[User] output, NSError* error) {
     if (output) {
         NSLog(@"%@", output);
@@ -6372,7 +12092,6 @@ BearerAuth.apiKey = "YOUR API KEY";
 
 // Create an instance of the API class
 var api = new FocalboardServer.DefaultApi()
-var workspaceID = workspaceID_example; // {String} Workspace ID
 var subscriberID = subscriberID_example; // {String} Subscriber ID
 
 var callback = function(error, data, response) {
@@ -6382,7 +12101,7 @@ var callback = function(error, data, response) {
     console.log('API called successfully. Returned data: ' + data);
   }
 };
-api.getSubscriptions(workspaceID, subscriberID, callback);
+api.getSubscriptions(subscriberID, callback);
 </code></pre>
                             </div>
 
@@ -6409,12 +12128,11 @@ namespace Example
 
             // Create an instance of the API class
             var apiInstance = new DefaultApi();
-            var workspaceID = workspaceID_example;  // String | Workspace ID (default to null)
             var subscriberID = subscriberID_example;  // String | Subscriber ID (default to null)
 
             try {
                 // Gets subscriptions for a user.
-                array[User] result = apiInstance.getSubscriptions(workspaceID, subscriberID);
+                array[User] result = apiInstance.getSubscriptions(subscriberID);
                 Debug.WriteLine(result);
             } catch (Exception e) {
                 Debug.Print("Exception when calling DefaultApi.getSubscriptions: " + e.Message );
@@ -6436,11 +12154,10 @@ OpenAPITools\Client\Configuration::getDefaultConfiguration()->setApiKey('Authori
 
 // Create an instance of the API class
 $api_instance = new OpenAPITools\Client\Api\DefaultApi();
-$workspaceID = workspaceID_example; // String | Workspace ID
 $subscriberID = subscriberID_example; // String | Subscriber ID
 
 try {
-    $result = $api_instance->getSubscriptions($workspaceID, $subscriberID);
+    $result = $api_instance->getSubscriptions($subscriberID);
     print_r($result);
 } catch (Exception $e) {
     echo 'Exception when calling DefaultApi->getSubscriptions: ', $e->getMessage(), PHP_EOL;
@@ -6460,11 +12177,10 @@ $WWW::OPenAPIClient::Configuration::api_key->{'Authorization'} = 'YOUR_API_KEY';
 
 # Create an instance of the API class
 my $api_instance = WWW::OPenAPIClient::DefaultApi->new();
-my $workspaceID = workspaceID_example; # String | Workspace ID
 my $subscriberID = subscriberID_example; # String | Subscriber ID
 
 eval {
-    my $result = $api_instance->getSubscriptions(workspaceID => $workspaceID, subscriberID => $subscriberID);
+    my $result = $api_instance->getSubscriptions(subscriberID => $subscriberID);
     print Dumper($result);
 };
 if ($@) {
@@ -6486,12 +12202,11 @@ openapi_client.configuration.api_key['Authorization'] = 'YOUR_API_KEY'
 
 # Create an instance of the API class
 api_instance = openapi_client.DefaultApi()
-workspaceID = workspaceID_example # String | Workspace ID (default to null)
 subscriberID = subscriberID_example # String | Subscriber ID (default to null)
 
 try:
     # Gets subscriptions for a user.
-    api_response = api_instance.get_subscriptions(workspaceID, subscriberID)
+    api_response = api_instance.get_subscriptions(subscriberID)
     pprint(api_response)
 except ApiException as e:
     print("Exception when calling DefaultApi->getSubscriptions: %s\n" % e)</code></pre>
@@ -6501,11 +12216,10 @@ except ApiException as e:
                               <pre class="prettyprint"><code class="language-rust">extern crate DefaultApi;
 
 pub fn main() {
-    let workspaceID = workspaceID_example; // String
     let subscriberID = subscriberID_example; // String
 
     let mut context = DefaultApi::Context::default();
-    let result = client.getSubscriptions(workspaceID, subscriberID, &context).wait();
+    let result = client.getSubscriptions(subscriberID, &context).wait();
 
     println!("{:?}", result);
 }
@@ -6526,29 +12240,6 @@ pub fn main() {
                                   <th width="150px">Name</th>
                                   <th>Description</th>
                                 </tr>
-                                  <tr><td style="width:150px;">workspaceID*</td>
-<td>
-
-
-    <div id="d2e199_getSubscriptions_workspaceID">
-        <div class="json-schema-view">
-            <div class="primitive">
-                <span class="type">
-                    String
-                </span>
-
-                    <div class="inner description marked">
-Workspace ID
-                    </div>
-            </div>
-                <div class="inner required">
-                    Required
-                </div>
-        </div>
-    </div>
-</td>
-</tr>
-
                                   <tr><td style="width:150px;">subscriberID*</td>
 <td>
 
@@ -6717,6 +12408,1790 @@ Subscriber ID
                         </article>
                       </div>
                       <hr>
+                    <div id="api-Default-getTeam">
+                      <article id="api-Default-getTeam-0" data-group="User" data-name="getTeam" data-version="0">
+                        <div class="pull-left">
+                          <h1>getTeam</h1>
+                          <p></p>
+                        </div>
+                        <div class="pull-right"></div>
+                        <div class="clearfix"></div>
+                        <p></p>
+                        <p class="marked">Returns information of the root team</p>
+                        <p></p>
+                        <br />
+                        <pre class="prettyprint language-html prettyprinted" data-type="get"><code><span class="pln">/teams/{teamID}</span></code></pre>
+                        <p>
+                          <h3>Usage and SDK Samples</h3>
+                        </p>
+                        <ul class="nav nav-tabs nav-tabs-examples">
+                          <li class="active"><a href="#examples-Default-getTeam-0-curl">Curl</a></li>
+                          <li class=""><a href="#examples-Default-getTeam-0-java">Java</a></li>
+                          <li class=""><a href="#examples-Default-getTeam-0-android">Android</a></li>
+                          <!--<li class=""><a href="#examples-Default-getTeam-0-groovy">Groovy</a></li>-->
+                          <li class=""><a href="#examples-Default-getTeam-0-objc">Obj-C</a></li>
+                          <li class=""><a href="#examples-Default-getTeam-0-javascript">JavaScript</a></li>
+                          <!--<li class=""><a href="#examples-Default-getTeam-0-angular">Angular</a></li>-->
+                          <li class=""><a href="#examples-Default-getTeam-0-csharp">C#</a></li>
+                          <li class=""><a href="#examples-Default-getTeam-0-php">PHP</a></li>
+                          <li class=""><a href="#examples-Default-getTeam-0-perl">Perl</a></li>
+                          <li class=""><a href="#examples-Default-getTeam-0-python">Python</a></li>
+                          <li class=""><a href="#examples-Default-getTeam-0-rust">Rust</a></li>
+                        </ul>
+
+                        <div class="tab-content">
+                          <div class="tab-pane active" id="examples-Default-getTeam-0-curl">
+                            <pre class="prettyprint"><code class="language-bsh">curl -X GET \
+-H "Authorization: [[apiKey]]" \
+ -H "Accept: application/json" \
+ "http://localhost/api/v2/teams/{teamID}"
+</code></pre>
+                          </div>
+                          <div class="tab-pane" id="examples-Default-getTeam-0-java">
+                            <pre class="prettyprint"><code class="language-java">import org.openapitools.client.*;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.model.*;
+import org.openapitools.client.api.DefaultApi;
+
+import java.io.File;
+import java.util.*;
+
+public class DefaultApiExample {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        
+        // Configure API key authorization: BearerAuth
+        ApiKeyAuth BearerAuth = (ApiKeyAuth) defaultClient.getAuthentication("BearerAuth");
+        BearerAuth.setApiKey("YOUR API KEY");
+        // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+        //BearerAuth.setApiKeyPrefix("Token");
+
+        // Create an instance of the API class
+        DefaultApi apiInstance = new DefaultApi();
+        String teamID = teamID_example; // String | Team ID
+
+        try {
+            Team result = apiInstance.getTeam(teamID);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling DefaultApi#getTeam");
+            e.printStackTrace();
+        }
+    }
+}
+</code></pre>
+                          </div>
+
+                          <div class="tab-pane" id="examples-Default-getTeam-0-android">
+                            <pre class="prettyprint"><code class="language-java">import org.openapitools.client.api.DefaultApi;
+
+public class DefaultApiExample {
+    public static void main(String[] args) {
+        DefaultApi apiInstance = new DefaultApi();
+        String teamID = teamID_example; // String | Team ID
+
+        try {
+            Team result = apiInstance.getTeam(teamID);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling DefaultApi#getTeam");
+            e.printStackTrace();
+        }
+    }
+}</code></pre>
+                          </div>
+  <!--
+  <div class="tab-pane" id="examples-Default-getTeam-0-groovy">
+  <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
+  </div> -->
+                            <div class="tab-pane" id="examples-Default-getTeam-0-objc">
+                              <pre class="prettyprint"><code class="language-cpp">Configuration *apiConfig = [Configuration sharedConfig];
+
+// Configure API key authorization: (authentication scheme: BearerAuth)
+[apiConfig setApiKey:@"YOUR_API_KEY" forApiKeyIdentifier:@"Authorization"];
+// Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+//[apiConfig setApiKeyPrefix:@"Bearer" forApiKeyIdentifier:@"Authorization"];
+
+
+// Create an instance of the API class
+DefaultApi *apiInstance = [[DefaultApi alloc] init];
+String *teamID = teamID_example; // Team ID (default to null)
+
+[apiInstance getTeamWith:teamID
+              completionHandler: ^(Team output, NSError* error) {
+    if (output) {
+        NSLog(@"%@", output);
+    }
+    if (error) {
+        NSLog(@"Error: %@", error);
+    }
+}];
+</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-getTeam-0-javascript">
+                              <pre class="prettyprint"><code class="language-js">var FocalboardServer = require('focalboard_server');
+var defaultClient = FocalboardServer.ApiClient.instance;
+
+// Configure API key authorization: BearerAuth
+var BearerAuth = defaultClient.authentications['BearerAuth'];
+BearerAuth.apiKey = "YOUR API KEY";
+// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+//BearerAuth.apiKeyPrefix['Authorization'] = "Token";
+
+// Create an instance of the API class
+var api = new FocalboardServer.DefaultApi()
+var teamID = teamID_example; // {String} Team ID
+
+var callback = function(error, data, response) {
+  if (error) {
+    console.error(error);
+  } else {
+    console.log('API called successfully. Returned data: ' + data);
+  }
+};
+api.getTeam(teamID, callback);
+</code></pre>
+                            </div>
+
+                            <!--<div class="tab-pane" id="examples-Default-getTeam-0-angular">
+              <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
+            </div>-->
+                            <div class="tab-pane" id="examples-Default-getTeam-0-csharp">
+                              <pre class="prettyprint"><code class="language-cs">using System;
+using System.Diagnostics;
+using Org.OpenAPITools.Api;
+using Org.OpenAPITools.Client;
+using Org.OpenAPITools.Model;
+
+namespace Example
+{
+    public class getTeamExample
+    {
+        public void main()
+        {
+            // Configure API key authorization: BearerAuth
+            Configuration.Default.ApiKey.Add("Authorization", "YOUR_API_KEY");
+            // Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+            // Configuration.Default.ApiKeyPrefix.Add("Authorization", "Bearer");
+
+            // Create an instance of the API class
+            var apiInstance = new DefaultApi();
+            var teamID = teamID_example;  // String | Team ID (default to null)
+
+            try {
+                Team result = apiInstance.getTeam(teamID);
+                Debug.WriteLine(result);
+            } catch (Exception e) {
+                Debug.Print("Exception when calling DefaultApi.getTeam: " + e.Message );
+            }
+        }
+    }
+}
+</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-getTeam-0-php">
+                              <pre class="prettyprint"><code class="language-php"><&#63;php
+require_once(__DIR__ . '/vendor/autoload.php');
+
+// Configure API key authorization: BearerAuth
+OpenAPITools\Client\Configuration::getDefaultConfiguration()->setApiKey('Authorization', 'YOUR_API_KEY');
+// Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+// OpenAPITools\Client\Configuration::getDefaultConfiguration()->setApiKeyPrefix('Authorization', 'Bearer');
+
+// Create an instance of the API class
+$api_instance = new OpenAPITools\Client\Api\DefaultApi();
+$teamID = teamID_example; // String | Team ID
+
+try {
+    $result = $api_instance->getTeam($teamID);
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling DefaultApi->getTeam: ', $e->getMessage(), PHP_EOL;
+}
+?></code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-getTeam-0-perl">
+                              <pre class="prettyprint"><code class="language-perl">use Data::Dumper;
+use WWW::OPenAPIClient::Configuration;
+use WWW::OPenAPIClient::DefaultApi;
+
+# Configure API key authorization: BearerAuth
+$WWW::OPenAPIClient::Configuration::api_key->{'Authorization'} = 'YOUR_API_KEY';
+# uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+#$WWW::OPenAPIClient::Configuration::api_key_prefix->{'Authorization'} = "Bearer";
+
+# Create an instance of the API class
+my $api_instance = WWW::OPenAPIClient::DefaultApi->new();
+my $teamID = teamID_example; # String | Team ID
+
+eval {
+    my $result = $api_instance->getTeam(teamID => $teamID);
+    print Dumper($result);
+};
+if ($@) {
+    warn "Exception when calling DefaultApi->getTeam: $@\n";
+}</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-getTeam-0-python">
+                              <pre class="prettyprint"><code class="language-python">from __future__ import print_statement
+import time
+import openapi_client
+from openapi_client.rest import ApiException
+from pprint import pprint
+
+# Configure API key authorization: BearerAuth
+openapi_client.configuration.api_key['Authorization'] = 'YOUR_API_KEY'
+# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+# openapi_client.configuration.api_key_prefix['Authorization'] = 'Bearer'
+
+# Create an instance of the API class
+api_instance = openapi_client.DefaultApi()
+teamID = teamID_example # String | Team ID (default to null)
+
+try:
+    api_response = api_instance.get_team(teamID)
+    pprint(api_response)
+except ApiException as e:
+    print("Exception when calling DefaultApi->getTeam: %s\n" % e)</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-getTeam-0-rust">
+                              <pre class="prettyprint"><code class="language-rust">extern crate DefaultApi;
+
+pub fn main() {
+    let teamID = teamID_example; // String
+
+    let mut context = DefaultApi::Context::default();
+    let result = client.getTeam(teamID, &context).wait();
+
+    println!("{:?}", result);
+}
+</code></pre>
+                            </div>
+                          </div>
+
+                          <h2>Scopes</h2>
+                          <table>
+                            
+                          </table>
+
+                          <h2>Parameters</h2>
+
+                            <div class="methodsubtabletitle">Path parameters</div>
+                            <table id="methodsubtable">
+                                <tr>
+                                  <th width="150px">Name</th>
+                                  <th>Description</th>
+                                </tr>
+                                  <tr><td style="width:150px;">teamID*</td>
+<td>
+
+
+    <div id="d2e199_getTeam_teamID">
+        <div class="json-schema-view">
+            <div class="primitive">
+                <span class="type">
+                    String
+                </span>
+
+                    <div class="inner description marked">
+Team ID
+                    </div>
+            </div>
+                <div class="inner required">
+                    Required
+                </div>
+        </div>
+    </div>
+</td>
+</tr>
+
+                            </table>
+
+
+
+
+
+                          <h2>Responses</h2>
+                            <h3 id="examples-Default-getTeam-title-200"></h3>
+                            <p id="examples-Default-getTeam-description-200" class="marked"></p>
+                            <script>
+                              var responseDefault200_description = `success`;
+                              var responseDefault200_description_break = responseDefault200_description.indexOf('\n');
+                              if (responseDefault200_description_break == -1) {
+                                $("#examples-Default-getTeam-title-200").text("Status: 200 - " + responseDefault200_description);
+                              } else {
+                                $("#examples-Default-getTeam-title-200").text("Status: 200 - " + responseDefault200_description.substring(0, responseDefault200_description_break));
+                                $("#examples-Default-getTeam-description-200").html(responseDefault200_description.substring(responseDefault200_description_break));
+                              }
+                            </script>
+
+
+                            <ul id="responses-detail-Default-getTeam-200" class="nav nav-tabs nav-tabs-examples" >
+                                <li class="active">
+                                  <a data-toggle="tab" href="#responses-Default-getTeam-200-schema">Schema</a>
+                                </li>
+
+
+
+
+                            </ul>
+
+
+                            <div class="tab-content" id="responses-Default-getTeam-200-wrapper" style='margin-bottom: 10px;'>
+                                <div class="tab-pane active" id="responses-Default-getTeam-200-schema">
+                                  <div id="responses-Default-getTeam-schema-200" class="exampleStyle">
+                                    <script>
+                                      $(document).ready(function() {
+                                        var schemaWrapper = {
+  "description" : "success",
+  "content" : {
+    "application/json" : {
+      "schema" : {
+        "$ref" : "#/components/schemas/Team"
+      }
+    }
+  }
+};
+                                        var schema = findNode('schema',schemaWrapper).schema;
+                                        if (!schema) {
+                                          schema = schemaWrapper.schema;
+                                        }
+                                        if (schema.$ref != null) {
+                                          schema = defsParser.$refs.get(schema.$ref);
+                                        } else if (schema.items != null && schema.items.$ref != null) {
+                                            schema.items = defsParser.$refs.get(schema.items.$ref);
+                                        } else {
+                                          schemaWrapper.definitions = Object.assign({}, defs);
+                                          $RefParser.dereference(schemaWrapper).catch(function(err) {
+                                            console.log(err);
+                                          });
+                                        }
+
+                                        var view = new JSONSchemaView(schema, 3);
+                                        $('#responses-Default-getTeam-200-schema-data').val(JSON.stringify(schema));
+                                        var result = $('#responses-Default-getTeam-schema-200');
+                                        result.empty();
+                                        result.append(view.render());
+                                      });
+                                    </script>
+                                  </div>
+                                  <input id='responses-Default-getTeam-200-schema-data' type='hidden' value=''></input>
+                                </div>
+                            </div>
+                            <h3 id="examples-Default-getTeam-title-default"></h3>
+                            <p id="examples-Default-getTeam-description-default" class="marked"></p>
+                            <script>
+                              var responseDefaultdefault_description = `internal error`;
+                              var responseDefaultdefault_description_break = responseDefaultdefault_description.indexOf('\n');
+                              if (responseDefaultdefault_description_break == -1) {
+                                $("#examples-Default-getTeam-title-default").text("Status: default - " + responseDefaultdefault_description);
+                              } else {
+                                $("#examples-Default-getTeam-title-default").text("Status: default - " + responseDefaultdefault_description.substring(0, responseDefaultdefault_description_break));
+                                $("#examples-Default-getTeam-description-default").html(responseDefaultdefault_description.substring(responseDefaultdefault_description_break));
+                              }
+                            </script>
+
+
+                            <ul id="responses-detail-Default-getTeam-default" class="nav nav-tabs nav-tabs-examples" >
+                                <li class="active">
+                                  <a data-toggle="tab" href="#responses-Default-getTeam-default-schema">Schema</a>
+                                </li>
+
+
+
+
+                            </ul>
+
+
+                            <div class="tab-content" id="responses-Default-getTeam-default-wrapper" style='margin-bottom: 10px;'>
+                                <div class="tab-pane active" id="responses-Default-getTeam-default-schema">
+                                  <div id="responses-Default-getTeam-schema-default" class="exampleStyle">
+                                    <script>
+                                      $(document).ready(function() {
+                                        var schemaWrapper = {
+  "description" : "internal error",
+  "content" : {
+    "application/json" : {
+      "schema" : {
+        "$ref" : "#/components/schemas/ErrorResponse"
+      }
+    }
+  }
+};
+                                        var schema = findNode('schema',schemaWrapper).schema;
+                                        if (!schema) {
+                                          schema = schemaWrapper.schema;
+                                        }
+                                        if (schema.$ref != null) {
+                                          schema = defsParser.$refs.get(schema.$ref);
+                                        } else if (schema.items != null && schema.items.$ref != null) {
+                                            schema.items = defsParser.$refs.get(schema.items.$ref);
+                                        } else {
+                                          schemaWrapper.definitions = Object.assign({}, defs);
+                                          $RefParser.dereference(schemaWrapper).catch(function(err) {
+                                            console.log(err);
+                                          });
+                                        }
+
+                                        var view = new JSONSchemaView(schema, 3);
+                                        $('#responses-Default-getTeam-default-schema-data').val(JSON.stringify(schema));
+                                        var result = $('#responses-Default-getTeam-schema-default');
+                                        result.empty();
+                                        result.append(view.render());
+                                      });
+                                    </script>
+                                  </div>
+                                  <input id='responses-Default-getTeam-default-schema-data' type='hidden' value=''></input>
+                                </div>
+                            </div>
+                        </article>
+                      </div>
+                      <hr>
+                    <div id="api-Default-getTeamUsers">
+                      <article id="api-Default-getTeamUsers-0" data-group="User" data-name="getTeamUsers" data-version="0">
+                        <div class="pull-left">
+                          <h1>getTeamUsers</h1>
+                          <p></p>
+                        </div>
+                        <div class="pull-right"></div>
+                        <div class="clearfix"></div>
+                        <p></p>
+                        <p class="marked">Returns team users</p>
+                        <p></p>
+                        <br />
+                        <pre class="prettyprint language-html prettyprinted" data-type="get"><code><span class="pln">/teams/{teamID}/users</span></code></pre>
+                        <p>
+                          <h3>Usage and SDK Samples</h3>
+                        </p>
+                        <ul class="nav nav-tabs nav-tabs-examples">
+                          <li class="active"><a href="#examples-Default-getTeamUsers-0-curl">Curl</a></li>
+                          <li class=""><a href="#examples-Default-getTeamUsers-0-java">Java</a></li>
+                          <li class=""><a href="#examples-Default-getTeamUsers-0-android">Android</a></li>
+                          <!--<li class=""><a href="#examples-Default-getTeamUsers-0-groovy">Groovy</a></li>-->
+                          <li class=""><a href="#examples-Default-getTeamUsers-0-objc">Obj-C</a></li>
+                          <li class=""><a href="#examples-Default-getTeamUsers-0-javascript">JavaScript</a></li>
+                          <!--<li class=""><a href="#examples-Default-getTeamUsers-0-angular">Angular</a></li>-->
+                          <li class=""><a href="#examples-Default-getTeamUsers-0-csharp">C#</a></li>
+                          <li class=""><a href="#examples-Default-getTeamUsers-0-php">PHP</a></li>
+                          <li class=""><a href="#examples-Default-getTeamUsers-0-perl">Perl</a></li>
+                          <li class=""><a href="#examples-Default-getTeamUsers-0-python">Python</a></li>
+                          <li class=""><a href="#examples-Default-getTeamUsers-0-rust">Rust</a></li>
+                        </ul>
+
+                        <div class="tab-content">
+                          <div class="tab-pane active" id="examples-Default-getTeamUsers-0-curl">
+                            <pre class="prettyprint"><code class="language-bsh">curl -X GET \
+-H "Authorization: [[apiKey]]" \
+ -H "Accept: application/json" \
+ "http://localhost/api/v2/teams/{teamID}/users?search=search_example"
+</code></pre>
+                          </div>
+                          <div class="tab-pane" id="examples-Default-getTeamUsers-0-java">
+                            <pre class="prettyprint"><code class="language-java">import org.openapitools.client.*;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.model.*;
+import org.openapitools.client.api.DefaultApi;
+
+import java.io.File;
+import java.util.*;
+
+public class DefaultApiExample {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        
+        // Configure API key authorization: BearerAuth
+        ApiKeyAuth BearerAuth = (ApiKeyAuth) defaultClient.getAuthentication("BearerAuth");
+        BearerAuth.setApiKey("YOUR API KEY");
+        // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+        //BearerAuth.setApiKeyPrefix("Token");
+
+        // Create an instance of the API class
+        DefaultApi apiInstance = new DefaultApi();
+        String teamID = teamID_example; // String | Team ID
+        String search = search_example; // String | string to filter users list
+
+        try {
+            array[User] result = apiInstance.getTeamUsers(teamID, search);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling DefaultApi#getTeamUsers");
+            e.printStackTrace();
+        }
+    }
+}
+</code></pre>
+                          </div>
+
+                          <div class="tab-pane" id="examples-Default-getTeamUsers-0-android">
+                            <pre class="prettyprint"><code class="language-java">import org.openapitools.client.api.DefaultApi;
+
+public class DefaultApiExample {
+    public static void main(String[] args) {
+        DefaultApi apiInstance = new DefaultApi();
+        String teamID = teamID_example; // String | Team ID
+        String search = search_example; // String | string to filter users list
+
+        try {
+            array[User] result = apiInstance.getTeamUsers(teamID, search);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling DefaultApi#getTeamUsers");
+            e.printStackTrace();
+        }
+    }
+}</code></pre>
+                          </div>
+  <!--
+  <div class="tab-pane" id="examples-Default-getTeamUsers-0-groovy">
+  <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
+  </div> -->
+                            <div class="tab-pane" id="examples-Default-getTeamUsers-0-objc">
+                              <pre class="prettyprint"><code class="language-cpp">Configuration *apiConfig = [Configuration sharedConfig];
+
+// Configure API key authorization: (authentication scheme: BearerAuth)
+[apiConfig setApiKey:@"YOUR_API_KEY" forApiKeyIdentifier:@"Authorization"];
+// Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+//[apiConfig setApiKeyPrefix:@"Bearer" forApiKeyIdentifier:@"Authorization"];
+
+
+// Create an instance of the API class
+DefaultApi *apiInstance = [[DefaultApi alloc] init];
+String *teamID = teamID_example; // Team ID (default to null)
+String *search = search_example; // string to filter users list (optional) (default to null)
+
+[apiInstance getTeamUsersWith:teamID
+    search:search
+              completionHandler: ^(array[User] output, NSError* error) {
+    if (output) {
+        NSLog(@"%@", output);
+    }
+    if (error) {
+        NSLog(@"Error: %@", error);
+    }
+}];
+</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-getTeamUsers-0-javascript">
+                              <pre class="prettyprint"><code class="language-js">var FocalboardServer = require('focalboard_server');
+var defaultClient = FocalboardServer.ApiClient.instance;
+
+// Configure API key authorization: BearerAuth
+var BearerAuth = defaultClient.authentications['BearerAuth'];
+BearerAuth.apiKey = "YOUR API KEY";
+// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+//BearerAuth.apiKeyPrefix['Authorization'] = "Token";
+
+// Create an instance of the API class
+var api = new FocalboardServer.DefaultApi()
+var teamID = teamID_example; // {String} Team ID
+var opts = {
+  'search': search_example // {String} string to filter users list
+};
+
+var callback = function(error, data, response) {
+  if (error) {
+    console.error(error);
+  } else {
+    console.log('API called successfully. Returned data: ' + data);
+  }
+};
+api.getTeamUsers(teamID, opts, callback);
+</code></pre>
+                            </div>
+
+                            <!--<div class="tab-pane" id="examples-Default-getTeamUsers-0-angular">
+              <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
+            </div>-->
+                            <div class="tab-pane" id="examples-Default-getTeamUsers-0-csharp">
+                              <pre class="prettyprint"><code class="language-cs">using System;
+using System.Diagnostics;
+using Org.OpenAPITools.Api;
+using Org.OpenAPITools.Client;
+using Org.OpenAPITools.Model;
+
+namespace Example
+{
+    public class getTeamUsersExample
+    {
+        public void main()
+        {
+            // Configure API key authorization: BearerAuth
+            Configuration.Default.ApiKey.Add("Authorization", "YOUR_API_KEY");
+            // Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+            // Configuration.Default.ApiKeyPrefix.Add("Authorization", "Bearer");
+
+            // Create an instance of the API class
+            var apiInstance = new DefaultApi();
+            var teamID = teamID_example;  // String | Team ID (default to null)
+            var search = search_example;  // String | string to filter users list (optional)  (default to null)
+
+            try {
+                array[User] result = apiInstance.getTeamUsers(teamID, search);
+                Debug.WriteLine(result);
+            } catch (Exception e) {
+                Debug.Print("Exception when calling DefaultApi.getTeamUsers: " + e.Message );
+            }
+        }
+    }
+}
+</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-getTeamUsers-0-php">
+                              <pre class="prettyprint"><code class="language-php"><&#63;php
+require_once(__DIR__ . '/vendor/autoload.php');
+
+// Configure API key authorization: BearerAuth
+OpenAPITools\Client\Configuration::getDefaultConfiguration()->setApiKey('Authorization', 'YOUR_API_KEY');
+// Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+// OpenAPITools\Client\Configuration::getDefaultConfiguration()->setApiKeyPrefix('Authorization', 'Bearer');
+
+// Create an instance of the API class
+$api_instance = new OpenAPITools\Client\Api\DefaultApi();
+$teamID = teamID_example; // String | Team ID
+$search = search_example; // String | string to filter users list
+
+try {
+    $result = $api_instance->getTeamUsers($teamID, $search);
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling DefaultApi->getTeamUsers: ', $e->getMessage(), PHP_EOL;
+}
+?></code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-getTeamUsers-0-perl">
+                              <pre class="prettyprint"><code class="language-perl">use Data::Dumper;
+use WWW::OPenAPIClient::Configuration;
+use WWW::OPenAPIClient::DefaultApi;
+
+# Configure API key authorization: BearerAuth
+$WWW::OPenAPIClient::Configuration::api_key->{'Authorization'} = 'YOUR_API_KEY';
+# uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+#$WWW::OPenAPIClient::Configuration::api_key_prefix->{'Authorization'} = "Bearer";
+
+# Create an instance of the API class
+my $api_instance = WWW::OPenAPIClient::DefaultApi->new();
+my $teamID = teamID_example; # String | Team ID
+my $search = search_example; # String | string to filter users list
+
+eval {
+    my $result = $api_instance->getTeamUsers(teamID => $teamID, search => $search);
+    print Dumper($result);
+};
+if ($@) {
+    warn "Exception when calling DefaultApi->getTeamUsers: $@\n";
+}</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-getTeamUsers-0-python">
+                              <pre class="prettyprint"><code class="language-python">from __future__ import print_statement
+import time
+import openapi_client
+from openapi_client.rest import ApiException
+from pprint import pprint
+
+# Configure API key authorization: BearerAuth
+openapi_client.configuration.api_key['Authorization'] = 'YOUR_API_KEY'
+# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+# openapi_client.configuration.api_key_prefix['Authorization'] = 'Bearer'
+
+# Create an instance of the API class
+api_instance = openapi_client.DefaultApi()
+teamID = teamID_example # String | Team ID (default to null)
+search = search_example # String | string to filter users list (optional) (default to null)
+
+try:
+    api_response = api_instance.get_team_users(teamID, search=search)
+    pprint(api_response)
+except ApiException as e:
+    print("Exception when calling DefaultApi->getTeamUsers: %s\n" % e)</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-getTeamUsers-0-rust">
+                              <pre class="prettyprint"><code class="language-rust">extern crate DefaultApi;
+
+pub fn main() {
+    let teamID = teamID_example; // String
+    let search = search_example; // String
+
+    let mut context = DefaultApi::Context::default();
+    let result = client.getTeamUsers(teamID, search, &context).wait();
+
+    println!("{:?}", result);
+}
+</code></pre>
+                            </div>
+                          </div>
+
+                          <h2>Scopes</h2>
+                          <table>
+                            
+                          </table>
+
+                          <h2>Parameters</h2>
+
+                            <div class="methodsubtabletitle">Path parameters</div>
+                            <table id="methodsubtable">
+                                <tr>
+                                  <th width="150px">Name</th>
+                                  <th>Description</th>
+                                </tr>
+                                  <tr><td style="width:150px;">teamID*</td>
+<td>
+
+
+    <div id="d2e199_getTeamUsers_teamID">
+        <div class="json-schema-view">
+            <div class="primitive">
+                <span class="type">
+                    String
+                </span>
+
+                    <div class="inner description marked">
+Team ID
+                    </div>
+            </div>
+                <div class="inner required">
+                    Required
+                </div>
+        </div>
+    </div>
+</td>
+</tr>
+
+                            </table>
+
+
+
+
+                            <div class="methodsubtabletitle">Query parameters</div>
+                            <table id="methodsubtable">
+                              <tr>
+                                <th width="150px">Name</th>
+                                <th>Description</th>
+                              </tr>
+                                <tr><td style="width:150px;">search</td>
+<td>
+
+
+    <div id="d2e199_getTeamUsers_search">
+        <div class="json-schema-view">
+            <div class="primitive">
+                <span class="type">
+                    String
+                </span>
+
+                    <div class="inner description marked">
+string to filter users list
+                    </div>
+            </div>
+        </div>
+    </div>
+</td>
+</tr>
+
+                            </table>
+
+                          <h2>Responses</h2>
+                            <h3 id="examples-Default-getTeamUsers-title-200"></h3>
+                            <p id="examples-Default-getTeamUsers-description-200" class="marked"></p>
+                            <script>
+                              var responseDefault200_description = `success`;
+                              var responseDefault200_description_break = responseDefault200_description.indexOf('\n');
+                              if (responseDefault200_description_break == -1) {
+                                $("#examples-Default-getTeamUsers-title-200").text("Status: 200 - " + responseDefault200_description);
+                              } else {
+                                $("#examples-Default-getTeamUsers-title-200").text("Status: 200 - " + responseDefault200_description.substring(0, responseDefault200_description_break));
+                                $("#examples-Default-getTeamUsers-description-200").html(responseDefault200_description.substring(responseDefault200_description_break));
+                              }
+                            </script>
+
+
+                            <ul id="responses-detail-Default-getTeamUsers-200" class="nav nav-tabs nav-tabs-examples" >
+                                <li class="active">
+                                  <a data-toggle="tab" href="#responses-Default-getTeamUsers-200-schema">Schema</a>
+                                </li>
+
+
+
+
+                            </ul>
+
+
+                            <div class="tab-content" id="responses-Default-getTeamUsers-200-wrapper" style='margin-bottom: 10px;'>
+                                <div class="tab-pane active" id="responses-Default-getTeamUsers-200-schema">
+                                  <div id="responses-Default-getTeamUsers-schema-200" class="exampleStyle">
+                                    <script>
+                                      $(document).ready(function() {
+                                        var schemaWrapper = {
+  "description" : "success",
+  "content" : {
+    "application/json" : {
+      "schema" : {
+        "type" : "array",
+        "items" : {
+          "$ref" : "#/components/schemas/User"
+        }
+      }
+    }
+  }
+};
+                                        var schema = findNode('schema',schemaWrapper).schema;
+                                        if (!schema) {
+                                          schema = schemaWrapper.schema;
+                                        }
+                                        if (schema.$ref != null) {
+                                          schema = defsParser.$refs.get(schema.$ref);
+                                        } else if (schema.items != null && schema.items.$ref != null) {
+                                            schema.items = defsParser.$refs.get(schema.items.$ref);
+                                        } else {
+                                          schemaWrapper.definitions = Object.assign({}, defs);
+                                          $RefParser.dereference(schemaWrapper).catch(function(err) {
+                                            console.log(err);
+                                          });
+                                        }
+
+                                        var view = new JSONSchemaView(schema, 3);
+                                        $('#responses-Default-getTeamUsers-200-schema-data').val(JSON.stringify(schema));
+                                        var result = $('#responses-Default-getTeamUsers-schema-200');
+                                        result.empty();
+                                        result.append(view.render());
+                                      });
+                                    </script>
+                                  </div>
+                                  <input id='responses-Default-getTeamUsers-200-schema-data' type='hidden' value=''></input>
+                                </div>
+                            </div>
+                            <h3 id="examples-Default-getTeamUsers-title-default"></h3>
+                            <p id="examples-Default-getTeamUsers-description-default" class="marked"></p>
+                            <script>
+                              var responseDefaultdefault_description = `internal error`;
+                              var responseDefaultdefault_description_break = responseDefaultdefault_description.indexOf('\n');
+                              if (responseDefaultdefault_description_break == -1) {
+                                $("#examples-Default-getTeamUsers-title-default").text("Status: default - " + responseDefaultdefault_description);
+                              } else {
+                                $("#examples-Default-getTeamUsers-title-default").text("Status: default - " + responseDefaultdefault_description.substring(0, responseDefaultdefault_description_break));
+                                $("#examples-Default-getTeamUsers-description-default").html(responseDefaultdefault_description.substring(responseDefaultdefault_description_break));
+                              }
+                            </script>
+
+
+                            <ul id="responses-detail-Default-getTeamUsers-default" class="nav nav-tabs nav-tabs-examples" >
+                                <li class="active">
+                                  <a data-toggle="tab" href="#responses-Default-getTeamUsers-default-schema">Schema</a>
+                                </li>
+
+
+
+
+                            </ul>
+
+
+                            <div class="tab-content" id="responses-Default-getTeamUsers-default-wrapper" style='margin-bottom: 10px;'>
+                                <div class="tab-pane active" id="responses-Default-getTeamUsers-default-schema">
+                                  <div id="responses-Default-getTeamUsers-schema-default" class="exampleStyle">
+                                    <script>
+                                      $(document).ready(function() {
+                                        var schemaWrapper = {
+  "description" : "internal error",
+  "content" : {
+    "application/json" : {
+      "schema" : {
+        "$ref" : "#/components/schemas/ErrorResponse"
+      }
+    }
+  }
+};
+                                        var schema = findNode('schema',schemaWrapper).schema;
+                                        if (!schema) {
+                                          schema = schemaWrapper.schema;
+                                        }
+                                        if (schema.$ref != null) {
+                                          schema = defsParser.$refs.get(schema.$ref);
+                                        } else if (schema.items != null && schema.items.$ref != null) {
+                                            schema.items = defsParser.$refs.get(schema.items.$ref);
+                                        } else {
+                                          schemaWrapper.definitions = Object.assign({}, defs);
+                                          $RefParser.dereference(schemaWrapper).catch(function(err) {
+                                            console.log(err);
+                                          });
+                                        }
+
+                                        var view = new JSONSchemaView(schema, 3);
+                                        $('#responses-Default-getTeamUsers-default-schema-data').val(JSON.stringify(schema));
+                                        var result = $('#responses-Default-getTeamUsers-schema-default');
+                                        result.empty();
+                                        result.append(view.render());
+                                      });
+                                    </script>
+                                  </div>
+                                  <input id='responses-Default-getTeamUsers-default-schema-data' type='hidden' value=''></input>
+                                </div>
+                            </div>
+                        </article>
+                      </div>
+                      <hr>
+                    <div id="api-Default-getTeams">
+                      <article id="api-Default-getTeams-0" data-group="User" data-name="getTeams" data-version="0">
+                        <div class="pull-left">
+                          <h1>getTeams</h1>
+                          <p></p>
+                        </div>
+                        <div class="pull-right"></div>
+                        <div class="clearfix"></div>
+                        <p></p>
+                        <p class="marked">Returns information of all the teams</p>
+                        <p></p>
+                        <br />
+                        <pre class="prettyprint language-html prettyprinted" data-type="get"><code><span class="pln">/teams</span></code></pre>
+                        <p>
+                          <h3>Usage and SDK Samples</h3>
+                        </p>
+                        <ul class="nav nav-tabs nav-tabs-examples">
+                          <li class="active"><a href="#examples-Default-getTeams-0-curl">Curl</a></li>
+                          <li class=""><a href="#examples-Default-getTeams-0-java">Java</a></li>
+                          <li class=""><a href="#examples-Default-getTeams-0-android">Android</a></li>
+                          <!--<li class=""><a href="#examples-Default-getTeams-0-groovy">Groovy</a></li>-->
+                          <li class=""><a href="#examples-Default-getTeams-0-objc">Obj-C</a></li>
+                          <li class=""><a href="#examples-Default-getTeams-0-javascript">JavaScript</a></li>
+                          <!--<li class=""><a href="#examples-Default-getTeams-0-angular">Angular</a></li>-->
+                          <li class=""><a href="#examples-Default-getTeams-0-csharp">C#</a></li>
+                          <li class=""><a href="#examples-Default-getTeams-0-php">PHP</a></li>
+                          <li class=""><a href="#examples-Default-getTeams-0-perl">Perl</a></li>
+                          <li class=""><a href="#examples-Default-getTeams-0-python">Python</a></li>
+                          <li class=""><a href="#examples-Default-getTeams-0-rust">Rust</a></li>
+                        </ul>
+
+                        <div class="tab-content">
+                          <div class="tab-pane active" id="examples-Default-getTeams-0-curl">
+                            <pre class="prettyprint"><code class="language-bsh">curl -X GET \
+-H "Authorization: [[apiKey]]" \
+ -H "Accept: application/json" \
+ "http://localhost/api/v2/teams"
+</code></pre>
+                          </div>
+                          <div class="tab-pane" id="examples-Default-getTeams-0-java">
+                            <pre class="prettyprint"><code class="language-java">import org.openapitools.client.*;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.model.*;
+import org.openapitools.client.api.DefaultApi;
+
+import java.io.File;
+import java.util.*;
+
+public class DefaultApiExample {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        
+        // Configure API key authorization: BearerAuth
+        ApiKeyAuth BearerAuth = (ApiKeyAuth) defaultClient.getAuthentication("BearerAuth");
+        BearerAuth.setApiKey("YOUR API KEY");
+        // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+        //BearerAuth.setApiKeyPrefix("Token");
+
+        // Create an instance of the API class
+        DefaultApi apiInstance = new DefaultApi();
+
+        try {
+            array[Team] result = apiInstance.getTeams();
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling DefaultApi#getTeams");
+            e.printStackTrace();
+        }
+    }
+}
+</code></pre>
+                          </div>
+
+                          <div class="tab-pane" id="examples-Default-getTeams-0-android">
+                            <pre class="prettyprint"><code class="language-java">import org.openapitools.client.api.DefaultApi;
+
+public class DefaultApiExample {
+    public static void main(String[] args) {
+        DefaultApi apiInstance = new DefaultApi();
+
+        try {
+            array[Team] result = apiInstance.getTeams();
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling DefaultApi#getTeams");
+            e.printStackTrace();
+        }
+    }
+}</code></pre>
+                          </div>
+  <!--
+  <div class="tab-pane" id="examples-Default-getTeams-0-groovy">
+  <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
+  </div> -->
+                            <div class="tab-pane" id="examples-Default-getTeams-0-objc">
+                              <pre class="prettyprint"><code class="language-cpp">Configuration *apiConfig = [Configuration sharedConfig];
+
+// Configure API key authorization: (authentication scheme: BearerAuth)
+[apiConfig setApiKey:@"YOUR_API_KEY" forApiKeyIdentifier:@"Authorization"];
+// Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+//[apiConfig setApiKeyPrefix:@"Bearer" forApiKeyIdentifier:@"Authorization"];
+
+
+// Create an instance of the API class
+DefaultApi *apiInstance = [[DefaultApi alloc] init];
+
+[apiInstance getTeamsWithCompletionHandler: 
+              ^(array[Team] output, NSError* error) {
+    if (output) {
+        NSLog(@"%@", output);
+    }
+    if (error) {
+        NSLog(@"Error: %@", error);
+    }
+}];
+</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-getTeams-0-javascript">
+                              <pre class="prettyprint"><code class="language-js">var FocalboardServer = require('focalboard_server');
+var defaultClient = FocalboardServer.ApiClient.instance;
+
+// Configure API key authorization: BearerAuth
+var BearerAuth = defaultClient.authentications['BearerAuth'];
+BearerAuth.apiKey = "YOUR API KEY";
+// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+//BearerAuth.apiKeyPrefix['Authorization'] = "Token";
+
+// Create an instance of the API class
+var api = new FocalboardServer.DefaultApi()
+var callback = function(error, data, response) {
+  if (error) {
+    console.error(error);
+  } else {
+    console.log('API called successfully. Returned data: ' + data);
+  }
+};
+api.getTeams(callback);
+</code></pre>
+                            </div>
+
+                            <!--<div class="tab-pane" id="examples-Default-getTeams-0-angular">
+              <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
+            </div>-->
+                            <div class="tab-pane" id="examples-Default-getTeams-0-csharp">
+                              <pre class="prettyprint"><code class="language-cs">using System;
+using System.Diagnostics;
+using Org.OpenAPITools.Api;
+using Org.OpenAPITools.Client;
+using Org.OpenAPITools.Model;
+
+namespace Example
+{
+    public class getTeamsExample
+    {
+        public void main()
+        {
+            // Configure API key authorization: BearerAuth
+            Configuration.Default.ApiKey.Add("Authorization", "YOUR_API_KEY");
+            // Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+            // Configuration.Default.ApiKeyPrefix.Add("Authorization", "Bearer");
+
+            // Create an instance of the API class
+            var apiInstance = new DefaultApi();
+
+            try {
+                array[Team] result = apiInstance.getTeams();
+                Debug.WriteLine(result);
+            } catch (Exception e) {
+                Debug.Print("Exception when calling DefaultApi.getTeams: " + e.Message );
+            }
+        }
+    }
+}
+</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-getTeams-0-php">
+                              <pre class="prettyprint"><code class="language-php"><&#63;php
+require_once(__DIR__ . '/vendor/autoload.php');
+
+// Configure API key authorization: BearerAuth
+OpenAPITools\Client\Configuration::getDefaultConfiguration()->setApiKey('Authorization', 'YOUR_API_KEY');
+// Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+// OpenAPITools\Client\Configuration::getDefaultConfiguration()->setApiKeyPrefix('Authorization', 'Bearer');
+
+// Create an instance of the API class
+$api_instance = new OpenAPITools\Client\Api\DefaultApi();
+
+try {
+    $result = $api_instance->getTeams();
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling DefaultApi->getTeams: ', $e->getMessage(), PHP_EOL;
+}
+?></code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-getTeams-0-perl">
+                              <pre class="prettyprint"><code class="language-perl">use Data::Dumper;
+use WWW::OPenAPIClient::Configuration;
+use WWW::OPenAPIClient::DefaultApi;
+
+# Configure API key authorization: BearerAuth
+$WWW::OPenAPIClient::Configuration::api_key->{'Authorization'} = 'YOUR_API_KEY';
+# uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+#$WWW::OPenAPIClient::Configuration::api_key_prefix->{'Authorization'} = "Bearer";
+
+# Create an instance of the API class
+my $api_instance = WWW::OPenAPIClient::DefaultApi->new();
+
+eval {
+    my $result = $api_instance->getTeams();
+    print Dumper($result);
+};
+if ($@) {
+    warn "Exception when calling DefaultApi->getTeams: $@\n";
+}</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-getTeams-0-python">
+                              <pre class="prettyprint"><code class="language-python">from __future__ import print_statement
+import time
+import openapi_client
+from openapi_client.rest import ApiException
+from pprint import pprint
+
+# Configure API key authorization: BearerAuth
+openapi_client.configuration.api_key['Authorization'] = 'YOUR_API_KEY'
+# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+# openapi_client.configuration.api_key_prefix['Authorization'] = 'Bearer'
+
+# Create an instance of the API class
+api_instance = openapi_client.DefaultApi()
+
+try:
+    api_response = api_instance.get_teams()
+    pprint(api_response)
+except ApiException as e:
+    print("Exception when calling DefaultApi->getTeams: %s\n" % e)</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-getTeams-0-rust">
+                              <pre class="prettyprint"><code class="language-rust">extern crate DefaultApi;
+
+pub fn main() {
+
+    let mut context = DefaultApi::Context::default();
+    let result = client.getTeams(&context).wait();
+
+    println!("{:?}", result);
+}
+</code></pre>
+                            </div>
+                          </div>
+
+                          <h2>Scopes</h2>
+                          <table>
+                            
+                          </table>
+
+                          <h2>Parameters</h2>
+
+
+
+
+
+
+                          <h2>Responses</h2>
+                            <h3 id="examples-Default-getTeams-title-200"></h3>
+                            <p id="examples-Default-getTeams-description-200" class="marked"></p>
+                            <script>
+                              var responseDefault200_description = `success`;
+                              var responseDefault200_description_break = responseDefault200_description.indexOf('\n');
+                              if (responseDefault200_description_break == -1) {
+                                $("#examples-Default-getTeams-title-200").text("Status: 200 - " + responseDefault200_description);
+                              } else {
+                                $("#examples-Default-getTeams-title-200").text("Status: 200 - " + responseDefault200_description.substring(0, responseDefault200_description_break));
+                                $("#examples-Default-getTeams-description-200").html(responseDefault200_description.substring(responseDefault200_description_break));
+                              }
+                            </script>
+
+
+                            <ul id="responses-detail-Default-getTeams-200" class="nav nav-tabs nav-tabs-examples" >
+                                <li class="active">
+                                  <a data-toggle="tab" href="#responses-Default-getTeams-200-schema">Schema</a>
+                                </li>
+
+
+
+
+                            </ul>
+
+
+                            <div class="tab-content" id="responses-Default-getTeams-200-wrapper" style='margin-bottom: 10px;'>
+                                <div class="tab-pane active" id="responses-Default-getTeams-200-schema">
+                                  <div id="responses-Default-getTeams-schema-200" class="exampleStyle">
+                                    <script>
+                                      $(document).ready(function() {
+                                        var schemaWrapper = {
+  "description" : "success",
+  "content" : {
+    "application/json" : {
+      "schema" : {
+        "type" : "array",
+        "items" : {
+          "$ref" : "#/components/schemas/Team"
+        }
+      }
+    }
+  }
+};
+                                        var schema = findNode('schema',schemaWrapper).schema;
+                                        if (!schema) {
+                                          schema = schemaWrapper.schema;
+                                        }
+                                        if (schema.$ref != null) {
+                                          schema = defsParser.$refs.get(schema.$ref);
+                                        } else if (schema.items != null && schema.items.$ref != null) {
+                                            schema.items = defsParser.$refs.get(schema.items.$ref);
+                                        } else {
+                                          schemaWrapper.definitions = Object.assign({}, defs);
+                                          $RefParser.dereference(schemaWrapper).catch(function(err) {
+                                            console.log(err);
+                                          });
+                                        }
+
+                                        var view = new JSONSchemaView(schema, 3);
+                                        $('#responses-Default-getTeams-200-schema-data').val(JSON.stringify(schema));
+                                        var result = $('#responses-Default-getTeams-schema-200');
+                                        result.empty();
+                                        result.append(view.render());
+                                      });
+                                    </script>
+                                  </div>
+                                  <input id='responses-Default-getTeams-200-schema-data' type='hidden' value=''></input>
+                                </div>
+                            </div>
+                            <h3 id="examples-Default-getTeams-title-default"></h3>
+                            <p id="examples-Default-getTeams-description-default" class="marked"></p>
+                            <script>
+                              var responseDefaultdefault_description = `internal error`;
+                              var responseDefaultdefault_description_break = responseDefaultdefault_description.indexOf('\n');
+                              if (responseDefaultdefault_description_break == -1) {
+                                $("#examples-Default-getTeams-title-default").text("Status: default - " + responseDefaultdefault_description);
+                              } else {
+                                $("#examples-Default-getTeams-title-default").text("Status: default - " + responseDefaultdefault_description.substring(0, responseDefaultdefault_description_break));
+                                $("#examples-Default-getTeams-description-default").html(responseDefaultdefault_description.substring(responseDefaultdefault_description_break));
+                              }
+                            </script>
+
+
+                            <ul id="responses-detail-Default-getTeams-default" class="nav nav-tabs nav-tabs-examples" >
+                                <li class="active">
+                                  <a data-toggle="tab" href="#responses-Default-getTeams-default-schema">Schema</a>
+                                </li>
+
+
+
+
+                            </ul>
+
+
+                            <div class="tab-content" id="responses-Default-getTeams-default-wrapper" style='margin-bottom: 10px;'>
+                                <div class="tab-pane active" id="responses-Default-getTeams-default-schema">
+                                  <div id="responses-Default-getTeams-schema-default" class="exampleStyle">
+                                    <script>
+                                      $(document).ready(function() {
+                                        var schemaWrapper = {
+  "description" : "internal error",
+  "content" : {
+    "application/json" : {
+      "schema" : {
+        "$ref" : "#/components/schemas/ErrorResponse"
+      }
+    }
+  }
+};
+                                        var schema = findNode('schema',schemaWrapper).schema;
+                                        if (!schema) {
+                                          schema = schemaWrapper.schema;
+                                        }
+                                        if (schema.$ref != null) {
+                                          schema = defsParser.$refs.get(schema.$ref);
+                                        } else if (schema.items != null && schema.items.$ref != null) {
+                                            schema.items = defsParser.$refs.get(schema.items.$ref);
+                                        } else {
+                                          schemaWrapper.definitions = Object.assign({}, defs);
+                                          $RefParser.dereference(schemaWrapper).catch(function(err) {
+                                            console.log(err);
+                                          });
+                                        }
+
+                                        var view = new JSONSchemaView(schema, 3);
+                                        $('#responses-Default-getTeams-default-schema-data').val(JSON.stringify(schema));
+                                        var result = $('#responses-Default-getTeams-schema-default');
+                                        result.empty();
+                                        result.append(view.render());
+                                      });
+                                    </script>
+                                  </div>
+                                  <input id='responses-Default-getTeams-default-schema-data' type='hidden' value=''></input>
+                                </div>
+                            </div>
+                        </article>
+                      </div>
+                      <hr>
+                    <div id="api-Default-getTemplates">
+                      <article id="api-Default-getTemplates-0" data-group="User" data-name="getTemplates" data-version="0">
+                        <div class="pull-left">
+                          <h1>getTemplates</h1>
+                          <p></p>
+                        </div>
+                        <div class="pull-right"></div>
+                        <div class="clearfix"></div>
+                        <p></p>
+                        <p class="marked">Returns team templates</p>
+                        <p></p>
+                        <br />
+                        <pre class="prettyprint language-html prettyprinted" data-type="get"><code><span class="pln">/teams/{teamID}/templates</span></code></pre>
+                        <p>
+                          <h3>Usage and SDK Samples</h3>
+                        </p>
+                        <ul class="nav nav-tabs nav-tabs-examples">
+                          <li class="active"><a href="#examples-Default-getTemplates-0-curl">Curl</a></li>
+                          <li class=""><a href="#examples-Default-getTemplates-0-java">Java</a></li>
+                          <li class=""><a href="#examples-Default-getTemplates-0-android">Android</a></li>
+                          <!--<li class=""><a href="#examples-Default-getTemplates-0-groovy">Groovy</a></li>-->
+                          <li class=""><a href="#examples-Default-getTemplates-0-objc">Obj-C</a></li>
+                          <li class=""><a href="#examples-Default-getTemplates-0-javascript">JavaScript</a></li>
+                          <!--<li class=""><a href="#examples-Default-getTemplates-0-angular">Angular</a></li>-->
+                          <li class=""><a href="#examples-Default-getTemplates-0-csharp">C#</a></li>
+                          <li class=""><a href="#examples-Default-getTemplates-0-php">PHP</a></li>
+                          <li class=""><a href="#examples-Default-getTemplates-0-perl">Perl</a></li>
+                          <li class=""><a href="#examples-Default-getTemplates-0-python">Python</a></li>
+                          <li class=""><a href="#examples-Default-getTemplates-0-rust">Rust</a></li>
+                        </ul>
+
+                        <div class="tab-content">
+                          <div class="tab-pane active" id="examples-Default-getTemplates-0-curl">
+                            <pre class="prettyprint"><code class="language-bsh">curl -X GET \
+-H "Authorization: [[apiKey]]" \
+ -H "Accept: application/json" \
+ "http://localhost/api/v2/teams/{teamID}/templates"
+</code></pre>
+                          </div>
+                          <div class="tab-pane" id="examples-Default-getTemplates-0-java">
+                            <pre class="prettyprint"><code class="language-java">import org.openapitools.client.*;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.model.*;
+import org.openapitools.client.api.DefaultApi;
+
+import java.io.File;
+import java.util.*;
+
+public class DefaultApiExample {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        
+        // Configure API key authorization: BearerAuth
+        ApiKeyAuth BearerAuth = (ApiKeyAuth) defaultClient.getAuthentication("BearerAuth");
+        BearerAuth.setApiKey("YOUR API KEY");
+        // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+        //BearerAuth.setApiKeyPrefix("Token");
+
+        // Create an instance of the API class
+        DefaultApi apiInstance = new DefaultApi();
+        String teamID = teamID_example; // String | Team ID
+
+        try {
+            array[Board] result = apiInstance.getTemplates(teamID);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling DefaultApi#getTemplates");
+            e.printStackTrace();
+        }
+    }
+}
+</code></pre>
+                          </div>
+
+                          <div class="tab-pane" id="examples-Default-getTemplates-0-android">
+                            <pre class="prettyprint"><code class="language-java">import org.openapitools.client.api.DefaultApi;
+
+public class DefaultApiExample {
+    public static void main(String[] args) {
+        DefaultApi apiInstance = new DefaultApi();
+        String teamID = teamID_example; // String | Team ID
+
+        try {
+            array[Board] result = apiInstance.getTemplates(teamID);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling DefaultApi#getTemplates");
+            e.printStackTrace();
+        }
+    }
+}</code></pre>
+                          </div>
+  <!--
+  <div class="tab-pane" id="examples-Default-getTemplates-0-groovy">
+  <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
+  </div> -->
+                            <div class="tab-pane" id="examples-Default-getTemplates-0-objc">
+                              <pre class="prettyprint"><code class="language-cpp">Configuration *apiConfig = [Configuration sharedConfig];
+
+// Configure API key authorization: (authentication scheme: BearerAuth)
+[apiConfig setApiKey:@"YOUR_API_KEY" forApiKeyIdentifier:@"Authorization"];
+// Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+//[apiConfig setApiKeyPrefix:@"Bearer" forApiKeyIdentifier:@"Authorization"];
+
+
+// Create an instance of the API class
+DefaultApi *apiInstance = [[DefaultApi alloc] init];
+String *teamID = teamID_example; // Team ID (default to null)
+
+[apiInstance getTemplatesWith:teamID
+              completionHandler: ^(array[Board] output, NSError* error) {
+    if (output) {
+        NSLog(@"%@", output);
+    }
+    if (error) {
+        NSLog(@"Error: %@", error);
+    }
+}];
+</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-getTemplates-0-javascript">
+                              <pre class="prettyprint"><code class="language-js">var FocalboardServer = require('focalboard_server');
+var defaultClient = FocalboardServer.ApiClient.instance;
+
+// Configure API key authorization: BearerAuth
+var BearerAuth = defaultClient.authentications['BearerAuth'];
+BearerAuth.apiKey = "YOUR API KEY";
+// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+//BearerAuth.apiKeyPrefix['Authorization'] = "Token";
+
+// Create an instance of the API class
+var api = new FocalboardServer.DefaultApi()
+var teamID = teamID_example; // {String} Team ID
+
+var callback = function(error, data, response) {
+  if (error) {
+    console.error(error);
+  } else {
+    console.log('API called successfully. Returned data: ' + data);
+  }
+};
+api.getTemplates(teamID, callback);
+</code></pre>
+                            </div>
+
+                            <!--<div class="tab-pane" id="examples-Default-getTemplates-0-angular">
+              <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
+            </div>-->
+                            <div class="tab-pane" id="examples-Default-getTemplates-0-csharp">
+                              <pre class="prettyprint"><code class="language-cs">using System;
+using System.Diagnostics;
+using Org.OpenAPITools.Api;
+using Org.OpenAPITools.Client;
+using Org.OpenAPITools.Model;
+
+namespace Example
+{
+    public class getTemplatesExample
+    {
+        public void main()
+        {
+            // Configure API key authorization: BearerAuth
+            Configuration.Default.ApiKey.Add("Authorization", "YOUR_API_KEY");
+            // Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+            // Configuration.Default.ApiKeyPrefix.Add("Authorization", "Bearer");
+
+            // Create an instance of the API class
+            var apiInstance = new DefaultApi();
+            var teamID = teamID_example;  // String | Team ID (default to null)
+
+            try {
+                array[Board] result = apiInstance.getTemplates(teamID);
+                Debug.WriteLine(result);
+            } catch (Exception e) {
+                Debug.Print("Exception when calling DefaultApi.getTemplates: " + e.Message );
+            }
+        }
+    }
+}
+</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-getTemplates-0-php">
+                              <pre class="prettyprint"><code class="language-php"><&#63;php
+require_once(__DIR__ . '/vendor/autoload.php');
+
+// Configure API key authorization: BearerAuth
+OpenAPITools\Client\Configuration::getDefaultConfiguration()->setApiKey('Authorization', 'YOUR_API_KEY');
+// Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+// OpenAPITools\Client\Configuration::getDefaultConfiguration()->setApiKeyPrefix('Authorization', 'Bearer');
+
+// Create an instance of the API class
+$api_instance = new OpenAPITools\Client\Api\DefaultApi();
+$teamID = teamID_example; // String | Team ID
+
+try {
+    $result = $api_instance->getTemplates($teamID);
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling DefaultApi->getTemplates: ', $e->getMessage(), PHP_EOL;
+}
+?></code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-getTemplates-0-perl">
+                              <pre class="prettyprint"><code class="language-perl">use Data::Dumper;
+use WWW::OPenAPIClient::Configuration;
+use WWW::OPenAPIClient::DefaultApi;
+
+# Configure API key authorization: BearerAuth
+$WWW::OPenAPIClient::Configuration::api_key->{'Authorization'} = 'YOUR_API_KEY';
+# uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+#$WWW::OPenAPIClient::Configuration::api_key_prefix->{'Authorization'} = "Bearer";
+
+# Create an instance of the API class
+my $api_instance = WWW::OPenAPIClient::DefaultApi->new();
+my $teamID = teamID_example; # String | Team ID
+
+eval {
+    my $result = $api_instance->getTemplates(teamID => $teamID);
+    print Dumper($result);
+};
+if ($@) {
+    warn "Exception when calling DefaultApi->getTemplates: $@\n";
+}</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-getTemplates-0-python">
+                              <pre class="prettyprint"><code class="language-python">from __future__ import print_statement
+import time
+import openapi_client
+from openapi_client.rest import ApiException
+from pprint import pprint
+
+# Configure API key authorization: BearerAuth
+openapi_client.configuration.api_key['Authorization'] = 'YOUR_API_KEY'
+# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+# openapi_client.configuration.api_key_prefix['Authorization'] = 'Bearer'
+
+# Create an instance of the API class
+api_instance = openapi_client.DefaultApi()
+teamID = teamID_example # String | Team ID (default to null)
+
+try:
+    api_response = api_instance.get_templates(teamID)
+    pprint(api_response)
+except ApiException as e:
+    print("Exception when calling DefaultApi->getTemplates: %s\n" % e)</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-getTemplates-0-rust">
+                              <pre class="prettyprint"><code class="language-rust">extern crate DefaultApi;
+
+pub fn main() {
+    let teamID = teamID_example; // String
+
+    let mut context = DefaultApi::Context::default();
+    let result = client.getTemplates(teamID, &context).wait();
+
+    println!("{:?}", result);
+}
+</code></pre>
+                            </div>
+                          </div>
+
+                          <h2>Scopes</h2>
+                          <table>
+                            
+                          </table>
+
+                          <h2>Parameters</h2>
+
+                            <div class="methodsubtabletitle">Path parameters</div>
+                            <table id="methodsubtable">
+                                <tr>
+                                  <th width="150px">Name</th>
+                                  <th>Description</th>
+                                </tr>
+                                  <tr><td style="width:150px;">teamID*</td>
+<td>
+
+
+    <div id="d2e199_getTemplates_teamID">
+        <div class="json-schema-view">
+            <div class="primitive">
+                <span class="type">
+                    String
+                </span>
+
+                    <div class="inner description marked">
+Team ID
+                    </div>
+            </div>
+                <div class="inner required">
+                    Required
+                </div>
+        </div>
+    </div>
+</td>
+</tr>
+
+                            </table>
+
+
+
+
+
+                          <h2>Responses</h2>
+                            <h3 id="examples-Default-getTemplates-title-200"></h3>
+                            <p id="examples-Default-getTemplates-description-200" class="marked"></p>
+                            <script>
+                              var responseDefault200_description = `success`;
+                              var responseDefault200_description_break = responseDefault200_description.indexOf('\n');
+                              if (responseDefault200_description_break == -1) {
+                                $("#examples-Default-getTemplates-title-200").text("Status: 200 - " + responseDefault200_description);
+                              } else {
+                                $("#examples-Default-getTemplates-title-200").text("Status: 200 - " + responseDefault200_description.substring(0, responseDefault200_description_break));
+                                $("#examples-Default-getTemplates-description-200").html(responseDefault200_description.substring(responseDefault200_description_break));
+                              }
+                            </script>
+
+
+                            <ul id="responses-detail-Default-getTemplates-200" class="nav nav-tabs nav-tabs-examples" >
+                                <li class="active">
+                                  <a data-toggle="tab" href="#responses-Default-getTemplates-200-schema">Schema</a>
+                                </li>
+
+
+
+
+                            </ul>
+
+
+                            <div class="tab-content" id="responses-Default-getTemplates-200-wrapper" style='margin-bottom: 10px;'>
+                                <div class="tab-pane active" id="responses-Default-getTemplates-200-schema">
+                                  <div id="responses-Default-getTemplates-schema-200" class="exampleStyle">
+                                    <script>
+                                      $(document).ready(function() {
+                                        var schemaWrapper = {
+  "description" : "success",
+  "content" : {
+    "application/json" : {
+      "schema" : {
+        "type" : "array",
+        "items" : {
+          "$ref" : "#/components/schemas/Board"
+        }
+      }
+    }
+  }
+};
+                                        var schema = findNode('schema',schemaWrapper).schema;
+                                        if (!schema) {
+                                          schema = schemaWrapper.schema;
+                                        }
+                                        if (schema.$ref != null) {
+                                          schema = defsParser.$refs.get(schema.$ref);
+                                        } else if (schema.items != null && schema.items.$ref != null) {
+                                            schema.items = defsParser.$refs.get(schema.items.$ref);
+                                        } else {
+                                          schemaWrapper.definitions = Object.assign({}, defs);
+                                          $RefParser.dereference(schemaWrapper).catch(function(err) {
+                                            console.log(err);
+                                          });
+                                        }
+
+                                        var view = new JSONSchemaView(schema, 3);
+                                        $('#responses-Default-getTemplates-200-schema-data').val(JSON.stringify(schema));
+                                        var result = $('#responses-Default-getTemplates-schema-200');
+                                        result.empty();
+                                        result.append(view.render());
+                                      });
+                                    </script>
+                                  </div>
+                                  <input id='responses-Default-getTemplates-200-schema-data' type='hidden' value=''></input>
+                                </div>
+                            </div>
+                            <h3 id="examples-Default-getTemplates-title-default"></h3>
+                            <p id="examples-Default-getTemplates-description-default" class="marked"></p>
+                            <script>
+                              var responseDefaultdefault_description = `internal error`;
+                              var responseDefaultdefault_description_break = responseDefaultdefault_description.indexOf('\n');
+                              if (responseDefaultdefault_description_break == -1) {
+                                $("#examples-Default-getTemplates-title-default").text("Status: default - " + responseDefaultdefault_description);
+                              } else {
+                                $("#examples-Default-getTemplates-title-default").text("Status: default - " + responseDefaultdefault_description.substring(0, responseDefaultdefault_description_break));
+                                $("#examples-Default-getTemplates-description-default").html(responseDefaultdefault_description.substring(responseDefaultdefault_description_break));
+                              }
+                            </script>
+
+
+                            <ul id="responses-detail-Default-getTemplates-default" class="nav nav-tabs nav-tabs-examples" >
+                                <li class="active">
+                                  <a data-toggle="tab" href="#responses-Default-getTemplates-default-schema">Schema</a>
+                                </li>
+
+
+
+
+                            </ul>
+
+
+                            <div class="tab-content" id="responses-Default-getTemplates-default-wrapper" style='margin-bottom: 10px;'>
+                                <div class="tab-pane active" id="responses-Default-getTemplates-default-schema">
+                                  <div id="responses-Default-getTemplates-schema-default" class="exampleStyle">
+                                    <script>
+                                      $(document).ready(function() {
+                                        var schemaWrapper = {
+  "description" : "internal error",
+  "content" : {
+    "application/json" : {
+      "schema" : {
+        "$ref" : "#/components/schemas/ErrorResponse"
+      }
+    }
+  }
+};
+                                        var schema = findNode('schema',schemaWrapper).schema;
+                                        if (!schema) {
+                                          schema = schemaWrapper.schema;
+                                        }
+                                        if (schema.$ref != null) {
+                                          schema = defsParser.$refs.get(schema.$ref);
+                                        } else if (schema.items != null && schema.items.$ref != null) {
+                                            schema.items = defsParser.$refs.get(schema.items.$ref);
+                                        } else {
+                                          schemaWrapper.definitions = Object.assign({}, defs);
+                                          $RefParser.dereference(schemaWrapper).catch(function(err) {
+                                            console.log(err);
+                                          });
+                                        }
+
+                                        var view = new JSONSchemaView(schema, 3);
+                                        $('#responses-Default-getTemplates-default-schema-data').val(JSON.stringify(schema));
+                                        var result = $('#responses-Default-getTemplates-schema-default');
+                                        result.empty();
+                                        result.append(view.render());
+                                      });
+                                    </script>
+                                  </div>
+                                  <input id='responses-Default-getTemplates-default-schema-data' type='hidden' value=''></input>
+                                </div>
+                            </div>
+                        </article>
+                      </div>
+                      <hr>
                     <div id="api-Default-getUser">
                       <article id="api-Default-getUser-0" data-group="User" data-name="getUser" data-version="0">
                         <div class="pull-left">
@@ -6729,7 +14204,7 @@ Subscriber ID
                         <p class="marked">Returns a user</p>
                         <p></p>
                         <br />
-                        <pre class="prettyprint language-html prettyprinted" data-type="get"><code><span class="pln">/api/v1/users/{userID}</span></code></pre>
+                        <pre class="prettyprint language-html prettyprinted" data-type="get"><code><span class="pln">/users/{userID}</span></code></pre>
                         <p>
                           <h3>Usage and SDK Samples</h3>
                         </p>
@@ -6753,7 +14228,7 @@ Subscriber ID
                             <pre class="prettyprint"><code class="language-bsh">curl -X GET \
 -H "Authorization: [[apiKey]]" \
  -H "Accept: application/json" \
- "http://localhost/api/v1/api/v1/users/{userID}"
+ "http://localhost/api/v2/users/{userID}"
 </code></pre>
                           </div>
                           <div class="tab-pane" id="examples-Default-getUser-0-java">
@@ -7161,955 +14636,135 @@ User ID
                         </article>
                       </div>
                       <hr>
-                    <div id="api-Default-getWorkspace">
-                      <article id="api-Default-getWorkspace-0" data-group="User" data-name="getWorkspace" data-version="0">
+                    <div id="api-Default-insertBoardsAndBlocks">
+                      <article id="api-Default-insertBoardsAndBlocks-0" data-group="User" data-name="insertBoardsAndBlocks" data-version="0">
                         <div class="pull-left">
-                          <h1>getWorkspace</h1>
+                          <h1>insertBoardsAndBlocks</h1>
                           <p></p>
                         </div>
                         <div class="pull-right"></div>
                         <div class="clearfix"></div>
                         <p></p>
-                        <p class="marked">Returns information of the root workspace</p>
+                        <p class="marked">Creates new boards and blocks</p>
                         <p></p>
                         <br />
-                        <pre class="prettyprint language-html prettyprinted" data-type="get"><code><span class="pln">/api/v1/workspaces/{workspaceID}</span></code></pre>
+                        <pre class="prettyprint language-html prettyprinted" data-type="post"><code><span class="pln">/boards-and-blocks</span></code></pre>
                         <p>
                           <h3>Usage and SDK Samples</h3>
                         </p>
                         <ul class="nav nav-tabs nav-tabs-examples">
-                          <li class="active"><a href="#examples-Default-getWorkspace-0-curl">Curl</a></li>
-                          <li class=""><a href="#examples-Default-getWorkspace-0-java">Java</a></li>
-                          <li class=""><a href="#examples-Default-getWorkspace-0-android">Android</a></li>
-                          <!--<li class=""><a href="#examples-Default-getWorkspace-0-groovy">Groovy</a></li>-->
-                          <li class=""><a href="#examples-Default-getWorkspace-0-objc">Obj-C</a></li>
-                          <li class=""><a href="#examples-Default-getWorkspace-0-javascript">JavaScript</a></li>
-                          <!--<li class=""><a href="#examples-Default-getWorkspace-0-angular">Angular</a></li>-->
-                          <li class=""><a href="#examples-Default-getWorkspace-0-csharp">C#</a></li>
-                          <li class=""><a href="#examples-Default-getWorkspace-0-php">PHP</a></li>
-                          <li class=""><a href="#examples-Default-getWorkspace-0-perl">Perl</a></li>
-                          <li class=""><a href="#examples-Default-getWorkspace-0-python">Python</a></li>
-                          <li class=""><a href="#examples-Default-getWorkspace-0-rust">Rust</a></li>
+                          <li class="active"><a href="#examples-Default-insertBoardsAndBlocks-0-curl">Curl</a></li>
+                          <li class=""><a href="#examples-Default-insertBoardsAndBlocks-0-java">Java</a></li>
+                          <li class=""><a href="#examples-Default-insertBoardsAndBlocks-0-android">Android</a></li>
+                          <!--<li class=""><a href="#examples-Default-insertBoardsAndBlocks-0-groovy">Groovy</a></li>-->
+                          <li class=""><a href="#examples-Default-insertBoardsAndBlocks-0-objc">Obj-C</a></li>
+                          <li class=""><a href="#examples-Default-insertBoardsAndBlocks-0-javascript">JavaScript</a></li>
+                          <!--<li class=""><a href="#examples-Default-insertBoardsAndBlocks-0-angular">Angular</a></li>-->
+                          <li class=""><a href="#examples-Default-insertBoardsAndBlocks-0-csharp">C#</a></li>
+                          <li class=""><a href="#examples-Default-insertBoardsAndBlocks-0-php">PHP</a></li>
+                          <li class=""><a href="#examples-Default-insertBoardsAndBlocks-0-perl">Perl</a></li>
+                          <li class=""><a href="#examples-Default-insertBoardsAndBlocks-0-python">Python</a></li>
+                          <li class=""><a href="#examples-Default-insertBoardsAndBlocks-0-rust">Rust</a></li>
                         </ul>
 
                         <div class="tab-content">
-                          <div class="tab-pane active" id="examples-Default-getWorkspace-0-curl">
-                            <pre class="prettyprint"><code class="language-bsh">curl -X GET \
--H "Authorization: [[apiKey]]" \
- -H "Accept: application/json" \
- "http://localhost/api/v1/api/v1/workspaces/{workspaceID}"
-</code></pre>
-                          </div>
-                          <div class="tab-pane" id="examples-Default-getWorkspace-0-java">
-                            <pre class="prettyprint"><code class="language-java">import org.openapitools.client.*;
-import org.openapitools.client.auth.*;
-import org.openapitools.client.model.*;
-import org.openapitools.client.api.DefaultApi;
-
-import java.io.File;
-import java.util.*;
-
-public class DefaultApiExample {
-    public static void main(String[] args) {
-        ApiClient defaultClient = Configuration.getDefaultApiClient();
-        
-        // Configure API key authorization: BearerAuth
-        ApiKeyAuth BearerAuth = (ApiKeyAuth) defaultClient.getAuthentication("BearerAuth");
-        BearerAuth.setApiKey("YOUR API KEY");
-        // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
-        //BearerAuth.setApiKeyPrefix("Token");
-
-        // Create an instance of the API class
-        DefaultApi apiInstance = new DefaultApi();
-        String workspaceID = workspaceID_example; // String | Workspace ID
-
-        try {
-            Workspace result = apiInstance.getWorkspace(workspaceID);
-            System.out.println(result);
-        } catch (ApiException e) {
-            System.err.println("Exception when calling DefaultApi#getWorkspace");
-            e.printStackTrace();
-        }
-    }
-}
-</code></pre>
-                          </div>
-
-                          <div class="tab-pane" id="examples-Default-getWorkspace-0-android">
-                            <pre class="prettyprint"><code class="language-java">import org.openapitools.client.api.DefaultApi;
-
-public class DefaultApiExample {
-    public static void main(String[] args) {
-        DefaultApi apiInstance = new DefaultApi();
-        String workspaceID = workspaceID_example; // String | Workspace ID
-
-        try {
-            Workspace result = apiInstance.getWorkspace(workspaceID);
-            System.out.println(result);
-        } catch (ApiException e) {
-            System.err.println("Exception when calling DefaultApi#getWorkspace");
-            e.printStackTrace();
-        }
-    }
-}</code></pre>
-                          </div>
-  <!--
-  <div class="tab-pane" id="examples-Default-getWorkspace-0-groovy">
-  <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
-  </div> -->
-                            <div class="tab-pane" id="examples-Default-getWorkspace-0-objc">
-                              <pre class="prettyprint"><code class="language-cpp">Configuration *apiConfig = [Configuration sharedConfig];
-
-// Configure API key authorization: (authentication scheme: BearerAuth)
-[apiConfig setApiKey:@"YOUR_API_KEY" forApiKeyIdentifier:@"Authorization"];
-// Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
-//[apiConfig setApiKeyPrefix:@"Bearer" forApiKeyIdentifier:@"Authorization"];
-
-
-// Create an instance of the API class
-DefaultApi *apiInstance = [[DefaultApi alloc] init];
-String *workspaceID = workspaceID_example; // Workspace ID (default to null)
-
-[apiInstance getWorkspaceWith:workspaceID
-              completionHandler: ^(Workspace output, NSError* error) {
-    if (output) {
-        NSLog(@"%@", output);
-    }
-    if (error) {
-        NSLog(@"Error: %@", error);
-    }
-}];
-</code></pre>
-                            </div>
-
-                            <div class="tab-pane" id="examples-Default-getWorkspace-0-javascript">
-                              <pre class="prettyprint"><code class="language-js">var FocalboardServer = require('focalboard_server');
-var defaultClient = FocalboardServer.ApiClient.instance;
-
-// Configure API key authorization: BearerAuth
-var BearerAuth = defaultClient.authentications['BearerAuth'];
-BearerAuth.apiKey = "YOUR API KEY";
-// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
-//BearerAuth.apiKeyPrefix['Authorization'] = "Token";
-
-// Create an instance of the API class
-var api = new FocalboardServer.DefaultApi()
-var workspaceID = workspaceID_example; // {String} Workspace ID
-
-var callback = function(error, data, response) {
-  if (error) {
-    console.error(error);
-  } else {
-    console.log('API called successfully. Returned data: ' + data);
-  }
-};
-api.getWorkspace(workspaceID, callback);
-</code></pre>
-                            </div>
-
-                            <!--<div class="tab-pane" id="examples-Default-getWorkspace-0-angular">
-              <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
-            </div>-->
-                            <div class="tab-pane" id="examples-Default-getWorkspace-0-csharp">
-                              <pre class="prettyprint"><code class="language-cs">using System;
-using System.Diagnostics;
-using Org.OpenAPITools.Api;
-using Org.OpenAPITools.Client;
-using Org.OpenAPITools.Model;
-
-namespace Example
-{
-    public class getWorkspaceExample
-    {
-        public void main()
-        {
-            // Configure API key authorization: BearerAuth
-            Configuration.Default.ApiKey.Add("Authorization", "YOUR_API_KEY");
-            // Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
-            // Configuration.Default.ApiKeyPrefix.Add("Authorization", "Bearer");
-
-            // Create an instance of the API class
-            var apiInstance = new DefaultApi();
-            var workspaceID = workspaceID_example;  // String | Workspace ID (default to null)
-
-            try {
-                Workspace result = apiInstance.getWorkspace(workspaceID);
-                Debug.WriteLine(result);
-            } catch (Exception e) {
-                Debug.Print("Exception when calling DefaultApi.getWorkspace: " + e.Message );
-            }
-        }
-    }
-}
-</code></pre>
-                            </div>
-
-                            <div class="tab-pane" id="examples-Default-getWorkspace-0-php">
-                              <pre class="prettyprint"><code class="language-php"><&#63;php
-require_once(__DIR__ . '/vendor/autoload.php');
-
-// Configure API key authorization: BearerAuth
-OpenAPITools\Client\Configuration::getDefaultConfiguration()->setApiKey('Authorization', 'YOUR_API_KEY');
-// Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
-// OpenAPITools\Client\Configuration::getDefaultConfiguration()->setApiKeyPrefix('Authorization', 'Bearer');
-
-// Create an instance of the API class
-$api_instance = new OpenAPITools\Client\Api\DefaultApi();
-$workspaceID = workspaceID_example; // String | Workspace ID
-
-try {
-    $result = $api_instance->getWorkspace($workspaceID);
-    print_r($result);
-} catch (Exception $e) {
-    echo 'Exception when calling DefaultApi->getWorkspace: ', $e->getMessage(), PHP_EOL;
-}
-?></code></pre>
-                            </div>
-
-                            <div class="tab-pane" id="examples-Default-getWorkspace-0-perl">
-                              <pre class="prettyprint"><code class="language-perl">use Data::Dumper;
-use WWW::OPenAPIClient::Configuration;
-use WWW::OPenAPIClient::DefaultApi;
-
-# Configure API key authorization: BearerAuth
-$WWW::OPenAPIClient::Configuration::api_key->{'Authorization'} = 'YOUR_API_KEY';
-# uncomment below to setup prefix (e.g. Bearer) for API key, if needed
-#$WWW::OPenAPIClient::Configuration::api_key_prefix->{'Authorization'} = "Bearer";
-
-# Create an instance of the API class
-my $api_instance = WWW::OPenAPIClient::DefaultApi->new();
-my $workspaceID = workspaceID_example; # String | Workspace ID
-
-eval {
-    my $result = $api_instance->getWorkspace(workspaceID => $workspaceID);
-    print Dumper($result);
-};
-if ($@) {
-    warn "Exception when calling DefaultApi->getWorkspace: $@\n";
-}</code></pre>
-                            </div>
-
-                            <div class="tab-pane" id="examples-Default-getWorkspace-0-python">
-                              <pre class="prettyprint"><code class="language-python">from __future__ import print_statement
-import time
-import openapi_client
-from openapi_client.rest import ApiException
-from pprint import pprint
-
-# Configure API key authorization: BearerAuth
-openapi_client.configuration.api_key['Authorization'] = 'YOUR_API_KEY'
-# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
-# openapi_client.configuration.api_key_prefix['Authorization'] = 'Bearer'
-
-# Create an instance of the API class
-api_instance = openapi_client.DefaultApi()
-workspaceID = workspaceID_example # String | Workspace ID (default to null)
-
-try:
-    api_response = api_instance.get_workspace(workspaceID)
-    pprint(api_response)
-except ApiException as e:
-    print("Exception when calling DefaultApi->getWorkspace: %s\n" % e)</code></pre>
-                            </div>
-
-                            <div class="tab-pane" id="examples-Default-getWorkspace-0-rust">
-                              <pre class="prettyprint"><code class="language-rust">extern crate DefaultApi;
-
-pub fn main() {
-    let workspaceID = workspaceID_example; // String
-
-    let mut context = DefaultApi::Context::default();
-    let result = client.getWorkspace(workspaceID, &context).wait();
-
-    println!("{:?}", result);
-}
-</code></pre>
-                            </div>
-                          </div>
-
-                          <h2>Scopes</h2>
-                          <table>
-                            
-                          </table>
-
-                          <h2>Parameters</h2>
-
-                            <div class="methodsubtabletitle">Path parameters</div>
-                            <table id="methodsubtable">
-                                <tr>
-                                  <th width="150px">Name</th>
-                                  <th>Description</th>
-                                </tr>
-                                  <tr><td style="width:150px;">workspaceID*</td>
-<td>
-
-
-    <div id="d2e199_getWorkspace_workspaceID">
-        <div class="json-schema-view">
-            <div class="primitive">
-                <span class="type">
-                    String
-                </span>
-
-                    <div class="inner description marked">
-Workspace ID
-                    </div>
-            </div>
-                <div class="inner required">
-                    Required
-                </div>
-        </div>
-    </div>
-</td>
-</tr>
-
-                            </table>
-
-
-
-
-
-                          <h2>Responses</h2>
-                            <h3 id="examples-Default-getWorkspace-title-200"></h3>
-                            <p id="examples-Default-getWorkspace-description-200" class="marked"></p>
-                            <script>
-                              var responseDefault200_description = `success`;
-                              var responseDefault200_description_break = responseDefault200_description.indexOf('\n');
-                              if (responseDefault200_description_break == -1) {
-                                $("#examples-Default-getWorkspace-title-200").text("Status: 200 - " + responseDefault200_description);
-                              } else {
-                                $("#examples-Default-getWorkspace-title-200").text("Status: 200 - " + responseDefault200_description.substring(0, responseDefault200_description_break));
-                                $("#examples-Default-getWorkspace-description-200").html(responseDefault200_description.substring(responseDefault200_description_break));
-                              }
-                            </script>
-
-
-                            <ul id="responses-detail-Default-getWorkspace-200" class="nav nav-tabs nav-tabs-examples" >
-                                <li class="active">
-                                  <a data-toggle="tab" href="#responses-Default-getWorkspace-200-schema">Schema</a>
-                                </li>
-
-
-
-
-                            </ul>
-
-
-                            <div class="tab-content" id="responses-Default-getWorkspace-200-wrapper" style='margin-bottom: 10px;'>
-                                <div class="tab-pane active" id="responses-Default-getWorkspace-200-schema">
-                                  <div id="responses-Default-getWorkspace-schema-200" class="exampleStyle">
-                                    <script>
-                                      $(document).ready(function() {
-                                        var schemaWrapper = {
-  "description" : "success",
-  "content" : {
-    "application/json" : {
-      "schema" : {
-        "$ref" : "#/components/schemas/Workspace"
-      }
-    }
-  }
-};
-                                        var schema = findNode('schema',schemaWrapper).schema;
-                                        if (!schema) {
-                                          schema = schemaWrapper.schema;
-                                        }
-                                        if (schema.$ref != null) {
-                                          schema = defsParser.$refs.get(schema.$ref);
-                                        } else if (schema.items != null && schema.items.$ref != null) {
-                                            schema.items = defsParser.$refs.get(schema.items.$ref);
-                                        } else {
-                                          schemaWrapper.definitions = Object.assign({}, defs);
-                                          $RefParser.dereference(schemaWrapper).catch(function(err) {
-                                            console.log(err);
-                                          });
-                                        }
-
-                                        var view = new JSONSchemaView(schema, 3);
-                                        $('#responses-Default-getWorkspace-200-schema-data').val(JSON.stringify(schema));
-                                        var result = $('#responses-Default-getWorkspace-schema-200');
-                                        result.empty();
-                                        result.append(view.render());
-                                      });
-                                    </script>
-                                  </div>
-                                  <input id='responses-Default-getWorkspace-200-schema-data' type='hidden' value=''></input>
-                                </div>
-                            </div>
-                            <h3 id="examples-Default-getWorkspace-title-default"></h3>
-                            <p id="examples-Default-getWorkspace-description-default" class="marked"></p>
-                            <script>
-                              var responseDefaultdefault_description = `internal error`;
-                              var responseDefaultdefault_description_break = responseDefaultdefault_description.indexOf('\n');
-                              if (responseDefaultdefault_description_break == -1) {
-                                $("#examples-Default-getWorkspace-title-default").text("Status: default - " + responseDefaultdefault_description);
-                              } else {
-                                $("#examples-Default-getWorkspace-title-default").text("Status: default - " + responseDefaultdefault_description.substring(0, responseDefaultdefault_description_break));
-                                $("#examples-Default-getWorkspace-description-default").html(responseDefaultdefault_description.substring(responseDefaultdefault_description_break));
-                              }
-                            </script>
-
-
-                            <ul id="responses-detail-Default-getWorkspace-default" class="nav nav-tabs nav-tabs-examples" >
-                                <li class="active">
-                                  <a data-toggle="tab" href="#responses-Default-getWorkspace-default-schema">Schema</a>
-                                </li>
-
-
-
-
-                            </ul>
-
-
-                            <div class="tab-content" id="responses-Default-getWorkspace-default-wrapper" style='margin-bottom: 10px;'>
-                                <div class="tab-pane active" id="responses-Default-getWorkspace-default-schema">
-                                  <div id="responses-Default-getWorkspace-schema-default" class="exampleStyle">
-                                    <script>
-                                      $(document).ready(function() {
-                                        var schemaWrapper = {
-  "description" : "internal error",
-  "content" : {
-    "application/json" : {
-      "schema" : {
-        "$ref" : "#/components/schemas/ErrorResponse"
-      }
-    }
-  }
-};
-                                        var schema = findNode('schema',schemaWrapper).schema;
-                                        if (!schema) {
-                                          schema = schemaWrapper.schema;
-                                        }
-                                        if (schema.$ref != null) {
-                                          schema = defsParser.$refs.get(schema.$ref);
-                                        } else if (schema.items != null && schema.items.$ref != null) {
-                                            schema.items = defsParser.$refs.get(schema.items.$ref);
-                                        } else {
-                                          schemaWrapper.definitions = Object.assign({}, defs);
-                                          $RefParser.dereference(schemaWrapper).catch(function(err) {
-                                            console.log(err);
-                                          });
-                                        }
-
-                                        var view = new JSONSchemaView(schema, 3);
-                                        $('#responses-Default-getWorkspace-default-schema-data').val(JSON.stringify(schema));
-                                        var result = $('#responses-Default-getWorkspace-schema-default');
-                                        result.empty();
-                                        result.append(view.render());
-                                      });
-                                    </script>
-                                  </div>
-                                  <input id='responses-Default-getWorkspace-default-schema-data' type='hidden' value=''></input>
-                                </div>
-                            </div>
-                        </article>
-                      </div>
-                      <hr>
-                    <div id="api-Default-getWorkspaceUsers">
-                      <article id="api-Default-getWorkspaceUsers-0" data-group="User" data-name="getWorkspaceUsers" data-version="0">
-                        <div class="pull-left">
-                          <h1>getWorkspaceUsers</h1>
-                          <p></p>
-                        </div>
-                        <div class="pull-right"></div>
-                        <div class="clearfix"></div>
-                        <p></p>
-                        <p class="marked">Returns workspace users</p>
-                        <p></p>
-                        <br />
-                        <pre class="prettyprint language-html prettyprinted" data-type="get"><code><span class="pln">/api/v1/workspaces/{workspaceID}/users</span></code></pre>
-                        <p>
-                          <h3>Usage and SDK Samples</h3>
-                        </p>
-                        <ul class="nav nav-tabs nav-tabs-examples">
-                          <li class="active"><a href="#examples-Default-getWorkspaceUsers-0-curl">Curl</a></li>
-                          <li class=""><a href="#examples-Default-getWorkspaceUsers-0-java">Java</a></li>
-                          <li class=""><a href="#examples-Default-getWorkspaceUsers-0-android">Android</a></li>
-                          <!--<li class=""><a href="#examples-Default-getWorkspaceUsers-0-groovy">Groovy</a></li>-->
-                          <li class=""><a href="#examples-Default-getWorkspaceUsers-0-objc">Obj-C</a></li>
-                          <li class=""><a href="#examples-Default-getWorkspaceUsers-0-javascript">JavaScript</a></li>
-                          <!--<li class=""><a href="#examples-Default-getWorkspaceUsers-0-angular">Angular</a></li>-->
-                          <li class=""><a href="#examples-Default-getWorkspaceUsers-0-csharp">C#</a></li>
-                          <li class=""><a href="#examples-Default-getWorkspaceUsers-0-php">PHP</a></li>
-                          <li class=""><a href="#examples-Default-getWorkspaceUsers-0-perl">Perl</a></li>
-                          <li class=""><a href="#examples-Default-getWorkspaceUsers-0-python">Python</a></li>
-                          <li class=""><a href="#examples-Default-getWorkspaceUsers-0-rust">Rust</a></li>
-                        </ul>
-
-                        <div class="tab-content">
-                          <div class="tab-pane active" id="examples-Default-getWorkspaceUsers-0-curl">
-                            <pre class="prettyprint"><code class="language-bsh">curl -X GET \
--H "Authorization: [[apiKey]]" \
- -H "Accept: application/json" \
- "http://localhost/api/v1/api/v1/workspaces/{workspaceID}/users"
-</code></pre>
-                          </div>
-                          <div class="tab-pane" id="examples-Default-getWorkspaceUsers-0-java">
-                            <pre class="prettyprint"><code class="language-java">import org.openapitools.client.*;
-import org.openapitools.client.auth.*;
-import org.openapitools.client.model.*;
-import org.openapitools.client.api.DefaultApi;
-
-import java.io.File;
-import java.util.*;
-
-public class DefaultApiExample {
-    public static void main(String[] args) {
-        ApiClient defaultClient = Configuration.getDefaultApiClient();
-        
-        // Configure API key authorization: BearerAuth
-        ApiKeyAuth BearerAuth = (ApiKeyAuth) defaultClient.getAuthentication("BearerAuth");
-        BearerAuth.setApiKey("YOUR API KEY");
-        // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
-        //BearerAuth.setApiKeyPrefix("Token");
-
-        // Create an instance of the API class
-        DefaultApi apiInstance = new DefaultApi();
-        String workspaceID = workspaceID_example; // String | Workspace ID
-
-        try {
-            array[User] result = apiInstance.getWorkspaceUsers(workspaceID);
-            System.out.println(result);
-        } catch (ApiException e) {
-            System.err.println("Exception when calling DefaultApi#getWorkspaceUsers");
-            e.printStackTrace();
-        }
-    }
-}
-</code></pre>
-                          </div>
-
-                          <div class="tab-pane" id="examples-Default-getWorkspaceUsers-0-android">
-                            <pre class="prettyprint"><code class="language-java">import org.openapitools.client.api.DefaultApi;
-
-public class DefaultApiExample {
-    public static void main(String[] args) {
-        DefaultApi apiInstance = new DefaultApi();
-        String workspaceID = workspaceID_example; // String | Workspace ID
-
-        try {
-            array[User] result = apiInstance.getWorkspaceUsers(workspaceID);
-            System.out.println(result);
-        } catch (ApiException e) {
-            System.err.println("Exception when calling DefaultApi#getWorkspaceUsers");
-            e.printStackTrace();
-        }
-    }
-}</code></pre>
-                          </div>
-  <!--
-  <div class="tab-pane" id="examples-Default-getWorkspaceUsers-0-groovy">
-  <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
-  </div> -->
-                            <div class="tab-pane" id="examples-Default-getWorkspaceUsers-0-objc">
-                              <pre class="prettyprint"><code class="language-cpp">Configuration *apiConfig = [Configuration sharedConfig];
-
-// Configure API key authorization: (authentication scheme: BearerAuth)
-[apiConfig setApiKey:@"YOUR_API_KEY" forApiKeyIdentifier:@"Authorization"];
-// Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
-//[apiConfig setApiKeyPrefix:@"Bearer" forApiKeyIdentifier:@"Authorization"];
-
-
-// Create an instance of the API class
-DefaultApi *apiInstance = [[DefaultApi alloc] init];
-String *workspaceID = workspaceID_example; // Workspace ID (default to null)
-
-[apiInstance getWorkspaceUsersWith:workspaceID
-              completionHandler: ^(array[User] output, NSError* error) {
-    if (output) {
-        NSLog(@"%@", output);
-    }
-    if (error) {
-        NSLog(@"Error: %@", error);
-    }
-}];
-</code></pre>
-                            </div>
-
-                            <div class="tab-pane" id="examples-Default-getWorkspaceUsers-0-javascript">
-                              <pre class="prettyprint"><code class="language-js">var FocalboardServer = require('focalboard_server');
-var defaultClient = FocalboardServer.ApiClient.instance;
-
-// Configure API key authorization: BearerAuth
-var BearerAuth = defaultClient.authentications['BearerAuth'];
-BearerAuth.apiKey = "YOUR API KEY";
-// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
-//BearerAuth.apiKeyPrefix['Authorization'] = "Token";
-
-// Create an instance of the API class
-var api = new FocalboardServer.DefaultApi()
-var workspaceID = workspaceID_example; // {String} Workspace ID
-
-var callback = function(error, data, response) {
-  if (error) {
-    console.error(error);
-  } else {
-    console.log('API called successfully. Returned data: ' + data);
-  }
-};
-api.getWorkspaceUsers(workspaceID, callback);
-</code></pre>
-                            </div>
-
-                            <!--<div class="tab-pane" id="examples-Default-getWorkspaceUsers-0-angular">
-              <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
-            </div>-->
-                            <div class="tab-pane" id="examples-Default-getWorkspaceUsers-0-csharp">
-                              <pre class="prettyprint"><code class="language-cs">using System;
-using System.Diagnostics;
-using Org.OpenAPITools.Api;
-using Org.OpenAPITools.Client;
-using Org.OpenAPITools.Model;
-
-namespace Example
-{
-    public class getWorkspaceUsersExample
-    {
-        public void main()
-        {
-            // Configure API key authorization: BearerAuth
-            Configuration.Default.ApiKey.Add("Authorization", "YOUR_API_KEY");
-            // Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
-            // Configuration.Default.ApiKeyPrefix.Add("Authorization", "Bearer");
-
-            // Create an instance of the API class
-            var apiInstance = new DefaultApi();
-            var workspaceID = workspaceID_example;  // String | Workspace ID (default to null)
-
-            try {
-                array[User] result = apiInstance.getWorkspaceUsers(workspaceID);
-                Debug.WriteLine(result);
-            } catch (Exception e) {
-                Debug.Print("Exception when calling DefaultApi.getWorkspaceUsers: " + e.Message );
-            }
-        }
-    }
-}
-</code></pre>
-                            </div>
-
-                            <div class="tab-pane" id="examples-Default-getWorkspaceUsers-0-php">
-                              <pre class="prettyprint"><code class="language-php"><&#63;php
-require_once(__DIR__ . '/vendor/autoload.php');
-
-// Configure API key authorization: BearerAuth
-OpenAPITools\Client\Configuration::getDefaultConfiguration()->setApiKey('Authorization', 'YOUR_API_KEY');
-// Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
-// OpenAPITools\Client\Configuration::getDefaultConfiguration()->setApiKeyPrefix('Authorization', 'Bearer');
-
-// Create an instance of the API class
-$api_instance = new OpenAPITools\Client\Api\DefaultApi();
-$workspaceID = workspaceID_example; // String | Workspace ID
-
-try {
-    $result = $api_instance->getWorkspaceUsers($workspaceID);
-    print_r($result);
-} catch (Exception $e) {
-    echo 'Exception when calling DefaultApi->getWorkspaceUsers: ', $e->getMessage(), PHP_EOL;
-}
-?></code></pre>
-                            </div>
-
-                            <div class="tab-pane" id="examples-Default-getWorkspaceUsers-0-perl">
-                              <pre class="prettyprint"><code class="language-perl">use Data::Dumper;
-use WWW::OPenAPIClient::Configuration;
-use WWW::OPenAPIClient::DefaultApi;
-
-# Configure API key authorization: BearerAuth
-$WWW::OPenAPIClient::Configuration::api_key->{'Authorization'} = 'YOUR_API_KEY';
-# uncomment below to setup prefix (e.g. Bearer) for API key, if needed
-#$WWW::OPenAPIClient::Configuration::api_key_prefix->{'Authorization'} = "Bearer";
-
-# Create an instance of the API class
-my $api_instance = WWW::OPenAPIClient::DefaultApi->new();
-my $workspaceID = workspaceID_example; # String | Workspace ID
-
-eval {
-    my $result = $api_instance->getWorkspaceUsers(workspaceID => $workspaceID);
-    print Dumper($result);
-};
-if ($@) {
-    warn "Exception when calling DefaultApi->getWorkspaceUsers: $@\n";
-}</code></pre>
-                            </div>
-
-                            <div class="tab-pane" id="examples-Default-getWorkspaceUsers-0-python">
-                              <pre class="prettyprint"><code class="language-python">from __future__ import print_statement
-import time
-import openapi_client
-from openapi_client.rest import ApiException
-from pprint import pprint
-
-# Configure API key authorization: BearerAuth
-openapi_client.configuration.api_key['Authorization'] = 'YOUR_API_KEY'
-# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
-# openapi_client.configuration.api_key_prefix['Authorization'] = 'Bearer'
-
-# Create an instance of the API class
-api_instance = openapi_client.DefaultApi()
-workspaceID = workspaceID_example # String | Workspace ID (default to null)
-
-try:
-    api_response = api_instance.get_workspace_users(workspaceID)
-    pprint(api_response)
-except ApiException as e:
-    print("Exception when calling DefaultApi->getWorkspaceUsers: %s\n" % e)</code></pre>
-                            </div>
-
-                            <div class="tab-pane" id="examples-Default-getWorkspaceUsers-0-rust">
-                              <pre class="prettyprint"><code class="language-rust">extern crate DefaultApi;
-
-pub fn main() {
-    let workspaceID = workspaceID_example; // String
-
-    let mut context = DefaultApi::Context::default();
-    let result = client.getWorkspaceUsers(workspaceID, &context).wait();
-
-    println!("{:?}", result);
-}
-</code></pre>
-                            </div>
-                          </div>
-
-                          <h2>Scopes</h2>
-                          <table>
-                            
-                          </table>
-
-                          <h2>Parameters</h2>
-
-                            <div class="methodsubtabletitle">Path parameters</div>
-                            <table id="methodsubtable">
-                                <tr>
-                                  <th width="150px">Name</th>
-                                  <th>Description</th>
-                                </tr>
-                                  <tr><td style="width:150px;">workspaceID*</td>
-<td>
-
-
-    <div id="d2e199_getWorkspaceUsers_workspaceID">
-        <div class="json-schema-view">
-            <div class="primitive">
-                <span class="type">
-                    String
-                </span>
-
-                    <div class="inner description marked">
-Workspace ID
-                    </div>
-            </div>
-                <div class="inner required">
-                    Required
-                </div>
-        </div>
-    </div>
-</td>
-</tr>
-
-                            </table>
-
-
-
-
-
-                          <h2>Responses</h2>
-                            <h3 id="examples-Default-getWorkspaceUsers-title-200"></h3>
-                            <p id="examples-Default-getWorkspaceUsers-description-200" class="marked"></p>
-                            <script>
-                              var responseDefault200_description = `success`;
-                              var responseDefault200_description_break = responseDefault200_description.indexOf('\n');
-                              if (responseDefault200_description_break == -1) {
-                                $("#examples-Default-getWorkspaceUsers-title-200").text("Status: 200 - " + responseDefault200_description);
-                              } else {
-                                $("#examples-Default-getWorkspaceUsers-title-200").text("Status: 200 - " + responseDefault200_description.substring(0, responseDefault200_description_break));
-                                $("#examples-Default-getWorkspaceUsers-description-200").html(responseDefault200_description.substring(responseDefault200_description_break));
-                              }
-                            </script>
-
-
-                            <ul id="responses-detail-Default-getWorkspaceUsers-200" class="nav nav-tabs nav-tabs-examples" >
-                                <li class="active">
-                                  <a data-toggle="tab" href="#responses-Default-getWorkspaceUsers-200-schema">Schema</a>
-                                </li>
-
-
-
-
-                            </ul>
-
-
-                            <div class="tab-content" id="responses-Default-getWorkspaceUsers-200-wrapper" style='margin-bottom: 10px;'>
-                                <div class="tab-pane active" id="responses-Default-getWorkspaceUsers-200-schema">
-                                  <div id="responses-Default-getWorkspaceUsers-schema-200" class="exampleStyle">
-                                    <script>
-                                      $(document).ready(function() {
-                                        var schemaWrapper = {
-  "description" : "success",
-  "content" : {
-    "application/json" : {
-      "schema" : {
-        "type" : "array",
-        "items" : {
-          "$ref" : "#/components/schemas/User"
-        }
-      }
-    }
-  }
-};
-                                        var schema = findNode('schema',schemaWrapper).schema;
-                                        if (!schema) {
-                                          schema = schemaWrapper.schema;
-                                        }
-                                        if (schema.$ref != null) {
-                                          schema = defsParser.$refs.get(schema.$ref);
-                                        } else if (schema.items != null && schema.items.$ref != null) {
-                                            schema.items = defsParser.$refs.get(schema.items.$ref);
-                                        } else {
-                                          schemaWrapper.definitions = Object.assign({}, defs);
-                                          $RefParser.dereference(schemaWrapper).catch(function(err) {
-                                            console.log(err);
-                                          });
-                                        }
-
-                                        var view = new JSONSchemaView(schema, 3);
-                                        $('#responses-Default-getWorkspaceUsers-200-schema-data').val(JSON.stringify(schema));
-                                        var result = $('#responses-Default-getWorkspaceUsers-schema-200');
-                                        result.empty();
-                                        result.append(view.render());
-                                      });
-                                    </script>
-                                  </div>
-                                  <input id='responses-Default-getWorkspaceUsers-200-schema-data' type='hidden' value=''></input>
-                                </div>
-                            </div>
-                            <h3 id="examples-Default-getWorkspaceUsers-title-default"></h3>
-                            <p id="examples-Default-getWorkspaceUsers-description-default" class="marked"></p>
-                            <script>
-                              var responseDefaultdefault_description = `internal error`;
-                              var responseDefaultdefault_description_break = responseDefaultdefault_description.indexOf('\n');
-                              if (responseDefaultdefault_description_break == -1) {
-                                $("#examples-Default-getWorkspaceUsers-title-default").text("Status: default - " + responseDefaultdefault_description);
-                              } else {
-                                $("#examples-Default-getWorkspaceUsers-title-default").text("Status: default - " + responseDefaultdefault_description.substring(0, responseDefaultdefault_description_break));
-                                $("#examples-Default-getWorkspaceUsers-description-default").html(responseDefaultdefault_description.substring(responseDefaultdefault_description_break));
-                              }
-                            </script>
-
-
-                            <ul id="responses-detail-Default-getWorkspaceUsers-default" class="nav nav-tabs nav-tabs-examples" >
-                                <li class="active">
-                                  <a data-toggle="tab" href="#responses-Default-getWorkspaceUsers-default-schema">Schema</a>
-                                </li>
-
-
-
-
-                            </ul>
-
-
-                            <div class="tab-content" id="responses-Default-getWorkspaceUsers-default-wrapper" style='margin-bottom: 10px;'>
-                                <div class="tab-pane active" id="responses-Default-getWorkspaceUsers-default-schema">
-                                  <div id="responses-Default-getWorkspaceUsers-schema-default" class="exampleStyle">
-                                    <script>
-                                      $(document).ready(function() {
-                                        var schemaWrapper = {
-  "description" : "internal error",
-  "content" : {
-    "application/json" : {
-      "schema" : {
-        "$ref" : "#/components/schemas/ErrorResponse"
-      }
-    }
-  }
-};
-                                        var schema = findNode('schema',schemaWrapper).schema;
-                                        if (!schema) {
-                                          schema = schemaWrapper.schema;
-                                        }
-                                        if (schema.$ref != null) {
-                                          schema = defsParser.$refs.get(schema.$ref);
-                                        } else if (schema.items != null && schema.items.$ref != null) {
-                                            schema.items = defsParser.$refs.get(schema.items.$ref);
-                                        } else {
-                                          schemaWrapper.definitions = Object.assign({}, defs);
-                                          $RefParser.dereference(schemaWrapper).catch(function(err) {
-                                            console.log(err);
-                                          });
-                                        }
-
-                                        var view = new JSONSchemaView(schema, 3);
-                                        $('#responses-Default-getWorkspaceUsers-default-schema-data').val(JSON.stringify(schema));
-                                        var result = $('#responses-Default-getWorkspaceUsers-schema-default');
-                                        result.empty();
-                                        result.append(view.render());
-                                      });
-                                    </script>
-                                  </div>
-                                  <input id='responses-Default-getWorkspaceUsers-default-schema-data' type='hidden' value=''></input>
-                                </div>
-                            </div>
-                        </article>
-                      </div>
-                      <hr>
-                    <div id="api-Default-importBlocks">
-                      <article id="api-Default-importBlocks-0" data-group="User" data-name="importBlocks" data-version="0">
-                        <div class="pull-left">
-                          <h1>importBlocks</h1>
-                          <p></p>
-                        </div>
-                        <div class="pull-right"></div>
-                        <div class="clearfix"></div>
-                        <p></p>
-                        <p class="marked">Import blocks</p>
-                        <p></p>
-                        <br />
-                        <pre class="prettyprint language-html prettyprinted" data-type="post"><code><span class="pln">/api/v1/workspaces/{workspaceID}/blocks/import</span></code></pre>
-                        <p>
-                          <h3>Usage and SDK Samples</h3>
-                        </p>
-                        <ul class="nav nav-tabs nav-tabs-examples">
-                          <li class="active"><a href="#examples-Default-importBlocks-0-curl">Curl</a></li>
-                          <li class=""><a href="#examples-Default-importBlocks-0-java">Java</a></li>
-                          <li class=""><a href="#examples-Default-importBlocks-0-android">Android</a></li>
-                          <!--<li class=""><a href="#examples-Default-importBlocks-0-groovy">Groovy</a></li>-->
-                          <li class=""><a href="#examples-Default-importBlocks-0-objc">Obj-C</a></li>
-                          <li class=""><a href="#examples-Default-importBlocks-0-javascript">JavaScript</a></li>
-                          <!--<li class=""><a href="#examples-Default-importBlocks-0-angular">Angular</a></li>-->
-                          <li class=""><a href="#examples-Default-importBlocks-0-csharp">C#</a></li>
-                          <li class=""><a href="#examples-Default-importBlocks-0-php">PHP</a></li>
-                          <li class=""><a href="#examples-Default-importBlocks-0-perl">Perl</a></li>
-                          <li class=""><a href="#examples-Default-importBlocks-0-python">Python</a></li>
-                          <li class=""><a href="#examples-Default-importBlocks-0-rust">Rust</a></li>
-                        </ul>
-
-                        <div class="tab-content">
-                          <div class="tab-pane active" id="examples-Default-importBlocks-0-curl">
+                          <div class="tab-pane active" id="examples-Default-insertBoardsAndBlocks-0-curl">
                             <pre class="prettyprint"><code class="language-bsh">curl -X POST \
 -H "Authorization: [[apiKey]]" \
  -H "Accept: application/json" \
  -H "Content-Type: application/json" \
- "http://localhost/api/v1/api/v1/workspaces/{workspaceID}/blocks/import" \
+ "http://localhost/api/v2/boards-and-blocks" \
  -d '{
-  &quot;schema&quot; : 1,
-  &quot;deleteAt&quot; : 6,
-  &quot;rootId&quot; : &quot;rootId&quot;,
-  &quot;updateAt&quot; : 5,
-  &quot;title&quot; : &quot;title&quot;,
-  &quot;type&quot; : &quot;type&quot;,
-  &quot;createAt&quot; : 0,
-  &quot;parentId&quot; : &quot;parentId&quot;,
-  &quot;createdBy&quot; : &quot;createdBy&quot;,
-  &quot;modifiedBy&quot; : &quot;modifiedBy&quot;,
-  &quot;id&quot; : &quot;id&quot;,
-  &quot;fields&quot; : {
-    &quot;key&quot; : &quot;{}&quot;
-  },
-  &quot;workspaceId&quot; : &quot;workspaceId&quot;
+  &quot;blocks&quot; : [ {
+    &quot;schema&quot; : 1,
+    &quot;createdBy&quot; : &quot;createdBy&quot;,
+    &quot;deleteAt&quot; : 6,
+    &quot;boardId&quot; : &quot;boardId&quot;,
+    &quot;updateAt&quot; : 5,
+    &quot;modifiedBy&quot; : &quot;modifiedBy&quot;,
+    &quot;id&quot; : &quot;id&quot;,
+    &quot;fields&quot; : {
+      &quot;key&quot; : &quot;{}&quot;
+    },
+    &quot;title&quot; : &quot;title&quot;,
+    &quot;type&quot; : &quot;type&quot;,
+    &quot;createAt&quot; : 0,
+    &quot;parentId&quot; : &quot;parentId&quot;
+  }, {
+    &quot;schema&quot; : 1,
+    &quot;createdBy&quot; : &quot;createdBy&quot;,
+    &quot;deleteAt&quot; : 6,
+    &quot;boardId&quot; : &quot;boardId&quot;,
+    &quot;updateAt&quot; : 5,
+    &quot;modifiedBy&quot; : &quot;modifiedBy&quot;,
+    &quot;id&quot; : &quot;id&quot;,
+    &quot;fields&quot; : {
+      &quot;key&quot; : &quot;{}&quot;
+    },
+    &quot;title&quot; : &quot;title&quot;,
+    &quot;type&quot; : &quot;type&quot;,
+    &quot;createAt&quot; : 0,
+    &quot;parentId&quot; : &quot;parentId&quot;
+  } ],
+  &quot;boards&quot; : [ {
+    &quot;deleteAt&quot; : 6,
+    &quot;icon&quot; : &quot;icon&quot;,
+    &quot;description&quot; : &quot;description&quot;,
+    &quot;updateAt&quot; : 5,
+    &quot;title&quot; : &quot;title&quot;,
+    &quot;type&quot; : &quot;type&quot;,
+    &quot;createAt&quot; : 0,
+    &quot;showDescription&quot; : true,
+    &quot;createdBy&quot; : &quot;createdBy&quot;,
+    &quot;isTemplate&quot; : true,
+    &quot;teamId&quot; : &quot;teamId&quot;,
+    &quot;cardProperties&quot; : [ {
+      &quot;key&quot; : &quot;{}&quot;
+    }, {
+      &quot;key&quot; : &quot;{}&quot;
+    } ],
+    &quot;modifiedBy&quot; : &quot;modifiedBy&quot;,
+    &quot;templateVersion&quot; : 1,
+    &quot;columnCalculations&quot; : {
+      &quot;key&quot; : &quot;{}&quot;
+    },
+    &quot;id&quot; : &quot;id&quot;,
+    &quot;channelId&quot; : &quot;channelId&quot;,
+    &quot;properties&quot; : {
+      &quot;key&quot; : &quot;{}&quot;
+    }
+  }, {
+    &quot;deleteAt&quot; : 6,
+    &quot;icon&quot; : &quot;icon&quot;,
+    &quot;description&quot; : &quot;description&quot;,
+    &quot;updateAt&quot; : 5,
+    &quot;title&quot; : &quot;title&quot;,
+    &quot;type&quot; : &quot;type&quot;,
+    &quot;createAt&quot; : 0,
+    &quot;showDescription&quot; : true,
+    &quot;createdBy&quot; : &quot;createdBy&quot;,
+    &quot;isTemplate&quot; : true,
+    &quot;teamId&quot; : &quot;teamId&quot;,
+    &quot;cardProperties&quot; : [ {
+      &quot;key&quot; : &quot;{}&quot;
+    }, {
+      &quot;key&quot; : &quot;{}&quot;
+    } ],
+    &quot;modifiedBy&quot; : &quot;modifiedBy&quot;,
+    &quot;templateVersion&quot; : 1,
+    &quot;columnCalculations&quot; : {
+      &quot;key&quot; : &quot;{}&quot;
+    },
+    &quot;id&quot; : &quot;id&quot;,
+    &quot;channelId&quot; : &quot;channelId&quot;,
+    &quot;properties&quot; : {
+      &quot;key&quot; : &quot;{}&quot;
+    }
+  } ]
 }'
 </code></pre>
                           </div>
-                          <div class="tab-pane" id="examples-Default-importBlocks-0-java">
+                          <div class="tab-pane" id="examples-Default-insertBoardsAndBlocks-0-java">
                             <pre class="prettyprint"><code class="language-java">import org.openapitools.client.*;
 import org.openapitools.client.auth.*;
 import org.openapitools.client.model.*;
@@ -8130,13 +14785,13 @@ public class DefaultApiExample {
 
         // Create an instance of the API class
         DefaultApi apiInstance = new DefaultApi();
-        String workspaceID = workspaceID_example; // String | Workspace ID
-        array[Block] body = ; // array[Block] | 
+        BoardsAndBlocks body = ; // BoardsAndBlocks | 
 
         try {
-            apiInstance.importBlocks(workspaceID, body);
+            BoardsAndBlocks result = apiInstance.insertBoardsAndBlocks(body);
+            System.out.println(result);
         } catch (ApiException e) {
-            System.err.println("Exception when calling DefaultApi#importBlocks");
+            System.err.println("Exception when calling DefaultApi#insertBoardsAndBlocks");
             e.printStackTrace();
         }
     }
@@ -8144,29 +14799,29 @@ public class DefaultApiExample {
 </code></pre>
                           </div>
 
-                          <div class="tab-pane" id="examples-Default-importBlocks-0-android">
+                          <div class="tab-pane" id="examples-Default-insertBoardsAndBlocks-0-android">
                             <pre class="prettyprint"><code class="language-java">import org.openapitools.client.api.DefaultApi;
 
 public class DefaultApiExample {
     public static void main(String[] args) {
         DefaultApi apiInstance = new DefaultApi();
-        String workspaceID = workspaceID_example; // String | Workspace ID
-        array[Block] body = ; // array[Block] | 
+        BoardsAndBlocks body = ; // BoardsAndBlocks | 
 
         try {
-            apiInstance.importBlocks(workspaceID, body);
+            BoardsAndBlocks result = apiInstance.insertBoardsAndBlocks(body);
+            System.out.println(result);
         } catch (ApiException e) {
-            System.err.println("Exception when calling DefaultApi#importBlocks");
+            System.err.println("Exception when calling DefaultApi#insertBoardsAndBlocks");
             e.printStackTrace();
         }
     }
 }</code></pre>
                           </div>
   <!--
-  <div class="tab-pane" id="examples-Default-importBlocks-0-groovy">
+  <div class="tab-pane" id="examples-Default-insertBoardsAndBlocks-0-groovy">
   <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
   </div> -->
-                            <div class="tab-pane" id="examples-Default-importBlocks-0-objc">
+                            <div class="tab-pane" id="examples-Default-insertBoardsAndBlocks-0-objc">
                               <pre class="prettyprint"><code class="language-cpp">Configuration *apiConfig = [Configuration sharedConfig];
 
 // Configure API key authorization: (authentication scheme: BearerAuth)
@@ -8177,12 +14832,13 @@ public class DefaultApiExample {
 
 // Create an instance of the API class
 DefaultApi *apiInstance = [[DefaultApi alloc] init];
-String *workspaceID = workspaceID_example; // Workspace ID (default to null)
-array[Block] *body = ; // 
+BoardsAndBlocks *body = ; // 
 
-[apiInstance importBlocksWith:workspaceID
-    body:body
-              completionHandler: ^(NSError* error) {
+[apiInstance insertBoardsAndBlocksWith:body
+              completionHandler: ^(BoardsAndBlocks output, NSError* error) {
+    if (output) {
+        NSLog(@"%@", output);
+    }
     if (error) {
         NSLog(@"Error: %@", error);
     }
@@ -8190,7 +14846,7 @@ array[Block] *body = ; //
 </code></pre>
                             </div>
 
-                            <div class="tab-pane" id="examples-Default-importBlocks-0-javascript">
+                            <div class="tab-pane" id="examples-Default-insertBoardsAndBlocks-0-javascript">
                               <pre class="prettyprint"><code class="language-js">var FocalboardServer = require('focalboard_server');
 var defaultClient = FocalboardServer.ApiClient.instance;
 
@@ -8202,24 +14858,23 @@ BearerAuth.apiKey = "YOUR API KEY";
 
 // Create an instance of the API class
 var api = new FocalboardServer.DefaultApi()
-var workspaceID = workspaceID_example; // {String} Workspace ID
-var body = ; // {array[Block]} 
+var body = ; // {BoardsAndBlocks} 
 
 var callback = function(error, data, response) {
   if (error) {
     console.error(error);
   } else {
-    console.log('API called successfully.');
+    console.log('API called successfully. Returned data: ' + data);
   }
 };
-api.importBlocks(workspaceID, body, callback);
+api.insertBoardsAndBlocks(body, callback);
 </code></pre>
                             </div>
 
-                            <!--<div class="tab-pane" id="examples-Default-importBlocks-0-angular">
+                            <!--<div class="tab-pane" id="examples-Default-insertBoardsAndBlocks-0-angular">
               <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
             </div>-->
-                            <div class="tab-pane" id="examples-Default-importBlocks-0-csharp">
+                            <div class="tab-pane" id="examples-Default-insertBoardsAndBlocks-0-csharp">
                               <pre class="prettyprint"><code class="language-cs">using System;
 using System.Diagnostics;
 using Org.OpenAPITools.Api;
@@ -8228,7 +14883,7 @@ using Org.OpenAPITools.Model;
 
 namespace Example
 {
-    public class importBlocksExample
+    public class insertBoardsAndBlocksExample
     {
         public void main()
         {
@@ -8239,13 +14894,13 @@ namespace Example
 
             // Create an instance of the API class
             var apiInstance = new DefaultApi();
-            var workspaceID = workspaceID_example;  // String | Workspace ID (default to null)
-            var body = new array[Block](); // array[Block] | 
+            var body = new BoardsAndBlocks(); // BoardsAndBlocks | 
 
             try {
-                apiInstance.importBlocks(workspaceID, body);
+                BoardsAndBlocks result = apiInstance.insertBoardsAndBlocks(body);
+                Debug.WriteLine(result);
             } catch (Exception e) {
-                Debug.Print("Exception when calling DefaultApi.importBlocks: " + e.Message );
+                Debug.Print("Exception when calling DefaultApi.insertBoardsAndBlocks: " + e.Message );
             }
         }
     }
@@ -8253,7 +14908,7 @@ namespace Example
 </code></pre>
                             </div>
 
-                            <div class="tab-pane" id="examples-Default-importBlocks-0-php">
+                            <div class="tab-pane" id="examples-Default-insertBoardsAndBlocks-0-php">
                               <pre class="prettyprint"><code class="language-php"><&#63;php
 require_once(__DIR__ . '/vendor/autoload.php');
 
@@ -8264,18 +14919,18 @@ OpenAPITools\Client\Configuration::getDefaultConfiguration()->setApiKey('Authori
 
 // Create an instance of the API class
 $api_instance = new OpenAPITools\Client\Api\DefaultApi();
-$workspaceID = workspaceID_example; // String | Workspace ID
-$body = ; // array[Block] | 
+$body = ; // BoardsAndBlocks | 
 
 try {
-    $api_instance->importBlocks($workspaceID, $body);
+    $result = $api_instance->insertBoardsAndBlocks($body);
+    print_r($result);
 } catch (Exception $e) {
-    echo 'Exception when calling DefaultApi->importBlocks: ', $e->getMessage(), PHP_EOL;
+    echo 'Exception when calling DefaultApi->insertBoardsAndBlocks: ', $e->getMessage(), PHP_EOL;
 }
 ?></code></pre>
                             </div>
 
-                            <div class="tab-pane" id="examples-Default-importBlocks-0-perl">
+                            <div class="tab-pane" id="examples-Default-insertBoardsAndBlocks-0-perl">
                               <pre class="prettyprint"><code class="language-perl">use Data::Dumper;
 use WWW::OPenAPIClient::Configuration;
 use WWW::OPenAPIClient::DefaultApi;
@@ -8287,18 +14942,18 @@ $WWW::OPenAPIClient::Configuration::api_key->{'Authorization'} = 'YOUR_API_KEY';
 
 # Create an instance of the API class
 my $api_instance = WWW::OPenAPIClient::DefaultApi->new();
-my $workspaceID = workspaceID_example; # String | Workspace ID
-my $body = [WWW::OPenAPIClient::Object::array[Block]->new()]; # array[Block] | 
+my $body = WWW::OPenAPIClient::Object::BoardsAndBlocks->new(); # BoardsAndBlocks | 
 
 eval {
-    $api_instance->importBlocks(workspaceID => $workspaceID, body => $body);
+    my $result = $api_instance->insertBoardsAndBlocks(body => $body);
+    print Dumper($result);
 };
 if ($@) {
-    warn "Exception when calling DefaultApi->importBlocks: $@\n";
+    warn "Exception when calling DefaultApi->insertBoardsAndBlocks: $@\n";
 }</code></pre>
                             </div>
 
-                            <div class="tab-pane" id="examples-Default-importBlocks-0-python">
+                            <div class="tab-pane" id="examples-Default-insertBoardsAndBlocks-0-python">
                               <pre class="prettyprint"><code class="language-python">from __future__ import print_statement
 import time
 import openapi_client
@@ -8312,24 +14967,23 @@ openapi_client.configuration.api_key['Authorization'] = 'YOUR_API_KEY'
 
 # Create an instance of the API class
 api_instance = openapi_client.DefaultApi()
-workspaceID = workspaceID_example # String | Workspace ID (default to null)
-body =  # array[Block] | 
+body =  # BoardsAndBlocks | 
 
 try:
-    api_instance.import_blocks(workspaceID, body)
+    api_response = api_instance.insert_boards_and_blocks(body)
+    pprint(api_response)
 except ApiException as e:
-    print("Exception when calling DefaultApi->importBlocks: %s\n" % e)</code></pre>
+    print("Exception when calling DefaultApi->insertBoardsAndBlocks: %s\n" % e)</code></pre>
                             </div>
 
-                            <div class="tab-pane" id="examples-Default-importBlocks-0-rust">
+                            <div class="tab-pane" id="examples-Default-insertBoardsAndBlocks-0-rust">
                               <pre class="prettyprint"><code class="language-rust">extern crate DefaultApi;
 
 pub fn main() {
-    let workspaceID = workspaceID_example; // String
-    let body = ; // array[Block]
+    let body = ; // BoardsAndBlocks
 
     let mut context = DefaultApi::Context::default();
-    let result = client.importBlocks(workspaceID, body, &context).wait();
+    let result = client.insertBoardsAndBlocks(body, &context).wait();
 
     println!("{:?}", result);
 }
@@ -8344,36 +14998,6 @@ pub fn main() {
 
                           <h2>Parameters</h2>
 
-                            <div class="methodsubtabletitle">Path parameters</div>
-                            <table id="methodsubtable">
-                                <tr>
-                                  <th width="150px">Name</th>
-                                  <th>Description</th>
-                                </tr>
-                                  <tr><td style="width:150px;">workspaceID*</td>
-<td>
-
-
-    <div id="d2e199_importBlocks_workspaceID">
-        <div class="json-schema-view">
-            <div class="primitive">
-                <span class="type">
-                    String
-                </span>
-
-                    <div class="inner description marked">
-Workspace ID
-                    </div>
-            </div>
-                <div class="inner required">
-                    Required
-                </div>
-        </div>
-    </div>
-</td>
-</tr>
-
-                            </table>
 
 
                             <div class="methodsubtabletitle">Body parameters</div>
@@ -8384,18 +15008,15 @@ Workspace ID
                               </tr>
                                 <tr><td style="width:150px;">body <span style="color:red;">*</span></td>
 <td>
-<p class="marked">array of blocks to import</p>
+<p class="marked">the boards and blocks to create</p>
 <script>
 $(document).ready(function() {
   var schemaWrapper = {
-  "description" : "array of blocks to import",
+  "description" : "the boards and blocks to create",
   "content" : {
     "application/json" : {
       "schema" : {
-        "type" : "array",
-        "items" : {
-          "$ref" : "#/components/schemas/Block"
-        }
+        "$ref" : "#/components/schemas/BoardsAndBlocks"
       }
     }
   },
@@ -8416,12 +15037,12 @@ $(document).ready(function() {
   }
 
   var view = new JSONSchemaView(schema,2,{isBodyParam: true});
-  var result = $('#d2e199_importBlocks_body');
+  var result = $('#d2e199_insertBoardsAndBlocks_body');
   result.empty();
   result.append(view.render());
 });
 </script>
-<div id="d2e199_importBlocks_body"></div>
+<div id="d2e199_insertBoardsAndBlocks_body"></div>
 </td>
 </tr>
 
@@ -8430,45 +15051,23 @@ $(document).ready(function() {
 
 
                           <h2>Responses</h2>
-                            <h3 id="examples-Default-importBlocks-title-200"></h3>
-                            <p id="examples-Default-importBlocks-description-200" class="marked"></p>
+                            <h3 id="examples-Default-insertBoardsAndBlocks-title-200"></h3>
+                            <p id="examples-Default-insertBoardsAndBlocks-description-200" class="marked"></p>
                             <script>
                               var responseDefault200_description = `success`;
                               var responseDefault200_description_break = responseDefault200_description.indexOf('\n');
                               if (responseDefault200_description_break == -1) {
-                                $("#examples-Default-importBlocks-title-200").text("Status: 200 - " + responseDefault200_description);
+                                $("#examples-Default-insertBoardsAndBlocks-title-200").text("Status: 200 - " + responseDefault200_description);
                               } else {
-                                $("#examples-Default-importBlocks-title-200").text("Status: 200 - " + responseDefault200_description.substring(0, responseDefault200_description_break));
-                                $("#examples-Default-importBlocks-description-200").html(responseDefault200_description.substring(responseDefault200_description_break));
+                                $("#examples-Default-insertBoardsAndBlocks-title-200").text("Status: 200 - " + responseDefault200_description.substring(0, responseDefault200_description_break));
+                                $("#examples-Default-insertBoardsAndBlocks-description-200").html(responseDefault200_description.substring(responseDefault200_description_break));
                               }
                             </script>
 
 
-                            <ul id="responses-detail-Default-importBlocks-200" class="nav nav-tabs nav-tabs-examples" >
-
-
-                            </ul>
-
-
-                            <div class="tab-content" id="responses-Default-importBlocks-200-wrapper" style='margin-bottom: 10px;'>
-                            </div>
-                            <h3 id="examples-Default-importBlocks-title-default"></h3>
-                            <p id="examples-Default-importBlocks-description-default" class="marked"></p>
-                            <script>
-                              var responseDefaultdefault_description = `internal error`;
-                              var responseDefaultdefault_description_break = responseDefaultdefault_description.indexOf('\n');
-                              if (responseDefaultdefault_description_break == -1) {
-                                $("#examples-Default-importBlocks-title-default").text("Status: default - " + responseDefaultdefault_description);
-                              } else {
-                                $("#examples-Default-importBlocks-title-default").text("Status: default - " + responseDefaultdefault_description.substring(0, responseDefaultdefault_description_break));
-                                $("#examples-Default-importBlocks-description-default").html(responseDefaultdefault_description.substring(responseDefaultdefault_description_break));
-                              }
-                            </script>
-
-
-                            <ul id="responses-detail-Default-importBlocks-default" class="nav nav-tabs nav-tabs-examples" >
+                            <ul id="responses-detail-Default-insertBoardsAndBlocks-200" class="nav nav-tabs nav-tabs-examples" >
                                 <li class="active">
-                                  <a data-toggle="tab" href="#responses-Default-importBlocks-default-schema">Schema</a>
+                                  <a data-toggle="tab" href="#responses-Default-insertBoardsAndBlocks-200-schema">Schema</a>
                                 </li>
 
 
@@ -8477,9 +15076,75 @@ $(document).ready(function() {
                             </ul>
 
 
-                            <div class="tab-content" id="responses-Default-importBlocks-default-wrapper" style='margin-bottom: 10px;'>
-                                <div class="tab-pane active" id="responses-Default-importBlocks-default-schema">
-                                  <div id="responses-Default-importBlocks-schema-default" class="exampleStyle">
+                            <div class="tab-content" id="responses-Default-insertBoardsAndBlocks-200-wrapper" style='margin-bottom: 10px;'>
+                                <div class="tab-pane active" id="responses-Default-insertBoardsAndBlocks-200-schema">
+                                  <div id="responses-Default-insertBoardsAndBlocks-schema-200" class="exampleStyle">
+                                    <script>
+                                      $(document).ready(function() {
+                                        var schemaWrapper = {
+  "description" : "success",
+  "content" : {
+    "application/json" : {
+      "schema" : {
+        "$ref" : "#/components/schemas/BoardsAndBlocks"
+      }
+    }
+  }
+};
+                                        var schema = findNode('schema',schemaWrapper).schema;
+                                        if (!schema) {
+                                          schema = schemaWrapper.schema;
+                                        }
+                                        if (schema.$ref != null) {
+                                          schema = defsParser.$refs.get(schema.$ref);
+                                        } else if (schema.items != null && schema.items.$ref != null) {
+                                            schema.items = defsParser.$refs.get(schema.items.$ref);
+                                        } else {
+                                          schemaWrapper.definitions = Object.assign({}, defs);
+                                          $RefParser.dereference(schemaWrapper).catch(function(err) {
+                                            console.log(err);
+                                          });
+                                        }
+
+                                        var view = new JSONSchemaView(schema, 3);
+                                        $('#responses-Default-insertBoardsAndBlocks-200-schema-data').val(JSON.stringify(schema));
+                                        var result = $('#responses-Default-insertBoardsAndBlocks-schema-200');
+                                        result.empty();
+                                        result.append(view.render());
+                                      });
+                                    </script>
+                                  </div>
+                                  <input id='responses-Default-insertBoardsAndBlocks-200-schema-data' type='hidden' value=''></input>
+                                </div>
+                            </div>
+                            <h3 id="examples-Default-insertBoardsAndBlocks-title-default"></h3>
+                            <p id="examples-Default-insertBoardsAndBlocks-description-default" class="marked"></p>
+                            <script>
+                              var responseDefaultdefault_description = `internal error`;
+                              var responseDefaultdefault_description_break = responseDefaultdefault_description.indexOf('\n');
+                              if (responseDefaultdefault_description_break == -1) {
+                                $("#examples-Default-insertBoardsAndBlocks-title-default").text("Status: default - " + responseDefaultdefault_description);
+                              } else {
+                                $("#examples-Default-insertBoardsAndBlocks-title-default").text("Status: default - " + responseDefaultdefault_description.substring(0, responseDefaultdefault_description_break));
+                                $("#examples-Default-insertBoardsAndBlocks-description-default").html(responseDefaultdefault_description.substring(responseDefaultdefault_description_break));
+                              }
+                            </script>
+
+
+                            <ul id="responses-detail-Default-insertBoardsAndBlocks-default" class="nav nav-tabs nav-tabs-examples" >
+                                <li class="active">
+                                  <a data-toggle="tab" href="#responses-Default-insertBoardsAndBlocks-default-schema">Schema</a>
+                                </li>
+
+
+
+
+                            </ul>
+
+
+                            <div class="tab-content" id="responses-Default-insertBoardsAndBlocks-default-wrapper" style='margin-bottom: 10px;'>
+                                <div class="tab-pane active" id="responses-Default-insertBoardsAndBlocks-default-schema">
+                                  <div id="responses-Default-insertBoardsAndBlocks-schema-default" class="exampleStyle">
                                     <script>
                                       $(document).ready(function() {
                                         var schemaWrapper = {
@@ -8508,14 +15173,937 @@ $(document).ready(function() {
                                         }
 
                                         var view = new JSONSchemaView(schema, 3);
-                                        $('#responses-Default-importBlocks-default-schema-data').val(JSON.stringify(schema));
-                                        var result = $('#responses-Default-importBlocks-schema-default');
+                                        $('#responses-Default-insertBoardsAndBlocks-default-schema-data').val(JSON.stringify(schema));
+                                        var result = $('#responses-Default-insertBoardsAndBlocks-schema-default');
                                         result.empty();
                                         result.append(view.render());
                                       });
                                     </script>
                                   </div>
-                                  <input id='responses-Default-importBlocks-default-schema-data' type='hidden' value=''></input>
+                                  <input id='responses-Default-insertBoardsAndBlocks-default-schema-data' type='hidden' value=''></input>
+                                </div>
+                            </div>
+                        </article>
+                      </div>
+                      <hr>
+                    <div id="api-Default-joinBoard">
+                      <article id="api-Default-joinBoard-0" data-group="User" data-name="joinBoard" data-version="0">
+                        <div class="pull-left">
+                          <h1>joinBoard</h1>
+                          <p></p>
+                        </div>
+                        <div class="pull-right"></div>
+                        <div class="clearfix"></div>
+                        <p></p>
+                        <p class="marked">Become a member of a board</p>
+                        <p></p>
+                        <br />
+                        <pre class="prettyprint language-html prettyprinted" data-type="post"><code><span class="pln">/boards/{boardID}/join</span></code></pre>
+                        <p>
+                          <h3>Usage and SDK Samples</h3>
+                        </p>
+                        <ul class="nav nav-tabs nav-tabs-examples">
+                          <li class="active"><a href="#examples-Default-joinBoard-0-curl">Curl</a></li>
+                          <li class=""><a href="#examples-Default-joinBoard-0-java">Java</a></li>
+                          <li class=""><a href="#examples-Default-joinBoard-0-android">Android</a></li>
+                          <!--<li class=""><a href="#examples-Default-joinBoard-0-groovy">Groovy</a></li>-->
+                          <li class=""><a href="#examples-Default-joinBoard-0-objc">Obj-C</a></li>
+                          <li class=""><a href="#examples-Default-joinBoard-0-javascript">JavaScript</a></li>
+                          <!--<li class=""><a href="#examples-Default-joinBoard-0-angular">Angular</a></li>-->
+                          <li class=""><a href="#examples-Default-joinBoard-0-csharp">C#</a></li>
+                          <li class=""><a href="#examples-Default-joinBoard-0-php">PHP</a></li>
+                          <li class=""><a href="#examples-Default-joinBoard-0-perl">Perl</a></li>
+                          <li class=""><a href="#examples-Default-joinBoard-0-python">Python</a></li>
+                          <li class=""><a href="#examples-Default-joinBoard-0-rust">Rust</a></li>
+                        </ul>
+
+                        <div class="tab-content">
+                          <div class="tab-pane active" id="examples-Default-joinBoard-0-curl">
+                            <pre class="prettyprint"><code class="language-bsh">curl -X POST \
+-H "Authorization: [[apiKey]]" \
+ -H "Accept: application/json" \
+ "http://localhost/api/v2/boards/{boardID}/join"
+</code></pre>
+                          </div>
+                          <div class="tab-pane" id="examples-Default-joinBoard-0-java">
+                            <pre class="prettyprint"><code class="language-java">import org.openapitools.client.*;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.model.*;
+import org.openapitools.client.api.DefaultApi;
+
+import java.io.File;
+import java.util.*;
+
+public class DefaultApiExample {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        
+        // Configure API key authorization: BearerAuth
+        ApiKeyAuth BearerAuth = (ApiKeyAuth) defaultClient.getAuthentication("BearerAuth");
+        BearerAuth.setApiKey("YOUR API KEY");
+        // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+        //BearerAuth.setApiKeyPrefix("Token");
+
+        // Create an instance of the API class
+        DefaultApi apiInstance = new DefaultApi();
+        String boardID = boardID_example; // String | Board ID
+
+        try {
+            BoardMember result = apiInstance.joinBoard(boardID);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling DefaultApi#joinBoard");
+            e.printStackTrace();
+        }
+    }
+}
+</code></pre>
+                          </div>
+
+                          <div class="tab-pane" id="examples-Default-joinBoard-0-android">
+                            <pre class="prettyprint"><code class="language-java">import org.openapitools.client.api.DefaultApi;
+
+public class DefaultApiExample {
+    public static void main(String[] args) {
+        DefaultApi apiInstance = new DefaultApi();
+        String boardID = boardID_example; // String | Board ID
+
+        try {
+            BoardMember result = apiInstance.joinBoard(boardID);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling DefaultApi#joinBoard");
+            e.printStackTrace();
+        }
+    }
+}</code></pre>
+                          </div>
+  <!--
+  <div class="tab-pane" id="examples-Default-joinBoard-0-groovy">
+  <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
+  </div> -->
+                            <div class="tab-pane" id="examples-Default-joinBoard-0-objc">
+                              <pre class="prettyprint"><code class="language-cpp">Configuration *apiConfig = [Configuration sharedConfig];
+
+// Configure API key authorization: (authentication scheme: BearerAuth)
+[apiConfig setApiKey:@"YOUR_API_KEY" forApiKeyIdentifier:@"Authorization"];
+// Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+//[apiConfig setApiKeyPrefix:@"Bearer" forApiKeyIdentifier:@"Authorization"];
+
+
+// Create an instance of the API class
+DefaultApi *apiInstance = [[DefaultApi alloc] init];
+String *boardID = boardID_example; // Board ID (default to null)
+
+[apiInstance joinBoardWith:boardID
+              completionHandler: ^(BoardMember output, NSError* error) {
+    if (output) {
+        NSLog(@"%@", output);
+    }
+    if (error) {
+        NSLog(@"Error: %@", error);
+    }
+}];
+</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-joinBoard-0-javascript">
+                              <pre class="prettyprint"><code class="language-js">var FocalboardServer = require('focalboard_server');
+var defaultClient = FocalboardServer.ApiClient.instance;
+
+// Configure API key authorization: BearerAuth
+var BearerAuth = defaultClient.authentications['BearerAuth'];
+BearerAuth.apiKey = "YOUR API KEY";
+// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+//BearerAuth.apiKeyPrefix['Authorization'] = "Token";
+
+// Create an instance of the API class
+var api = new FocalboardServer.DefaultApi()
+var boardID = boardID_example; // {String} Board ID
+
+var callback = function(error, data, response) {
+  if (error) {
+    console.error(error);
+  } else {
+    console.log('API called successfully. Returned data: ' + data);
+  }
+};
+api.joinBoard(boardID, callback);
+</code></pre>
+                            </div>
+
+                            <!--<div class="tab-pane" id="examples-Default-joinBoard-0-angular">
+              <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
+            </div>-->
+                            <div class="tab-pane" id="examples-Default-joinBoard-0-csharp">
+                              <pre class="prettyprint"><code class="language-cs">using System;
+using System.Diagnostics;
+using Org.OpenAPITools.Api;
+using Org.OpenAPITools.Client;
+using Org.OpenAPITools.Model;
+
+namespace Example
+{
+    public class joinBoardExample
+    {
+        public void main()
+        {
+            // Configure API key authorization: BearerAuth
+            Configuration.Default.ApiKey.Add("Authorization", "YOUR_API_KEY");
+            // Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+            // Configuration.Default.ApiKeyPrefix.Add("Authorization", "Bearer");
+
+            // Create an instance of the API class
+            var apiInstance = new DefaultApi();
+            var boardID = boardID_example;  // String | Board ID (default to null)
+
+            try {
+                BoardMember result = apiInstance.joinBoard(boardID);
+                Debug.WriteLine(result);
+            } catch (Exception e) {
+                Debug.Print("Exception when calling DefaultApi.joinBoard: " + e.Message );
+            }
+        }
+    }
+}
+</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-joinBoard-0-php">
+                              <pre class="prettyprint"><code class="language-php"><&#63;php
+require_once(__DIR__ . '/vendor/autoload.php');
+
+// Configure API key authorization: BearerAuth
+OpenAPITools\Client\Configuration::getDefaultConfiguration()->setApiKey('Authorization', 'YOUR_API_KEY');
+// Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+// OpenAPITools\Client\Configuration::getDefaultConfiguration()->setApiKeyPrefix('Authorization', 'Bearer');
+
+// Create an instance of the API class
+$api_instance = new OpenAPITools\Client\Api\DefaultApi();
+$boardID = boardID_example; // String | Board ID
+
+try {
+    $result = $api_instance->joinBoard($boardID);
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling DefaultApi->joinBoard: ', $e->getMessage(), PHP_EOL;
+}
+?></code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-joinBoard-0-perl">
+                              <pre class="prettyprint"><code class="language-perl">use Data::Dumper;
+use WWW::OPenAPIClient::Configuration;
+use WWW::OPenAPIClient::DefaultApi;
+
+# Configure API key authorization: BearerAuth
+$WWW::OPenAPIClient::Configuration::api_key->{'Authorization'} = 'YOUR_API_KEY';
+# uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+#$WWW::OPenAPIClient::Configuration::api_key_prefix->{'Authorization'} = "Bearer";
+
+# Create an instance of the API class
+my $api_instance = WWW::OPenAPIClient::DefaultApi->new();
+my $boardID = boardID_example; # String | Board ID
+
+eval {
+    my $result = $api_instance->joinBoard(boardID => $boardID);
+    print Dumper($result);
+};
+if ($@) {
+    warn "Exception when calling DefaultApi->joinBoard: $@\n";
+}</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-joinBoard-0-python">
+                              <pre class="prettyprint"><code class="language-python">from __future__ import print_statement
+import time
+import openapi_client
+from openapi_client.rest import ApiException
+from pprint import pprint
+
+# Configure API key authorization: BearerAuth
+openapi_client.configuration.api_key['Authorization'] = 'YOUR_API_KEY'
+# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+# openapi_client.configuration.api_key_prefix['Authorization'] = 'Bearer'
+
+# Create an instance of the API class
+api_instance = openapi_client.DefaultApi()
+boardID = boardID_example # String | Board ID (default to null)
+
+try:
+    api_response = api_instance.join_board(boardID)
+    pprint(api_response)
+except ApiException as e:
+    print("Exception when calling DefaultApi->joinBoard: %s\n" % e)</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-joinBoard-0-rust">
+                              <pre class="prettyprint"><code class="language-rust">extern crate DefaultApi;
+
+pub fn main() {
+    let boardID = boardID_example; // String
+
+    let mut context = DefaultApi::Context::default();
+    let result = client.joinBoard(boardID, &context).wait();
+
+    println!("{:?}", result);
+}
+</code></pre>
+                            </div>
+                          </div>
+
+                          <h2>Scopes</h2>
+                          <table>
+                            
+                          </table>
+
+                          <h2>Parameters</h2>
+
+                            <div class="methodsubtabletitle">Path parameters</div>
+                            <table id="methodsubtable">
+                                <tr>
+                                  <th width="150px">Name</th>
+                                  <th>Description</th>
+                                </tr>
+                                  <tr><td style="width:150px;">boardID*</td>
+<td>
+
+
+    <div id="d2e199_joinBoard_boardID">
+        <div class="json-schema-view">
+            <div class="primitive">
+                <span class="type">
+                    String
+                </span>
+
+                    <div class="inner description marked">
+Board ID
+                    </div>
+            </div>
+                <div class="inner required">
+                    Required
+                </div>
+        </div>
+    </div>
+</td>
+</tr>
+
+                            </table>
+
+
+
+
+
+                          <h2>Responses</h2>
+                            <h3 id="examples-Default-joinBoard-title-200"></h3>
+                            <p id="examples-Default-joinBoard-description-200" class="marked"></p>
+                            <script>
+                              var responseDefault200_description = `success`;
+                              var responseDefault200_description_break = responseDefault200_description.indexOf('\n');
+                              if (responseDefault200_description_break == -1) {
+                                $("#examples-Default-joinBoard-title-200").text("Status: 200 - " + responseDefault200_description);
+                              } else {
+                                $("#examples-Default-joinBoard-title-200").text("Status: 200 - " + responseDefault200_description.substring(0, responseDefault200_description_break));
+                                $("#examples-Default-joinBoard-description-200").html(responseDefault200_description.substring(responseDefault200_description_break));
+                              }
+                            </script>
+
+
+                            <ul id="responses-detail-Default-joinBoard-200" class="nav nav-tabs nav-tabs-examples" >
+                                <li class="active">
+                                  <a data-toggle="tab" href="#responses-Default-joinBoard-200-schema">Schema</a>
+                                </li>
+
+
+
+
+                            </ul>
+
+
+                            <div class="tab-content" id="responses-Default-joinBoard-200-wrapper" style='margin-bottom: 10px;'>
+                                <div class="tab-pane active" id="responses-Default-joinBoard-200-schema">
+                                  <div id="responses-Default-joinBoard-schema-200" class="exampleStyle">
+                                    <script>
+                                      $(document).ready(function() {
+                                        var schemaWrapper = {
+  "description" : "success",
+  "content" : {
+    "application/json" : {
+      "schema" : {
+        "$ref" : "#/components/schemas/BoardMember"
+      }
+    }
+  }
+};
+                                        var schema = findNode('schema',schemaWrapper).schema;
+                                        if (!schema) {
+                                          schema = schemaWrapper.schema;
+                                        }
+                                        if (schema.$ref != null) {
+                                          schema = defsParser.$refs.get(schema.$ref);
+                                        } else if (schema.items != null && schema.items.$ref != null) {
+                                            schema.items = defsParser.$refs.get(schema.items.$ref);
+                                        } else {
+                                          schemaWrapper.definitions = Object.assign({}, defs);
+                                          $RefParser.dereference(schemaWrapper).catch(function(err) {
+                                            console.log(err);
+                                          });
+                                        }
+
+                                        var view = new JSONSchemaView(schema, 3);
+                                        $('#responses-Default-joinBoard-200-schema-data').val(JSON.stringify(schema));
+                                        var result = $('#responses-Default-joinBoard-schema-200');
+                                        result.empty();
+                                        result.append(view.render());
+                                      });
+                                    </script>
+                                  </div>
+                                  <input id='responses-Default-joinBoard-200-schema-data' type='hidden' value=''></input>
+                                </div>
+                            </div>
+                            <h3 id="examples-Default-joinBoard-title-403"></h3>
+                            <p id="examples-Default-joinBoard-description-403" class="marked"></p>
+                            <script>
+                              var responseDefault403_description = `access denied`;
+                              var responseDefault403_description_break = responseDefault403_description.indexOf('\n');
+                              if (responseDefault403_description_break == -1) {
+                                $("#examples-Default-joinBoard-title-403").text("Status: 403 - " + responseDefault403_description);
+                              } else {
+                                $("#examples-Default-joinBoard-title-403").text("Status: 403 - " + responseDefault403_description.substring(0, responseDefault403_description_break));
+                                $("#examples-Default-joinBoard-description-403").html(responseDefault403_description.substring(responseDefault403_description_break));
+                              }
+                            </script>
+
+
+                            <ul id="responses-detail-Default-joinBoard-403" class="nav nav-tabs nav-tabs-examples" >
+
+
+                            </ul>
+
+
+                            <div class="tab-content" id="responses-Default-joinBoard-403-wrapper" style='margin-bottom: 10px;'>
+                            </div>
+                            <h3 id="examples-Default-joinBoard-title-404"></h3>
+                            <p id="examples-Default-joinBoard-description-404" class="marked"></p>
+                            <script>
+                              var responseDefault404_description = `board not found`;
+                              var responseDefault404_description_break = responseDefault404_description.indexOf('\n');
+                              if (responseDefault404_description_break == -1) {
+                                $("#examples-Default-joinBoard-title-404").text("Status: 404 - " + responseDefault404_description);
+                              } else {
+                                $("#examples-Default-joinBoard-title-404").text("Status: 404 - " + responseDefault404_description.substring(0, responseDefault404_description_break));
+                                $("#examples-Default-joinBoard-description-404").html(responseDefault404_description.substring(responseDefault404_description_break));
+                              }
+                            </script>
+
+
+                            <ul id="responses-detail-Default-joinBoard-404" class="nav nav-tabs nav-tabs-examples" >
+
+
+                            </ul>
+
+
+                            <div class="tab-content" id="responses-Default-joinBoard-404-wrapper" style='margin-bottom: 10px;'>
+                            </div>
+                            <h3 id="examples-Default-joinBoard-title-default"></h3>
+                            <p id="examples-Default-joinBoard-description-default" class="marked"></p>
+                            <script>
+                              var responseDefaultdefault_description = `internal error`;
+                              var responseDefaultdefault_description_break = responseDefaultdefault_description.indexOf('\n');
+                              if (responseDefaultdefault_description_break == -1) {
+                                $("#examples-Default-joinBoard-title-default").text("Status: default - " + responseDefaultdefault_description);
+                              } else {
+                                $("#examples-Default-joinBoard-title-default").text("Status: default - " + responseDefaultdefault_description.substring(0, responseDefaultdefault_description_break));
+                                $("#examples-Default-joinBoard-description-default").html(responseDefaultdefault_description.substring(responseDefaultdefault_description_break));
+                              }
+                            </script>
+
+
+                            <ul id="responses-detail-Default-joinBoard-default" class="nav nav-tabs nav-tabs-examples" >
+                                <li class="active">
+                                  <a data-toggle="tab" href="#responses-Default-joinBoard-default-schema">Schema</a>
+                                </li>
+
+
+
+
+                            </ul>
+
+
+                            <div class="tab-content" id="responses-Default-joinBoard-default-wrapper" style='margin-bottom: 10px;'>
+                                <div class="tab-pane active" id="responses-Default-joinBoard-default-schema">
+                                  <div id="responses-Default-joinBoard-schema-default" class="exampleStyle">
+                                    <script>
+                                      $(document).ready(function() {
+                                        var schemaWrapper = {
+  "description" : "internal error",
+  "content" : {
+    "application/json" : {
+      "schema" : {
+        "$ref" : "#/components/schemas/ErrorResponse"
+      }
+    }
+  }
+};
+                                        var schema = findNode('schema',schemaWrapper).schema;
+                                        if (!schema) {
+                                          schema = schemaWrapper.schema;
+                                        }
+                                        if (schema.$ref != null) {
+                                          schema = defsParser.$refs.get(schema.$ref);
+                                        } else if (schema.items != null && schema.items.$ref != null) {
+                                            schema.items = defsParser.$refs.get(schema.items.$ref);
+                                        } else {
+                                          schemaWrapper.definitions = Object.assign({}, defs);
+                                          $RefParser.dereference(schemaWrapper).catch(function(err) {
+                                            console.log(err);
+                                          });
+                                        }
+
+                                        var view = new JSONSchemaView(schema, 3);
+                                        $('#responses-Default-joinBoard-default-schema-data').val(JSON.stringify(schema));
+                                        var result = $('#responses-Default-joinBoard-schema-default');
+                                        result.empty();
+                                        result.append(view.render());
+                                      });
+                                    </script>
+                                  </div>
+                                  <input id='responses-Default-joinBoard-default-schema-data' type='hidden' value=''></input>
+                                </div>
+                            </div>
+                        </article>
+                      </div>
+                      <hr>
+                    <div id="api-Default-leaveBoard">
+                      <article id="api-Default-leaveBoard-0" data-group="User" data-name="leaveBoard" data-version="0">
+                        <div class="pull-left">
+                          <h1>leaveBoard</h1>
+                          <p></p>
+                        </div>
+                        <div class="pull-right"></div>
+                        <div class="clearfix"></div>
+                        <p></p>
+                        <p class="marked">Remove your own membership from a board</p>
+                        <p></p>
+                        <br />
+                        <pre class="prettyprint language-html prettyprinted" data-type="post"><code><span class="pln">/boards/{boardID}/leave</span></code></pre>
+                        <p>
+                          <h3>Usage and SDK Samples</h3>
+                        </p>
+                        <ul class="nav nav-tabs nav-tabs-examples">
+                          <li class="active"><a href="#examples-Default-leaveBoard-0-curl">Curl</a></li>
+                          <li class=""><a href="#examples-Default-leaveBoard-0-java">Java</a></li>
+                          <li class=""><a href="#examples-Default-leaveBoard-0-android">Android</a></li>
+                          <!--<li class=""><a href="#examples-Default-leaveBoard-0-groovy">Groovy</a></li>-->
+                          <li class=""><a href="#examples-Default-leaveBoard-0-objc">Obj-C</a></li>
+                          <li class=""><a href="#examples-Default-leaveBoard-0-javascript">JavaScript</a></li>
+                          <!--<li class=""><a href="#examples-Default-leaveBoard-0-angular">Angular</a></li>-->
+                          <li class=""><a href="#examples-Default-leaveBoard-0-csharp">C#</a></li>
+                          <li class=""><a href="#examples-Default-leaveBoard-0-php">PHP</a></li>
+                          <li class=""><a href="#examples-Default-leaveBoard-0-perl">Perl</a></li>
+                          <li class=""><a href="#examples-Default-leaveBoard-0-python">Python</a></li>
+                          <li class=""><a href="#examples-Default-leaveBoard-0-rust">Rust</a></li>
+                        </ul>
+
+                        <div class="tab-content">
+                          <div class="tab-pane active" id="examples-Default-leaveBoard-0-curl">
+                            <pre class="prettyprint"><code class="language-bsh">curl -X POST \
+-H "Authorization: [[apiKey]]" \
+ -H "Accept: application/json" \
+ "http://localhost/api/v2/boards/{boardID}/leave"
+</code></pre>
+                          </div>
+                          <div class="tab-pane" id="examples-Default-leaveBoard-0-java">
+                            <pre class="prettyprint"><code class="language-java">import org.openapitools.client.*;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.model.*;
+import org.openapitools.client.api.DefaultApi;
+
+import java.io.File;
+import java.util.*;
+
+public class DefaultApiExample {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        
+        // Configure API key authorization: BearerAuth
+        ApiKeyAuth BearerAuth = (ApiKeyAuth) defaultClient.getAuthentication("BearerAuth");
+        BearerAuth.setApiKey("YOUR API KEY");
+        // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+        //BearerAuth.setApiKeyPrefix("Token");
+
+        // Create an instance of the API class
+        DefaultApi apiInstance = new DefaultApi();
+        String boardID = boardID_example; // String | Board ID
+
+        try {
+            apiInstance.leaveBoard(boardID);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling DefaultApi#leaveBoard");
+            e.printStackTrace();
+        }
+    }
+}
+</code></pre>
+                          </div>
+
+                          <div class="tab-pane" id="examples-Default-leaveBoard-0-android">
+                            <pre class="prettyprint"><code class="language-java">import org.openapitools.client.api.DefaultApi;
+
+public class DefaultApiExample {
+    public static void main(String[] args) {
+        DefaultApi apiInstance = new DefaultApi();
+        String boardID = boardID_example; // String | Board ID
+
+        try {
+            apiInstance.leaveBoard(boardID);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling DefaultApi#leaveBoard");
+            e.printStackTrace();
+        }
+    }
+}</code></pre>
+                          </div>
+  <!--
+  <div class="tab-pane" id="examples-Default-leaveBoard-0-groovy">
+  <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
+  </div> -->
+                            <div class="tab-pane" id="examples-Default-leaveBoard-0-objc">
+                              <pre class="prettyprint"><code class="language-cpp">Configuration *apiConfig = [Configuration sharedConfig];
+
+// Configure API key authorization: (authentication scheme: BearerAuth)
+[apiConfig setApiKey:@"YOUR_API_KEY" forApiKeyIdentifier:@"Authorization"];
+// Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+//[apiConfig setApiKeyPrefix:@"Bearer" forApiKeyIdentifier:@"Authorization"];
+
+
+// Create an instance of the API class
+DefaultApi *apiInstance = [[DefaultApi alloc] init];
+String *boardID = boardID_example; // Board ID (default to null)
+
+[apiInstance leaveBoardWith:boardID
+              completionHandler: ^(NSError* error) {
+    if (error) {
+        NSLog(@"Error: %@", error);
+    }
+}];
+</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-leaveBoard-0-javascript">
+                              <pre class="prettyprint"><code class="language-js">var FocalboardServer = require('focalboard_server');
+var defaultClient = FocalboardServer.ApiClient.instance;
+
+// Configure API key authorization: BearerAuth
+var BearerAuth = defaultClient.authentications['BearerAuth'];
+BearerAuth.apiKey = "YOUR API KEY";
+// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+//BearerAuth.apiKeyPrefix['Authorization'] = "Token";
+
+// Create an instance of the API class
+var api = new FocalboardServer.DefaultApi()
+var boardID = boardID_example; // {String} Board ID
+
+var callback = function(error, data, response) {
+  if (error) {
+    console.error(error);
+  } else {
+    console.log('API called successfully.');
+  }
+};
+api.leaveBoard(boardID, callback);
+</code></pre>
+                            </div>
+
+                            <!--<div class="tab-pane" id="examples-Default-leaveBoard-0-angular">
+              <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
+            </div>-->
+                            <div class="tab-pane" id="examples-Default-leaveBoard-0-csharp">
+                              <pre class="prettyprint"><code class="language-cs">using System;
+using System.Diagnostics;
+using Org.OpenAPITools.Api;
+using Org.OpenAPITools.Client;
+using Org.OpenAPITools.Model;
+
+namespace Example
+{
+    public class leaveBoardExample
+    {
+        public void main()
+        {
+            // Configure API key authorization: BearerAuth
+            Configuration.Default.ApiKey.Add("Authorization", "YOUR_API_KEY");
+            // Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+            // Configuration.Default.ApiKeyPrefix.Add("Authorization", "Bearer");
+
+            // Create an instance of the API class
+            var apiInstance = new DefaultApi();
+            var boardID = boardID_example;  // String | Board ID (default to null)
+
+            try {
+                apiInstance.leaveBoard(boardID);
+            } catch (Exception e) {
+                Debug.Print("Exception when calling DefaultApi.leaveBoard: " + e.Message );
+            }
+        }
+    }
+}
+</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-leaveBoard-0-php">
+                              <pre class="prettyprint"><code class="language-php"><&#63;php
+require_once(__DIR__ . '/vendor/autoload.php');
+
+// Configure API key authorization: BearerAuth
+OpenAPITools\Client\Configuration::getDefaultConfiguration()->setApiKey('Authorization', 'YOUR_API_KEY');
+// Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+// OpenAPITools\Client\Configuration::getDefaultConfiguration()->setApiKeyPrefix('Authorization', 'Bearer');
+
+// Create an instance of the API class
+$api_instance = new OpenAPITools\Client\Api\DefaultApi();
+$boardID = boardID_example; // String | Board ID
+
+try {
+    $api_instance->leaveBoard($boardID);
+} catch (Exception $e) {
+    echo 'Exception when calling DefaultApi->leaveBoard: ', $e->getMessage(), PHP_EOL;
+}
+?></code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-leaveBoard-0-perl">
+                              <pre class="prettyprint"><code class="language-perl">use Data::Dumper;
+use WWW::OPenAPIClient::Configuration;
+use WWW::OPenAPIClient::DefaultApi;
+
+# Configure API key authorization: BearerAuth
+$WWW::OPenAPIClient::Configuration::api_key->{'Authorization'} = 'YOUR_API_KEY';
+# uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+#$WWW::OPenAPIClient::Configuration::api_key_prefix->{'Authorization'} = "Bearer";
+
+# Create an instance of the API class
+my $api_instance = WWW::OPenAPIClient::DefaultApi->new();
+my $boardID = boardID_example; # String | Board ID
+
+eval {
+    $api_instance->leaveBoard(boardID => $boardID);
+};
+if ($@) {
+    warn "Exception when calling DefaultApi->leaveBoard: $@\n";
+}</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-leaveBoard-0-python">
+                              <pre class="prettyprint"><code class="language-python">from __future__ import print_statement
+import time
+import openapi_client
+from openapi_client.rest import ApiException
+from pprint import pprint
+
+# Configure API key authorization: BearerAuth
+openapi_client.configuration.api_key['Authorization'] = 'YOUR_API_KEY'
+# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+# openapi_client.configuration.api_key_prefix['Authorization'] = 'Bearer'
+
+# Create an instance of the API class
+api_instance = openapi_client.DefaultApi()
+boardID = boardID_example # String | Board ID (default to null)
+
+try:
+    api_instance.leave_board(boardID)
+except ApiException as e:
+    print("Exception when calling DefaultApi->leaveBoard: %s\n" % e)</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-leaveBoard-0-rust">
+                              <pre class="prettyprint"><code class="language-rust">extern crate DefaultApi;
+
+pub fn main() {
+    let boardID = boardID_example; // String
+
+    let mut context = DefaultApi::Context::default();
+    let result = client.leaveBoard(boardID, &context).wait();
+
+    println!("{:?}", result);
+}
+</code></pre>
+                            </div>
+                          </div>
+
+                          <h2>Scopes</h2>
+                          <table>
+                            
+                          </table>
+
+                          <h2>Parameters</h2>
+
+                            <div class="methodsubtabletitle">Path parameters</div>
+                            <table id="methodsubtable">
+                                <tr>
+                                  <th width="150px">Name</th>
+                                  <th>Description</th>
+                                </tr>
+                                  <tr><td style="width:150px;">boardID*</td>
+<td>
+
+
+    <div id="d2e199_leaveBoard_boardID">
+        <div class="json-schema-view">
+            <div class="primitive">
+                <span class="type">
+                    String
+                </span>
+
+                    <div class="inner description marked">
+Board ID
+                    </div>
+            </div>
+                <div class="inner required">
+                    Required
+                </div>
+        </div>
+    </div>
+</td>
+</tr>
+
+                            </table>
+
+
+
+
+
+                          <h2>Responses</h2>
+                            <h3 id="examples-Default-leaveBoard-title-200"></h3>
+                            <p id="examples-Default-leaveBoard-description-200" class="marked"></p>
+                            <script>
+                              var responseDefault200_description = `success`;
+                              var responseDefault200_description_break = responseDefault200_description.indexOf('\n');
+                              if (responseDefault200_description_break == -1) {
+                                $("#examples-Default-leaveBoard-title-200").text("Status: 200 - " + responseDefault200_description);
+                              } else {
+                                $("#examples-Default-leaveBoard-title-200").text("Status: 200 - " + responseDefault200_description.substring(0, responseDefault200_description_break));
+                                $("#examples-Default-leaveBoard-description-200").html(responseDefault200_description.substring(responseDefault200_description_break));
+                              }
+                            </script>
+
+
+                            <ul id="responses-detail-Default-leaveBoard-200" class="nav nav-tabs nav-tabs-examples" >
+
+
+                            </ul>
+
+
+                            <div class="tab-content" id="responses-Default-leaveBoard-200-wrapper" style='margin-bottom: 10px;'>
+                            </div>
+                            <h3 id="examples-Default-leaveBoard-title-403"></h3>
+                            <p id="examples-Default-leaveBoard-description-403" class="marked"></p>
+                            <script>
+                              var responseDefault403_description = `access denied`;
+                              var responseDefault403_description_break = responseDefault403_description.indexOf('\n');
+                              if (responseDefault403_description_break == -1) {
+                                $("#examples-Default-leaveBoard-title-403").text("Status: 403 - " + responseDefault403_description);
+                              } else {
+                                $("#examples-Default-leaveBoard-title-403").text("Status: 403 - " + responseDefault403_description.substring(0, responseDefault403_description_break));
+                                $("#examples-Default-leaveBoard-description-403").html(responseDefault403_description.substring(responseDefault403_description_break));
+                              }
+                            </script>
+
+
+                            <ul id="responses-detail-Default-leaveBoard-403" class="nav nav-tabs nav-tabs-examples" >
+
+
+                            </ul>
+
+
+                            <div class="tab-content" id="responses-Default-leaveBoard-403-wrapper" style='margin-bottom: 10px;'>
+                            </div>
+                            <h3 id="examples-Default-leaveBoard-title-404"></h3>
+                            <p id="examples-Default-leaveBoard-description-404" class="marked"></p>
+                            <script>
+                              var responseDefault404_description = `board not found`;
+                              var responseDefault404_description_break = responseDefault404_description.indexOf('\n');
+                              if (responseDefault404_description_break == -1) {
+                                $("#examples-Default-leaveBoard-title-404").text("Status: 404 - " + responseDefault404_description);
+                              } else {
+                                $("#examples-Default-leaveBoard-title-404").text("Status: 404 - " + responseDefault404_description.substring(0, responseDefault404_description_break));
+                                $("#examples-Default-leaveBoard-description-404").html(responseDefault404_description.substring(responseDefault404_description_break));
+                              }
+                            </script>
+
+
+                            <ul id="responses-detail-Default-leaveBoard-404" class="nav nav-tabs nav-tabs-examples" >
+
+
+                            </ul>
+
+
+                            <div class="tab-content" id="responses-Default-leaveBoard-404-wrapper" style='margin-bottom: 10px;'>
+                            </div>
+                            <h3 id="examples-Default-leaveBoard-title-default"></h3>
+                            <p id="examples-Default-leaveBoard-description-default" class="marked"></p>
+                            <script>
+                              var responseDefaultdefault_description = `internal error`;
+                              var responseDefaultdefault_description_break = responseDefaultdefault_description.indexOf('\n');
+                              if (responseDefaultdefault_description_break == -1) {
+                                $("#examples-Default-leaveBoard-title-default").text("Status: default - " + responseDefaultdefault_description);
+                              } else {
+                                $("#examples-Default-leaveBoard-title-default").text("Status: default - " + responseDefaultdefault_description.substring(0, responseDefaultdefault_description_break));
+                                $("#examples-Default-leaveBoard-description-default").html(responseDefaultdefault_description.substring(responseDefaultdefault_description_break));
+                              }
+                            </script>
+
+
+                            <ul id="responses-detail-Default-leaveBoard-default" class="nav nav-tabs nav-tabs-examples" >
+                                <li class="active">
+                                  <a data-toggle="tab" href="#responses-Default-leaveBoard-default-schema">Schema</a>
+                                </li>
+
+
+
+
+                            </ul>
+
+
+                            <div class="tab-content" id="responses-Default-leaveBoard-default-wrapper" style='margin-bottom: 10px;'>
+                                <div class="tab-pane active" id="responses-Default-leaveBoard-default-schema">
+                                  <div id="responses-Default-leaveBoard-schema-default" class="exampleStyle">
+                                    <script>
+                                      $(document).ready(function() {
+                                        var schemaWrapper = {
+  "description" : "internal error",
+  "content" : {
+    "application/json" : {
+      "schema" : {
+        "$ref" : "#/components/schemas/ErrorResponse"
+      }
+    }
+  }
+};
+                                        var schema = findNode('schema',schemaWrapper).schema;
+                                        if (!schema) {
+                                          schema = schemaWrapper.schema;
+                                        }
+                                        if (schema.$ref != null) {
+                                          schema = defsParser.$refs.get(schema.$ref);
+                                        } else if (schema.items != null && schema.items.$ref != null) {
+                                            schema.items = defsParser.$refs.get(schema.items.$ref);
+                                        } else {
+                                          schemaWrapper.definitions = Object.assign({}, defs);
+                                          $RefParser.dereference(schemaWrapper).catch(function(err) {
+                                            console.log(err);
+                                          });
+                                        }
+
+                                        var view = new JSONSchemaView(schema, 3);
+                                        $('#responses-Default-leaveBoard-default-schema-data').val(JSON.stringify(schema));
+                                        var result = $('#responses-Default-leaveBoard-schema-default');
+                                        result.empty();
+                                        result.append(view.render());
+                                      });
+                                    </script>
+                                  </div>
+                                  <input id='responses-Default-leaveBoard-default-schema-data' type='hidden' value=''></input>
                                 </div>
                             </div>
                         </article>
@@ -8533,7 +16121,7 @@ $(document).ready(function() {
                         <p class="marked">Login user</p>
                         <p></p>
                         <br />
-                        <pre class="prettyprint language-html prettyprinted" data-type="post"><code><span class="pln">/api/v1/login</span></code></pre>
+                        <pre class="prettyprint language-html prettyprinted" data-type="post"><code><span class="pln">/login</span></code></pre>
                         <p>
                           <h3>Usage and SDK Samples</h3>
                         </p>
@@ -8557,7 +16145,7 @@ $(document).ready(function() {
                             <pre class="prettyprint"><code class="language-bsh">curl -X POST \
  -H "Accept: application/json" \
  -H "Content-Type: application/json" \
- "http://localhost/api/v1/api/v1/login" \
+ "http://localhost/api/v2/login" \
  -d '{
   &quot;password&quot; : &quot;password&quot;,
   &quot;type&quot; : &quot;type&quot;,
@@ -9027,7 +16615,7 @@ $(document).ready(function() {
                         <p class="marked">Logout user</p>
                         <p></p>
                         <br />
-                        <pre class="prettyprint language-html prettyprinted" data-type="post"><code><span class="pln">/api/v1/logout</span></code></pre>
+                        <pre class="prettyprint language-html prettyprinted" data-type="post"><code><span class="pln">/logout</span></code></pre>
                         <p>
                           <h3>Usage and SDK Samples</h3>
                         </p>
@@ -9051,7 +16639,7 @@ $(document).ready(function() {
                             <pre class="prettyprint"><code class="language-bsh">curl -X POST \
 -H "Authorization: [[apiKey]]" \
  -H "Accept: application/json" \
- "http://localhost/api/v1/api/v1/logout"
+ "http://localhost/api/v2/logout"
 </code></pre>
                           </div>
                           <div class="tab-pane" id="examples-Default-logout-0-java">
@@ -9366,6 +16954,453 @@ pub fn main() {
                         </article>
                       </div>
                       <hr>
+                    <div id="api-Default-onboard">
+                      <article id="api-Default-onboard-0" data-group="User" data-name="onboard" data-version="0">
+                        <div class="pull-left">
+                          <h1>onboard</h1>
+                          <p>Onboards a user on Boards.</p>
+                        </div>
+                        <div class="pull-right"></div>
+                        <div class="clearfix"></div>
+                        <p></p>
+                        <p class="marked"></p>
+                        <p></p>
+                        <br />
+                        <pre class="prettyprint language-html prettyprinted" data-type="post"><code><span class="pln">/team/{teamID}/onboard</span></code></pre>
+                        <p>
+                          <h3>Usage and SDK Samples</h3>
+                        </p>
+                        <ul class="nav nav-tabs nav-tabs-examples">
+                          <li class="active"><a href="#examples-Default-onboard-0-curl">Curl</a></li>
+                          <li class=""><a href="#examples-Default-onboard-0-java">Java</a></li>
+                          <li class=""><a href="#examples-Default-onboard-0-android">Android</a></li>
+                          <!--<li class=""><a href="#examples-Default-onboard-0-groovy">Groovy</a></li>-->
+                          <li class=""><a href="#examples-Default-onboard-0-objc">Obj-C</a></li>
+                          <li class=""><a href="#examples-Default-onboard-0-javascript">JavaScript</a></li>
+                          <!--<li class=""><a href="#examples-Default-onboard-0-angular">Angular</a></li>-->
+                          <li class=""><a href="#examples-Default-onboard-0-csharp">C#</a></li>
+                          <li class=""><a href="#examples-Default-onboard-0-php">PHP</a></li>
+                          <li class=""><a href="#examples-Default-onboard-0-perl">Perl</a></li>
+                          <li class=""><a href="#examples-Default-onboard-0-python">Python</a></li>
+                          <li class=""><a href="#examples-Default-onboard-0-rust">Rust</a></li>
+                        </ul>
+
+                        <div class="tab-content">
+                          <div class="tab-pane active" id="examples-Default-onboard-0-curl">
+                            <pre class="prettyprint"><code class="language-bsh">curl -X POST \
+-H "Authorization: [[apiKey]]" \
+ -H "Accept: application/json" \
+ "http://localhost/api/v2/team/{teamID}/onboard"
+</code></pre>
+                          </div>
+                          <div class="tab-pane" id="examples-Default-onboard-0-java">
+                            <pre class="prettyprint"><code class="language-java">import org.openapitools.client.*;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.model.*;
+import org.openapitools.client.api.DefaultApi;
+
+import java.io.File;
+import java.util.*;
+
+public class DefaultApiExample {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        
+        // Configure API key authorization: BearerAuth
+        ApiKeyAuth BearerAuth = (ApiKeyAuth) defaultClient.getAuthentication("BearerAuth");
+        BearerAuth.setApiKey("YOUR API KEY");
+        // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+        //BearerAuth.setApiKeyPrefix("Token");
+
+        // Create an instance of the API class
+        DefaultApi apiInstance = new DefaultApi();
+        String teamID = teamID_example; // String | Team ID
+
+        try {
+            OnboardingResponse result = apiInstance.onboard(teamID);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling DefaultApi#onboard");
+            e.printStackTrace();
+        }
+    }
+}
+</code></pre>
+                          </div>
+
+                          <div class="tab-pane" id="examples-Default-onboard-0-android">
+                            <pre class="prettyprint"><code class="language-java">import org.openapitools.client.api.DefaultApi;
+
+public class DefaultApiExample {
+    public static void main(String[] args) {
+        DefaultApi apiInstance = new DefaultApi();
+        String teamID = teamID_example; // String | Team ID
+
+        try {
+            OnboardingResponse result = apiInstance.onboard(teamID);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling DefaultApi#onboard");
+            e.printStackTrace();
+        }
+    }
+}</code></pre>
+                          </div>
+  <!--
+  <div class="tab-pane" id="examples-Default-onboard-0-groovy">
+  <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
+  </div> -->
+                            <div class="tab-pane" id="examples-Default-onboard-0-objc">
+                              <pre class="prettyprint"><code class="language-cpp">Configuration *apiConfig = [Configuration sharedConfig];
+
+// Configure API key authorization: (authentication scheme: BearerAuth)
+[apiConfig setApiKey:@"YOUR_API_KEY" forApiKeyIdentifier:@"Authorization"];
+// Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+//[apiConfig setApiKeyPrefix:@"Bearer" forApiKeyIdentifier:@"Authorization"];
+
+
+// Create an instance of the API class
+DefaultApi *apiInstance = [[DefaultApi alloc] init];
+String *teamID = teamID_example; // Team ID (default to null)
+
+// Onboards a user on Boards.
+[apiInstance onboardWith:teamID
+              completionHandler: ^(OnboardingResponse output, NSError* error) {
+    if (output) {
+        NSLog(@"%@", output);
+    }
+    if (error) {
+        NSLog(@"Error: %@", error);
+    }
+}];
+</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-onboard-0-javascript">
+                              <pre class="prettyprint"><code class="language-js">var FocalboardServer = require('focalboard_server');
+var defaultClient = FocalboardServer.ApiClient.instance;
+
+// Configure API key authorization: BearerAuth
+var BearerAuth = defaultClient.authentications['BearerAuth'];
+BearerAuth.apiKey = "YOUR API KEY";
+// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+//BearerAuth.apiKeyPrefix['Authorization'] = "Token";
+
+// Create an instance of the API class
+var api = new FocalboardServer.DefaultApi()
+var teamID = teamID_example; // {String} Team ID
+
+var callback = function(error, data, response) {
+  if (error) {
+    console.error(error);
+  } else {
+    console.log('API called successfully. Returned data: ' + data);
+  }
+};
+api.onboard(teamID, callback);
+</code></pre>
+                            </div>
+
+                            <!--<div class="tab-pane" id="examples-Default-onboard-0-angular">
+              <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
+            </div>-->
+                            <div class="tab-pane" id="examples-Default-onboard-0-csharp">
+                              <pre class="prettyprint"><code class="language-cs">using System;
+using System.Diagnostics;
+using Org.OpenAPITools.Api;
+using Org.OpenAPITools.Client;
+using Org.OpenAPITools.Model;
+
+namespace Example
+{
+    public class onboardExample
+    {
+        public void main()
+        {
+            // Configure API key authorization: BearerAuth
+            Configuration.Default.ApiKey.Add("Authorization", "YOUR_API_KEY");
+            // Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+            // Configuration.Default.ApiKeyPrefix.Add("Authorization", "Bearer");
+
+            // Create an instance of the API class
+            var apiInstance = new DefaultApi();
+            var teamID = teamID_example;  // String | Team ID (default to null)
+
+            try {
+                // Onboards a user on Boards.
+                OnboardingResponse result = apiInstance.onboard(teamID);
+                Debug.WriteLine(result);
+            } catch (Exception e) {
+                Debug.Print("Exception when calling DefaultApi.onboard: " + e.Message );
+            }
+        }
+    }
+}
+</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-onboard-0-php">
+                              <pre class="prettyprint"><code class="language-php"><&#63;php
+require_once(__DIR__ . '/vendor/autoload.php');
+
+// Configure API key authorization: BearerAuth
+OpenAPITools\Client\Configuration::getDefaultConfiguration()->setApiKey('Authorization', 'YOUR_API_KEY');
+// Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+// OpenAPITools\Client\Configuration::getDefaultConfiguration()->setApiKeyPrefix('Authorization', 'Bearer');
+
+// Create an instance of the API class
+$api_instance = new OpenAPITools\Client\Api\DefaultApi();
+$teamID = teamID_example; // String | Team ID
+
+try {
+    $result = $api_instance->onboard($teamID);
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling DefaultApi->onboard: ', $e->getMessage(), PHP_EOL;
+}
+?></code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-onboard-0-perl">
+                              <pre class="prettyprint"><code class="language-perl">use Data::Dumper;
+use WWW::OPenAPIClient::Configuration;
+use WWW::OPenAPIClient::DefaultApi;
+
+# Configure API key authorization: BearerAuth
+$WWW::OPenAPIClient::Configuration::api_key->{'Authorization'} = 'YOUR_API_KEY';
+# uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+#$WWW::OPenAPIClient::Configuration::api_key_prefix->{'Authorization'} = "Bearer";
+
+# Create an instance of the API class
+my $api_instance = WWW::OPenAPIClient::DefaultApi->new();
+my $teamID = teamID_example; # String | Team ID
+
+eval {
+    my $result = $api_instance->onboard(teamID => $teamID);
+    print Dumper($result);
+};
+if ($@) {
+    warn "Exception when calling DefaultApi->onboard: $@\n";
+}</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-onboard-0-python">
+                              <pre class="prettyprint"><code class="language-python">from __future__ import print_statement
+import time
+import openapi_client
+from openapi_client.rest import ApiException
+from pprint import pprint
+
+# Configure API key authorization: BearerAuth
+openapi_client.configuration.api_key['Authorization'] = 'YOUR_API_KEY'
+# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+# openapi_client.configuration.api_key_prefix['Authorization'] = 'Bearer'
+
+# Create an instance of the API class
+api_instance = openapi_client.DefaultApi()
+teamID = teamID_example # String | Team ID (default to null)
+
+try:
+    # Onboards a user on Boards.
+    api_response = api_instance.onboard(teamID)
+    pprint(api_response)
+except ApiException as e:
+    print("Exception when calling DefaultApi->onboard: %s\n" % e)</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-onboard-0-rust">
+                              <pre class="prettyprint"><code class="language-rust">extern crate DefaultApi;
+
+pub fn main() {
+    let teamID = teamID_example; // String
+
+    let mut context = DefaultApi::Context::default();
+    let result = client.onboard(teamID, &context).wait();
+
+    println!("{:?}", result);
+}
+</code></pre>
+                            </div>
+                          </div>
+
+                          <h2>Scopes</h2>
+                          <table>
+                            
+                          </table>
+
+                          <h2>Parameters</h2>
+
+                            <div class="methodsubtabletitle">Path parameters</div>
+                            <table id="methodsubtable">
+                                <tr>
+                                  <th width="150px">Name</th>
+                                  <th>Description</th>
+                                </tr>
+                                  <tr><td style="width:150px;">teamID*</td>
+<td>
+
+
+    <div id="d2e199_onboard_teamID">
+        <div class="json-schema-view">
+            <div class="primitive">
+                <span class="type">
+                    String
+                </span>
+
+                    <div class="inner description marked">
+Team ID
+                    </div>
+            </div>
+                <div class="inner required">
+                    Required
+                </div>
+        </div>
+    </div>
+</td>
+</tr>
+
+                            </table>
+
+
+
+
+
+                          <h2>Responses</h2>
+                            <h3 id="examples-Default-onboard-title-200"></h3>
+                            <p id="examples-Default-onboard-description-200" class="marked"></p>
+                            <script>
+                              var responseDefault200_description = `success`;
+                              var responseDefault200_description_break = responseDefault200_description.indexOf('\n');
+                              if (responseDefault200_description_break == -1) {
+                                $("#examples-Default-onboard-title-200").text("Status: 200 - " + responseDefault200_description);
+                              } else {
+                                $("#examples-Default-onboard-title-200").text("Status: 200 - " + responseDefault200_description.substring(0, responseDefault200_description_break));
+                                $("#examples-Default-onboard-description-200").html(responseDefault200_description.substring(responseDefault200_description_break));
+                              }
+                            </script>
+
+
+                            <ul id="responses-detail-Default-onboard-200" class="nav nav-tabs nav-tabs-examples" >
+                                <li class="active">
+                                  <a data-toggle="tab" href="#responses-Default-onboard-200-schema">Schema</a>
+                                </li>
+
+
+
+
+                            </ul>
+
+
+                            <div class="tab-content" id="responses-Default-onboard-200-wrapper" style='margin-bottom: 10px;'>
+                                <div class="tab-pane active" id="responses-Default-onboard-200-schema">
+                                  <div id="responses-Default-onboard-schema-200" class="exampleStyle">
+                                    <script>
+                                      $(document).ready(function() {
+                                        var schemaWrapper = {
+  "description" : "success",
+  "content" : {
+    "application/json" : {
+      "schema" : {
+        "$ref" : "#/components/schemas/OnboardingResponse"
+      }
+    }
+  }
+};
+                                        var schema = findNode('schema',schemaWrapper).schema;
+                                        if (!schema) {
+                                          schema = schemaWrapper.schema;
+                                        }
+                                        if (schema.$ref != null) {
+                                          schema = defsParser.$refs.get(schema.$ref);
+                                        } else if (schema.items != null && schema.items.$ref != null) {
+                                            schema.items = defsParser.$refs.get(schema.items.$ref);
+                                        } else {
+                                          schemaWrapper.definitions = Object.assign({}, defs);
+                                          $RefParser.dereference(schemaWrapper).catch(function(err) {
+                                            console.log(err);
+                                          });
+                                        }
+
+                                        var view = new JSONSchemaView(schema, 3);
+                                        $('#responses-Default-onboard-200-schema-data').val(JSON.stringify(schema));
+                                        var result = $('#responses-Default-onboard-schema-200');
+                                        result.empty();
+                                        result.append(view.render());
+                                      });
+                                    </script>
+                                  </div>
+                                  <input id='responses-Default-onboard-200-schema-data' type='hidden' value=''></input>
+                                </div>
+                            </div>
+                            <h3 id="examples-Default-onboard-title-default"></h3>
+                            <p id="examples-Default-onboard-description-default" class="marked"></p>
+                            <script>
+                              var responseDefaultdefault_description = `internal error`;
+                              var responseDefaultdefault_description_break = responseDefaultdefault_description.indexOf('\n');
+                              if (responseDefaultdefault_description_break == -1) {
+                                $("#examples-Default-onboard-title-default").text("Status: default - " + responseDefaultdefault_description);
+                              } else {
+                                $("#examples-Default-onboard-title-default").text("Status: default - " + responseDefaultdefault_description.substring(0, responseDefaultdefault_description_break));
+                                $("#examples-Default-onboard-description-default").html(responseDefaultdefault_description.substring(responseDefaultdefault_description_break));
+                              }
+                            </script>
+
+
+                            <ul id="responses-detail-Default-onboard-default" class="nav nav-tabs nav-tabs-examples" >
+                                <li class="active">
+                                  <a data-toggle="tab" href="#responses-Default-onboard-default-schema">Schema</a>
+                                </li>
+
+
+
+
+                            </ul>
+
+
+                            <div class="tab-content" id="responses-Default-onboard-default-wrapper" style='margin-bottom: 10px;'>
+                                <div class="tab-pane active" id="responses-Default-onboard-default-schema">
+                                  <div id="responses-Default-onboard-schema-default" class="exampleStyle">
+                                    <script>
+                                      $(document).ready(function() {
+                                        var schemaWrapper = {
+  "description" : "internal error",
+  "content" : {
+    "application/json" : {
+      "schema" : {
+        "$ref" : "#/components/schemas/ErrorResponse"
+      }
+    }
+  }
+};
+                                        var schema = findNode('schema',schemaWrapper).schema;
+                                        if (!schema) {
+                                          schema = schemaWrapper.schema;
+                                        }
+                                        if (schema.$ref != null) {
+                                          schema = defsParser.$refs.get(schema.$ref);
+                                        } else if (schema.items != null && schema.items.$ref != null) {
+                                            schema.items = defsParser.$refs.get(schema.items.$ref);
+                                        } else {
+                                          schemaWrapper.definitions = Object.assign({}, defs);
+                                          $RefParser.dereference(schemaWrapper).catch(function(err) {
+                                            console.log(err);
+                                          });
+                                        }
+
+                                        var view = new JSONSchemaView(schema, 3);
+                                        $('#responses-Default-onboard-default-schema-data').val(JSON.stringify(schema));
+                                        var result = $('#responses-Default-onboard-schema-default');
+                                        result.empty();
+                                        result.append(view.render());
+                                      });
+                                    </script>
+                                  </div>
+                                  <input id='responses-Default-onboard-default-schema-data' type='hidden' value=''></input>
+                                </div>
+                            </div>
+                        </article>
+                      </div>
+                      <hr>
                     <div id="api-Default-patchBlock">
                       <article id="api-Default-patchBlock-0" data-group="User" data-name="patchBlock" data-version="0">
                         <div class="pull-left">
@@ -9378,7 +17413,7 @@ pub fn main() {
                         <p class="marked">Partially updates a block</p>
                         <p></p>
                         <br />
-                        <pre class="prettyprint language-html prettyprinted" data-type="patch"><code><span class="pln">/api/v1/workspaces/{workspaceID}/blocks/{blockID}</span></code></pre>
+                        <pre class="prettyprint language-html prettyprinted" data-type="patch"><code><span class="pln">/boards/{boardID}/blocks/{blockID}</span></code></pre>
                         <p>
                           <h3>Usage and SDK Samples</h3>
                         </p>
@@ -9403,13 +17438,13 @@ pub fn main() {
 -H "Authorization: [[apiKey]]" \
  -H "Accept: application/json" \
  -H "Content-Type: application/json" \
- "http://localhost/api/v1/api/v1/workspaces/{workspaceID}/blocks/{blockID}" \
+ "http://localhost/api/v2/boards/{boardID}/blocks/{blockID}" \
  -d '{
   &quot;schema&quot; : 0,
   &quot;updatedFields&quot; : {
     &quot;key&quot; : &quot;{}&quot;
   },
-  &quot;rootId&quot; : &quot;rootId&quot;,
+  &quot;boardId&quot; : &quot;boardId&quot;,
   &quot;title&quot; : &quot;title&quot;,
   &quot;type&quot; : &quot;type&quot;,
   &quot;deletedFields&quot; : [ &quot;deletedFields&quot;, &quot;deletedFields&quot; ],
@@ -9438,12 +17473,12 @@ public class DefaultApiExample {
 
         // Create an instance of the API class
         DefaultApi apiInstance = new DefaultApi();
-        String workspaceID = workspaceID_example; // String | Workspace ID
+        String boardID = boardID_example; // String | Board ID
         String blockID = blockID_example; // String | ID of block to patch
         BlockPatch body = ; // BlockPatch | 
 
         try {
-            apiInstance.patchBlock(workspaceID, blockID, body);
+            apiInstance.patchBlock(boardID, blockID, body);
         } catch (ApiException e) {
             System.err.println("Exception when calling DefaultApi#patchBlock");
             e.printStackTrace();
@@ -9459,12 +17494,12 @@ public class DefaultApiExample {
 public class DefaultApiExample {
     public static void main(String[] args) {
         DefaultApi apiInstance = new DefaultApi();
-        String workspaceID = workspaceID_example; // String | Workspace ID
+        String boardID = boardID_example; // String | Board ID
         String blockID = blockID_example; // String | ID of block to patch
         BlockPatch body = ; // BlockPatch | 
 
         try {
-            apiInstance.patchBlock(workspaceID, blockID, body);
+            apiInstance.patchBlock(boardID, blockID, body);
         } catch (ApiException e) {
             System.err.println("Exception when calling DefaultApi#patchBlock");
             e.printStackTrace();
@@ -9487,11 +17522,11 @@ public class DefaultApiExample {
 
 // Create an instance of the API class
 DefaultApi *apiInstance = [[DefaultApi alloc] init];
-String *workspaceID = workspaceID_example; // Workspace ID (default to null)
+String *boardID = boardID_example; // Board ID (default to null)
 String *blockID = blockID_example; // ID of block to patch (default to null)
 BlockPatch *body = ; // 
 
-[apiInstance patchBlockWith:workspaceID
+[apiInstance patchBlockWith:boardID
     blockID:blockID
     body:body
               completionHandler: ^(NSError* error) {
@@ -9514,7 +17549,7 @@ BearerAuth.apiKey = "YOUR API KEY";
 
 // Create an instance of the API class
 var api = new FocalboardServer.DefaultApi()
-var workspaceID = workspaceID_example; // {String} Workspace ID
+var boardID = boardID_example; // {String} Board ID
 var blockID = blockID_example; // {String} ID of block to patch
 var body = ; // {BlockPatch} 
 
@@ -9525,7 +17560,7 @@ var callback = function(error, data, response) {
     console.log('API called successfully.');
   }
 };
-api.patchBlock(workspaceID, blockID, body, callback);
+api.patchBlock(boardID, blockID, body, callback);
 </code></pre>
                             </div>
 
@@ -9552,12 +17587,12 @@ namespace Example
 
             // Create an instance of the API class
             var apiInstance = new DefaultApi();
-            var workspaceID = workspaceID_example;  // String | Workspace ID (default to null)
+            var boardID = boardID_example;  // String | Board ID (default to null)
             var blockID = blockID_example;  // String | ID of block to patch (default to null)
             var body = new BlockPatch(); // BlockPatch | 
 
             try {
-                apiInstance.patchBlock(workspaceID, blockID, body);
+                apiInstance.patchBlock(boardID, blockID, body);
             } catch (Exception e) {
                 Debug.Print("Exception when calling DefaultApi.patchBlock: " + e.Message );
             }
@@ -9578,12 +17613,12 @@ OpenAPITools\Client\Configuration::getDefaultConfiguration()->setApiKey('Authori
 
 // Create an instance of the API class
 $api_instance = new OpenAPITools\Client\Api\DefaultApi();
-$workspaceID = workspaceID_example; // String | Workspace ID
+$boardID = boardID_example; // String | Board ID
 $blockID = blockID_example; // String | ID of block to patch
 $body = ; // BlockPatch | 
 
 try {
-    $api_instance->patchBlock($workspaceID, $blockID, $body);
+    $api_instance->patchBlock($boardID, $blockID, $body);
 } catch (Exception $e) {
     echo 'Exception when calling DefaultApi->patchBlock: ', $e->getMessage(), PHP_EOL;
 }
@@ -9602,12 +17637,12 @@ $WWW::OPenAPIClient::Configuration::api_key->{'Authorization'} = 'YOUR_API_KEY';
 
 # Create an instance of the API class
 my $api_instance = WWW::OPenAPIClient::DefaultApi->new();
-my $workspaceID = workspaceID_example; # String | Workspace ID
+my $boardID = boardID_example; # String | Board ID
 my $blockID = blockID_example; # String | ID of block to patch
 my $body = WWW::OPenAPIClient::Object::BlockPatch->new(); # BlockPatch | 
 
 eval {
-    $api_instance->patchBlock(workspaceID => $workspaceID, blockID => $blockID, body => $body);
+    $api_instance->patchBlock(boardID => $boardID, blockID => $blockID, body => $body);
 };
 if ($@) {
     warn "Exception when calling DefaultApi->patchBlock: $@\n";
@@ -9628,12 +17663,12 @@ openapi_client.configuration.api_key['Authorization'] = 'YOUR_API_KEY'
 
 # Create an instance of the API class
 api_instance = openapi_client.DefaultApi()
-workspaceID = workspaceID_example # String | Workspace ID (default to null)
+boardID = boardID_example # String | Board ID (default to null)
 blockID = blockID_example # String | ID of block to patch (default to null)
 body =  # BlockPatch | 
 
 try:
-    api_instance.patch_block(workspaceID, blockID, body)
+    api_instance.patch_block(boardID, blockID, body)
 except ApiException as e:
     print("Exception when calling DefaultApi->patchBlock: %s\n" % e)</code></pre>
                             </div>
@@ -9642,12 +17677,12 @@ except ApiException as e:
                               <pre class="prettyprint"><code class="language-rust">extern crate DefaultApi;
 
 pub fn main() {
-    let workspaceID = workspaceID_example; // String
+    let boardID = boardID_example; // String
     let blockID = blockID_example; // String
     let body = ; // BlockPatch
 
     let mut context = DefaultApi::Context::default();
-    let result = client.patchBlock(workspaceID, blockID, body, &context).wait();
+    let result = client.patchBlock(boardID, blockID, body, &context).wait();
 
     println!("{:?}", result);
 }
@@ -9668,11 +17703,11 @@ pub fn main() {
                                   <th width="150px">Name</th>
                                   <th>Description</th>
                                 </tr>
-                                  <tr><td style="width:150px;">workspaceID*</td>
+                                  <tr><td style="width:150px;">boardID*</td>
 <td>
 
 
-    <div id="d2e199_patchBlock_workspaceID">
+    <div id="d2e199_patchBlock_boardID">
         <div class="json-schema-view">
             <div class="primitive">
                 <span class="type">
@@ -9680,7 +17715,7 @@ pub fn main() {
                 </span>
 
                     <div class="inner description marked">
-Workspace ID
+Board ID
                     </div>
             </div>
                 <div class="inner required">
@@ -9790,6 +17825,28 @@ $(document).ready(function() {
 
                             <div class="tab-content" id="responses-Default-patchBlock-200-wrapper" style='margin-bottom: 10px;'>
                             </div>
+                            <h3 id="examples-Default-patchBlock-title-404"></h3>
+                            <p id="examples-Default-patchBlock-description-404" class="marked"></p>
+                            <script>
+                              var responseDefault404_description = `block not found`;
+                              var responseDefault404_description_break = responseDefault404_description.indexOf('\n');
+                              if (responseDefault404_description_break == -1) {
+                                $("#examples-Default-patchBlock-title-404").text("Status: 404 - " + responseDefault404_description);
+                              } else {
+                                $("#examples-Default-patchBlock-title-404").text("Status: 404 - " + responseDefault404_description.substring(0, responseDefault404_description_break));
+                                $("#examples-Default-patchBlock-description-404").html(responseDefault404_description.substring(responseDefault404_description_break));
+                              }
+                            </script>
+
+
+                            <ul id="responses-detail-Default-patchBlock-404" class="nav nav-tabs nav-tabs-examples" >
+
+
+                            </ul>
+
+
+                            <div class="tab-content" id="responses-Default-patchBlock-404-wrapper" style='margin-bottom: 10px;'>
+                            </div>
                             <h3 id="examples-Default-patchBlock-title-default"></h3>
                             <p id="examples-Default-patchBlock-description-default" class="marked"></p>
                             <script>
@@ -9871,7 +17928,7 @@ $(document).ready(function() {
                         <p class="marked">Partially updates batch of blocks</p>
                         <p></p>
                         <br />
-                        <pre class="prettyprint language-html prettyprinted" data-type="patch"><code><span class="pln">/api/v1/workspaces/{workspaceID}/blocks/</span></code></pre>
+                        <pre class="prettyprint language-html prettyprinted" data-type="patch"><code><span class="pln">/boards/{boardID}/blocks/</span></code></pre>
                         <p>
                           <h3>Usage and SDK Samples</h3>
                         </p>
@@ -9896,14 +17953,14 @@ $(document).ready(function() {
 -H "Authorization: [[apiKey]]" \
  -H "Accept: application/json" \
  -H "Content-Type: application/json" \
- "http://localhost/api/v1/api/v1/workspaces/{workspaceID}/blocks/" \
+ "http://localhost/api/v2/boards/{boardID}/blocks/" \
  -d '{
   &quot;block_patches&quot; : [ {
     &quot;schema&quot; : 0,
     &quot;updatedFields&quot; : {
       &quot;key&quot; : &quot;{}&quot;
     },
-    &quot;rootId&quot; : &quot;rootId&quot;,
+    &quot;boardId&quot; : &quot;boardId&quot;,
     &quot;title&quot; : &quot;title&quot;,
     &quot;type&quot; : &quot;type&quot;,
     &quot;deletedFields&quot; : [ &quot;deletedFields&quot;, &quot;deletedFields&quot; ],
@@ -9913,7 +17970,7 @@ $(document).ready(function() {
     &quot;updatedFields&quot; : {
       &quot;key&quot; : &quot;{}&quot;
     },
-    &quot;rootId&quot; : &quot;rootId&quot;,
+    &quot;boardId&quot; : &quot;boardId&quot;,
     &quot;title&quot; : &quot;title&quot;,
     &quot;type&quot; : &quot;type&quot;,
     &quot;deletedFields&quot; : [ &quot;deletedFields&quot;, &quot;deletedFields&quot; ],
@@ -9944,11 +18001,11 @@ public class DefaultApiExample {
 
         // Create an instance of the API class
         DefaultApi apiInstance = new DefaultApi();
-        String workspaceID = workspaceID_example; // String | Workspace ID
+        String boardID = boardID_example; // String | Workspace ID
         BlockPatchBatch body = ; // BlockPatchBatch | 
 
         try {
-            apiInstance.patchBlocks(workspaceID, body);
+            apiInstance.patchBlocks(boardID, body);
         } catch (ApiException e) {
             System.err.println("Exception when calling DefaultApi#patchBlocks");
             e.printStackTrace();
@@ -9964,11 +18021,11 @@ public class DefaultApiExample {
 public class DefaultApiExample {
     public static void main(String[] args) {
         DefaultApi apiInstance = new DefaultApi();
-        String workspaceID = workspaceID_example; // String | Workspace ID
+        String boardID = boardID_example; // String | Workspace ID
         BlockPatchBatch body = ; // BlockPatchBatch | 
 
         try {
-            apiInstance.patchBlocks(workspaceID, body);
+            apiInstance.patchBlocks(boardID, body);
         } catch (ApiException e) {
             System.err.println("Exception when calling DefaultApi#patchBlocks");
             e.printStackTrace();
@@ -9991,10 +18048,10 @@ public class DefaultApiExample {
 
 // Create an instance of the API class
 DefaultApi *apiInstance = [[DefaultApi alloc] init];
-String *workspaceID = workspaceID_example; // Workspace ID (default to null)
+String *boardID = boardID_example; // Workspace ID (default to null)
 BlockPatchBatch *body = ; // 
 
-[apiInstance patchBlocksWith:workspaceID
+[apiInstance patchBlocksWith:boardID
     body:body
               completionHandler: ^(NSError* error) {
     if (error) {
@@ -10016,7 +18073,7 @@ BearerAuth.apiKey = "YOUR API KEY";
 
 // Create an instance of the API class
 var api = new FocalboardServer.DefaultApi()
-var workspaceID = workspaceID_example; // {String} Workspace ID
+var boardID = boardID_example; // {String} Workspace ID
 var body = ; // {BlockPatchBatch} 
 
 var callback = function(error, data, response) {
@@ -10026,7 +18083,7 @@ var callback = function(error, data, response) {
     console.log('API called successfully.');
   }
 };
-api.patchBlocks(workspaceID, body, callback);
+api.patchBlocks(boardID, body, callback);
 </code></pre>
                             </div>
 
@@ -10053,11 +18110,11 @@ namespace Example
 
             // Create an instance of the API class
             var apiInstance = new DefaultApi();
-            var workspaceID = workspaceID_example;  // String | Workspace ID (default to null)
+            var boardID = boardID_example;  // String | Workspace ID (default to null)
             var body = new BlockPatchBatch(); // BlockPatchBatch | 
 
             try {
-                apiInstance.patchBlocks(workspaceID, body);
+                apiInstance.patchBlocks(boardID, body);
             } catch (Exception e) {
                 Debug.Print("Exception when calling DefaultApi.patchBlocks: " + e.Message );
             }
@@ -10078,11 +18135,11 @@ OpenAPITools\Client\Configuration::getDefaultConfiguration()->setApiKey('Authori
 
 // Create an instance of the API class
 $api_instance = new OpenAPITools\Client\Api\DefaultApi();
-$workspaceID = workspaceID_example; // String | Workspace ID
+$boardID = boardID_example; // String | Workspace ID
 $body = ; // BlockPatchBatch | 
 
 try {
-    $api_instance->patchBlocks($workspaceID, $body);
+    $api_instance->patchBlocks($boardID, $body);
 } catch (Exception $e) {
     echo 'Exception when calling DefaultApi->patchBlocks: ', $e->getMessage(), PHP_EOL;
 }
@@ -10101,11 +18158,11 @@ $WWW::OPenAPIClient::Configuration::api_key->{'Authorization'} = 'YOUR_API_KEY';
 
 # Create an instance of the API class
 my $api_instance = WWW::OPenAPIClient::DefaultApi->new();
-my $workspaceID = workspaceID_example; # String | Workspace ID
+my $boardID = boardID_example; # String | Workspace ID
 my $body = WWW::OPenAPIClient::Object::BlockPatchBatch->new(); # BlockPatchBatch | 
 
 eval {
-    $api_instance->patchBlocks(workspaceID => $workspaceID, body => $body);
+    $api_instance->patchBlocks(boardID => $boardID, body => $body);
 };
 if ($@) {
     warn "Exception when calling DefaultApi->patchBlocks: $@\n";
@@ -10126,11 +18183,11 @@ openapi_client.configuration.api_key['Authorization'] = 'YOUR_API_KEY'
 
 # Create an instance of the API class
 api_instance = openapi_client.DefaultApi()
-workspaceID = workspaceID_example # String | Workspace ID (default to null)
+boardID = boardID_example # String | Workspace ID (default to null)
 body =  # BlockPatchBatch | 
 
 try:
-    api_instance.patch_blocks(workspaceID, body)
+    api_instance.patch_blocks(boardID, body)
 except ApiException as e:
     print("Exception when calling DefaultApi->patchBlocks: %s\n" % e)</code></pre>
                             </div>
@@ -10139,11 +18196,11 @@ except ApiException as e:
                               <pre class="prettyprint"><code class="language-rust">extern crate DefaultApi;
 
 pub fn main() {
-    let workspaceID = workspaceID_example; // String
+    let boardID = boardID_example; // String
     let body = ; // BlockPatchBatch
 
     let mut context = DefaultApi::Context::default();
-    let result = client.patchBlocks(workspaceID, body, &context).wait();
+    let result = client.patchBlocks(boardID, body, &context).wait();
 
     println!("{:?}", result);
 }
@@ -10164,11 +18221,11 @@ pub fn main() {
                                   <th width="150px">Name</th>
                                   <th>Description</th>
                                 </tr>
-                                  <tr><td style="width:150px;">workspaceID*</td>
+                                  <tr><td style="width:150px;">boardID*</td>
 <td>
 
 
-    <div id="d2e199_patchBlocks_workspaceID">
+    <div id="d2e199_patchBlocks_boardID">
         <div class="json-schema-view">
             <div class="primitive">
                 <span class="type">
@@ -10332,6 +18389,1079 @@ $(document).ready(function() {
                         </article>
                       </div>
                       <hr>
+                    <div id="api-Default-patchBoard">
+                      <article id="api-Default-patchBoard-0" data-group="User" data-name="patchBoard" data-version="0">
+                        <div class="pull-left">
+                          <h1>patchBoard</h1>
+                          <p></p>
+                        </div>
+                        <div class="pull-right"></div>
+                        <div class="clearfix"></div>
+                        <p></p>
+                        <p class="marked">Partially updates a board</p>
+                        <p></p>
+                        <br />
+                        <pre class="prettyprint language-html prettyprinted" data-type="patch"><code><span class="pln">/boards/{boardID}</span></code></pre>
+                        <p>
+                          <h3>Usage and SDK Samples</h3>
+                        </p>
+                        <ul class="nav nav-tabs nav-tabs-examples">
+                          <li class="active"><a href="#examples-Default-patchBoard-0-curl">Curl</a></li>
+                          <li class=""><a href="#examples-Default-patchBoard-0-java">Java</a></li>
+                          <li class=""><a href="#examples-Default-patchBoard-0-android">Android</a></li>
+                          <!--<li class=""><a href="#examples-Default-patchBoard-0-groovy">Groovy</a></li>-->
+                          <li class=""><a href="#examples-Default-patchBoard-0-objc">Obj-C</a></li>
+                          <li class=""><a href="#examples-Default-patchBoard-0-javascript">JavaScript</a></li>
+                          <!--<li class=""><a href="#examples-Default-patchBoard-0-angular">Angular</a></li>-->
+                          <li class=""><a href="#examples-Default-patchBoard-0-csharp">C#</a></li>
+                          <li class=""><a href="#examples-Default-patchBoard-0-php">PHP</a></li>
+                          <li class=""><a href="#examples-Default-patchBoard-0-perl">Perl</a></li>
+                          <li class=""><a href="#examples-Default-patchBoard-0-python">Python</a></li>
+                          <li class=""><a href="#examples-Default-patchBoard-0-rust">Rust</a></li>
+                        </ul>
+
+                        <div class="tab-content">
+                          <div class="tab-pane active" id="examples-Default-patchBoard-0-curl">
+                            <pre class="prettyprint"><code class="language-bsh">curl -X PATCH \
+-H "Authorization: [[apiKey]]" \
+ -H "Accept: application/json" \
+ -H "Content-Type: application/json" \
+ "http://localhost/api/v2/boards/{boardID}" \
+ -d '{
+  &quot;showDescription&quot; : true,
+  &quot;updatedProperties&quot; : {
+    &quot;key&quot; : &quot;{}&quot;
+  },
+  &quot;deletedColumnCalculations&quot; : [ &quot;deletedColumnCalculations&quot;, &quot;deletedColumnCalculations&quot; ],
+  &quot;icon&quot; : &quot;icon&quot;,
+  &quot;updatedColumnCalculations&quot; : {
+    &quot;key&quot; : &quot;{}&quot;
+  },
+  &quot;deletedCardProperties&quot; : [ &quot;deletedCardProperties&quot;, &quot;deletedCardProperties&quot; ],
+  &quot;description&quot; : &quot;description&quot;,
+  &quot;updatedCardProperties&quot; : [ {
+    &quot;key&quot; : &quot;{}&quot;
+  }, {
+    &quot;key&quot; : &quot;{}&quot;
+  } ],
+  &quot;title&quot; : &quot;title&quot;,
+  &quot;type&quot; : &quot;type&quot;,
+  &quot;deletedProperties&quot; : [ &quot;deletedProperties&quot;, &quot;deletedProperties&quot; ]
+}'
+</code></pre>
+                          </div>
+                          <div class="tab-pane" id="examples-Default-patchBoard-0-java">
+                            <pre class="prettyprint"><code class="language-java">import org.openapitools.client.*;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.model.*;
+import org.openapitools.client.api.DefaultApi;
+
+import java.io.File;
+import java.util.*;
+
+public class DefaultApiExample {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        
+        // Configure API key authorization: BearerAuth
+        ApiKeyAuth BearerAuth = (ApiKeyAuth) defaultClient.getAuthentication("BearerAuth");
+        BearerAuth.setApiKey("YOUR API KEY");
+        // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+        //BearerAuth.setApiKeyPrefix("Token");
+
+        // Create an instance of the API class
+        DefaultApi apiInstance = new DefaultApi();
+        String boardID = boardID_example; // String | Board ID
+        BoardPatch body = ; // BoardPatch | 
+
+        try {
+            Board result = apiInstance.patchBoard(boardID, body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling DefaultApi#patchBoard");
+            e.printStackTrace();
+        }
+    }
+}
+</code></pre>
+                          </div>
+
+                          <div class="tab-pane" id="examples-Default-patchBoard-0-android">
+                            <pre class="prettyprint"><code class="language-java">import org.openapitools.client.api.DefaultApi;
+
+public class DefaultApiExample {
+    public static void main(String[] args) {
+        DefaultApi apiInstance = new DefaultApi();
+        String boardID = boardID_example; // String | Board ID
+        BoardPatch body = ; // BoardPatch | 
+
+        try {
+            Board result = apiInstance.patchBoard(boardID, body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling DefaultApi#patchBoard");
+            e.printStackTrace();
+        }
+    }
+}</code></pre>
+                          </div>
+  <!--
+  <div class="tab-pane" id="examples-Default-patchBoard-0-groovy">
+  <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
+  </div> -->
+                            <div class="tab-pane" id="examples-Default-patchBoard-0-objc">
+                              <pre class="prettyprint"><code class="language-cpp">Configuration *apiConfig = [Configuration sharedConfig];
+
+// Configure API key authorization: (authentication scheme: BearerAuth)
+[apiConfig setApiKey:@"YOUR_API_KEY" forApiKeyIdentifier:@"Authorization"];
+// Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+//[apiConfig setApiKeyPrefix:@"Bearer" forApiKeyIdentifier:@"Authorization"];
+
+
+// Create an instance of the API class
+DefaultApi *apiInstance = [[DefaultApi alloc] init];
+String *boardID = boardID_example; // Board ID (default to null)
+BoardPatch *body = ; // 
+
+[apiInstance patchBoardWith:boardID
+    body:body
+              completionHandler: ^(Board output, NSError* error) {
+    if (output) {
+        NSLog(@"%@", output);
+    }
+    if (error) {
+        NSLog(@"Error: %@", error);
+    }
+}];
+</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-patchBoard-0-javascript">
+                              <pre class="prettyprint"><code class="language-js">var FocalboardServer = require('focalboard_server');
+var defaultClient = FocalboardServer.ApiClient.instance;
+
+// Configure API key authorization: BearerAuth
+var BearerAuth = defaultClient.authentications['BearerAuth'];
+BearerAuth.apiKey = "YOUR API KEY";
+// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+//BearerAuth.apiKeyPrefix['Authorization'] = "Token";
+
+// Create an instance of the API class
+var api = new FocalboardServer.DefaultApi()
+var boardID = boardID_example; // {String} Board ID
+var body = ; // {BoardPatch} 
+
+var callback = function(error, data, response) {
+  if (error) {
+    console.error(error);
+  } else {
+    console.log('API called successfully. Returned data: ' + data);
+  }
+};
+api.patchBoard(boardID, body, callback);
+</code></pre>
+                            </div>
+
+                            <!--<div class="tab-pane" id="examples-Default-patchBoard-0-angular">
+              <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
+            </div>-->
+                            <div class="tab-pane" id="examples-Default-patchBoard-0-csharp">
+                              <pre class="prettyprint"><code class="language-cs">using System;
+using System.Diagnostics;
+using Org.OpenAPITools.Api;
+using Org.OpenAPITools.Client;
+using Org.OpenAPITools.Model;
+
+namespace Example
+{
+    public class patchBoardExample
+    {
+        public void main()
+        {
+            // Configure API key authorization: BearerAuth
+            Configuration.Default.ApiKey.Add("Authorization", "YOUR_API_KEY");
+            // Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+            // Configuration.Default.ApiKeyPrefix.Add("Authorization", "Bearer");
+
+            // Create an instance of the API class
+            var apiInstance = new DefaultApi();
+            var boardID = boardID_example;  // String | Board ID (default to null)
+            var body = new BoardPatch(); // BoardPatch | 
+
+            try {
+                Board result = apiInstance.patchBoard(boardID, body);
+                Debug.WriteLine(result);
+            } catch (Exception e) {
+                Debug.Print("Exception when calling DefaultApi.patchBoard: " + e.Message );
+            }
+        }
+    }
+}
+</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-patchBoard-0-php">
+                              <pre class="prettyprint"><code class="language-php"><&#63;php
+require_once(__DIR__ . '/vendor/autoload.php');
+
+// Configure API key authorization: BearerAuth
+OpenAPITools\Client\Configuration::getDefaultConfiguration()->setApiKey('Authorization', 'YOUR_API_KEY');
+// Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+// OpenAPITools\Client\Configuration::getDefaultConfiguration()->setApiKeyPrefix('Authorization', 'Bearer');
+
+// Create an instance of the API class
+$api_instance = new OpenAPITools\Client\Api\DefaultApi();
+$boardID = boardID_example; // String | Board ID
+$body = ; // BoardPatch | 
+
+try {
+    $result = $api_instance->patchBoard($boardID, $body);
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling DefaultApi->patchBoard: ', $e->getMessage(), PHP_EOL;
+}
+?></code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-patchBoard-0-perl">
+                              <pre class="prettyprint"><code class="language-perl">use Data::Dumper;
+use WWW::OPenAPIClient::Configuration;
+use WWW::OPenAPIClient::DefaultApi;
+
+# Configure API key authorization: BearerAuth
+$WWW::OPenAPIClient::Configuration::api_key->{'Authorization'} = 'YOUR_API_KEY';
+# uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+#$WWW::OPenAPIClient::Configuration::api_key_prefix->{'Authorization'} = "Bearer";
+
+# Create an instance of the API class
+my $api_instance = WWW::OPenAPIClient::DefaultApi->new();
+my $boardID = boardID_example; # String | Board ID
+my $body = WWW::OPenAPIClient::Object::BoardPatch->new(); # BoardPatch | 
+
+eval {
+    my $result = $api_instance->patchBoard(boardID => $boardID, body => $body);
+    print Dumper($result);
+};
+if ($@) {
+    warn "Exception when calling DefaultApi->patchBoard: $@\n";
+}</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-patchBoard-0-python">
+                              <pre class="prettyprint"><code class="language-python">from __future__ import print_statement
+import time
+import openapi_client
+from openapi_client.rest import ApiException
+from pprint import pprint
+
+# Configure API key authorization: BearerAuth
+openapi_client.configuration.api_key['Authorization'] = 'YOUR_API_KEY'
+# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+# openapi_client.configuration.api_key_prefix['Authorization'] = 'Bearer'
+
+# Create an instance of the API class
+api_instance = openapi_client.DefaultApi()
+boardID = boardID_example # String | Board ID (default to null)
+body =  # BoardPatch | 
+
+try:
+    api_response = api_instance.patch_board(boardID, body)
+    pprint(api_response)
+except ApiException as e:
+    print("Exception when calling DefaultApi->patchBoard: %s\n" % e)</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-patchBoard-0-rust">
+                              <pre class="prettyprint"><code class="language-rust">extern crate DefaultApi;
+
+pub fn main() {
+    let boardID = boardID_example; // String
+    let body = ; // BoardPatch
+
+    let mut context = DefaultApi::Context::default();
+    let result = client.patchBoard(boardID, body, &context).wait();
+
+    println!("{:?}", result);
+}
+</code></pre>
+                            </div>
+                          </div>
+
+                          <h2>Scopes</h2>
+                          <table>
+                            
+                          </table>
+
+                          <h2>Parameters</h2>
+
+                            <div class="methodsubtabletitle">Path parameters</div>
+                            <table id="methodsubtable">
+                                <tr>
+                                  <th width="150px">Name</th>
+                                  <th>Description</th>
+                                </tr>
+                                  <tr><td style="width:150px;">boardID*</td>
+<td>
+
+
+    <div id="d2e199_patchBoard_boardID">
+        <div class="json-schema-view">
+            <div class="primitive">
+                <span class="type">
+                    String
+                </span>
+
+                    <div class="inner description marked">
+Board ID
+                    </div>
+            </div>
+                <div class="inner required">
+                    Required
+                </div>
+        </div>
+    </div>
+</td>
+</tr>
+
+                            </table>
+
+
+                            <div class="methodsubtabletitle">Body parameters</div>
+                            <table id="methodsubtable">
+                              <tr>
+                                <th width="150px">Name</th>
+                                <th>Description</th>
+                              </tr>
+                                <tr><td style="width:150px;">body <span style="color:red;">*</span></td>
+<td>
+<p class="marked">board patch to apply</p>
+<script>
+$(document).ready(function() {
+  var schemaWrapper = {
+  "description" : "board patch to apply",
+  "content" : {
+    "application/json" : {
+      "schema" : {
+        "$ref" : "#/components/schemas/BoardPatch"
+      }
+    }
+  },
+  "required" : true
+};
+
+  var schema = findNode('schema',schemaWrapper).schema;
+  if (!schema) {
+    schema = schemaWrapper.schema;
+  }
+  if (schema.$ref != null) {
+    schema = defsParser.$refs.get(schema.$ref);
+  } else {
+    schemaWrapper.definitions = Object.assign({}, defs);
+    $RefParser.dereference(schemaWrapper).catch(function(err) {
+      console.log(err);
+    });
+  }
+
+  var view = new JSONSchemaView(schema,2,{isBodyParam: true});
+  var result = $('#d2e199_patchBoard_body');
+  result.empty();
+  result.append(view.render());
+});
+</script>
+<div id="d2e199_patchBoard_body"></div>
+</td>
+</tr>
+
+                            </table>
+
+
+
+                          <h2>Responses</h2>
+                            <h3 id="examples-Default-patchBoard-title-200"></h3>
+                            <p id="examples-Default-patchBoard-description-200" class="marked"></p>
+                            <script>
+                              var responseDefault200_description = `success`;
+                              var responseDefault200_description_break = responseDefault200_description.indexOf('\n');
+                              if (responseDefault200_description_break == -1) {
+                                $("#examples-Default-patchBoard-title-200").text("Status: 200 - " + responseDefault200_description);
+                              } else {
+                                $("#examples-Default-patchBoard-title-200").text("Status: 200 - " + responseDefault200_description.substring(0, responseDefault200_description_break));
+                                $("#examples-Default-patchBoard-description-200").html(responseDefault200_description.substring(responseDefault200_description_break));
+                              }
+                            </script>
+
+
+                            <ul id="responses-detail-Default-patchBoard-200" class="nav nav-tabs nav-tabs-examples" >
+                                <li class="active">
+                                  <a data-toggle="tab" href="#responses-Default-patchBoard-200-schema">Schema</a>
+                                </li>
+
+
+
+
+                            </ul>
+
+
+                            <div class="tab-content" id="responses-Default-patchBoard-200-wrapper" style='margin-bottom: 10px;'>
+                                <div class="tab-pane active" id="responses-Default-patchBoard-200-schema">
+                                  <div id="responses-Default-patchBoard-schema-200" class="exampleStyle">
+                                    <script>
+                                      $(document).ready(function() {
+                                        var schemaWrapper = {
+  "description" : "success",
+  "content" : {
+    "application/json" : {
+      "schema" : {
+        "$ref" : "#/components/schemas/Board"
+      }
+    }
+  }
+};
+                                        var schema = findNode('schema',schemaWrapper).schema;
+                                        if (!schema) {
+                                          schema = schemaWrapper.schema;
+                                        }
+                                        if (schema.$ref != null) {
+                                          schema = defsParser.$refs.get(schema.$ref);
+                                        } else if (schema.items != null && schema.items.$ref != null) {
+                                            schema.items = defsParser.$refs.get(schema.items.$ref);
+                                        } else {
+                                          schemaWrapper.definitions = Object.assign({}, defs);
+                                          $RefParser.dereference(schemaWrapper).catch(function(err) {
+                                            console.log(err);
+                                          });
+                                        }
+
+                                        var view = new JSONSchemaView(schema, 3);
+                                        $('#responses-Default-patchBoard-200-schema-data').val(JSON.stringify(schema));
+                                        var result = $('#responses-Default-patchBoard-schema-200');
+                                        result.empty();
+                                        result.append(view.render());
+                                      });
+                                    </script>
+                                  </div>
+                                  <input id='responses-Default-patchBoard-200-schema-data' type='hidden' value=''></input>
+                                </div>
+                            </div>
+                            <h3 id="examples-Default-patchBoard-title-404"></h3>
+                            <p id="examples-Default-patchBoard-description-404" class="marked"></p>
+                            <script>
+                              var responseDefault404_description = `board not found`;
+                              var responseDefault404_description_break = responseDefault404_description.indexOf('\n');
+                              if (responseDefault404_description_break == -1) {
+                                $("#examples-Default-patchBoard-title-404").text("Status: 404 - " + responseDefault404_description);
+                              } else {
+                                $("#examples-Default-patchBoard-title-404").text("Status: 404 - " + responseDefault404_description.substring(0, responseDefault404_description_break));
+                                $("#examples-Default-patchBoard-description-404").html(responseDefault404_description.substring(responseDefault404_description_break));
+                              }
+                            </script>
+
+
+                            <ul id="responses-detail-Default-patchBoard-404" class="nav nav-tabs nav-tabs-examples" >
+
+
+                            </ul>
+
+
+                            <div class="tab-content" id="responses-Default-patchBoard-404-wrapper" style='margin-bottom: 10px;'>
+                            </div>
+                            <h3 id="examples-Default-patchBoard-title-default"></h3>
+                            <p id="examples-Default-patchBoard-description-default" class="marked"></p>
+                            <script>
+                              var responseDefaultdefault_description = `internal error`;
+                              var responseDefaultdefault_description_break = responseDefaultdefault_description.indexOf('\n');
+                              if (responseDefaultdefault_description_break == -1) {
+                                $("#examples-Default-patchBoard-title-default").text("Status: default - " + responseDefaultdefault_description);
+                              } else {
+                                $("#examples-Default-patchBoard-title-default").text("Status: default - " + responseDefaultdefault_description.substring(0, responseDefaultdefault_description_break));
+                                $("#examples-Default-patchBoard-description-default").html(responseDefaultdefault_description.substring(responseDefaultdefault_description_break));
+                              }
+                            </script>
+
+
+                            <ul id="responses-detail-Default-patchBoard-default" class="nav nav-tabs nav-tabs-examples" >
+                                <li class="active">
+                                  <a data-toggle="tab" href="#responses-Default-patchBoard-default-schema">Schema</a>
+                                </li>
+
+
+
+
+                            </ul>
+
+
+                            <div class="tab-content" id="responses-Default-patchBoard-default-wrapper" style='margin-bottom: 10px;'>
+                                <div class="tab-pane active" id="responses-Default-patchBoard-default-schema">
+                                  <div id="responses-Default-patchBoard-schema-default" class="exampleStyle">
+                                    <script>
+                                      $(document).ready(function() {
+                                        var schemaWrapper = {
+  "description" : "internal error",
+  "content" : {
+    "application/json" : {
+      "schema" : {
+        "$ref" : "#/components/schemas/ErrorResponse"
+      }
+    }
+  }
+};
+                                        var schema = findNode('schema',schemaWrapper).schema;
+                                        if (!schema) {
+                                          schema = schemaWrapper.schema;
+                                        }
+                                        if (schema.$ref != null) {
+                                          schema = defsParser.$refs.get(schema.$ref);
+                                        } else if (schema.items != null && schema.items.$ref != null) {
+                                            schema.items = defsParser.$refs.get(schema.items.$ref);
+                                        } else {
+                                          schemaWrapper.definitions = Object.assign({}, defs);
+                                          $RefParser.dereference(schemaWrapper).catch(function(err) {
+                                            console.log(err);
+                                          });
+                                        }
+
+                                        var view = new JSONSchemaView(schema, 3);
+                                        $('#responses-Default-patchBoard-default-schema-data').val(JSON.stringify(schema));
+                                        var result = $('#responses-Default-patchBoard-schema-default');
+                                        result.empty();
+                                        result.append(view.render());
+                                      });
+                                    </script>
+                                  </div>
+                                  <input id='responses-Default-patchBoard-default-schema-data' type='hidden' value=''></input>
+                                </div>
+                            </div>
+                        </article>
+                      </div>
+                      <hr>
+                    <div id="api-Default-patchBoardsAndBlocks">
+                      <article id="api-Default-patchBoardsAndBlocks-0" data-group="User" data-name="patchBoardsAndBlocks" data-version="0">
+                        <div class="pull-left">
+                          <h1>patchBoardsAndBlocks</h1>
+                          <p></p>
+                        </div>
+                        <div class="pull-right"></div>
+                        <div class="clearfix"></div>
+                        <p></p>
+                        <p class="marked">Patches a set of related boards and blocks</p>
+                        <p></p>
+                        <br />
+                        <pre class="prettyprint language-html prettyprinted" data-type="patch"><code><span class="pln">/boards-and-blocks</span></code></pre>
+                        <p>
+                          <h3>Usage and SDK Samples</h3>
+                        </p>
+                        <ul class="nav nav-tabs nav-tabs-examples">
+                          <li class="active"><a href="#examples-Default-patchBoardsAndBlocks-0-curl">Curl</a></li>
+                          <li class=""><a href="#examples-Default-patchBoardsAndBlocks-0-java">Java</a></li>
+                          <li class=""><a href="#examples-Default-patchBoardsAndBlocks-0-android">Android</a></li>
+                          <!--<li class=""><a href="#examples-Default-patchBoardsAndBlocks-0-groovy">Groovy</a></li>-->
+                          <li class=""><a href="#examples-Default-patchBoardsAndBlocks-0-objc">Obj-C</a></li>
+                          <li class=""><a href="#examples-Default-patchBoardsAndBlocks-0-javascript">JavaScript</a></li>
+                          <!--<li class=""><a href="#examples-Default-patchBoardsAndBlocks-0-angular">Angular</a></li>-->
+                          <li class=""><a href="#examples-Default-patchBoardsAndBlocks-0-csharp">C#</a></li>
+                          <li class=""><a href="#examples-Default-patchBoardsAndBlocks-0-php">PHP</a></li>
+                          <li class=""><a href="#examples-Default-patchBoardsAndBlocks-0-perl">Perl</a></li>
+                          <li class=""><a href="#examples-Default-patchBoardsAndBlocks-0-python">Python</a></li>
+                          <li class=""><a href="#examples-Default-patchBoardsAndBlocks-0-rust">Rust</a></li>
+                        </ul>
+
+                        <div class="tab-content">
+                          <div class="tab-pane active" id="examples-Default-patchBoardsAndBlocks-0-curl">
+                            <pre class="prettyprint"><code class="language-bsh">curl -X PATCH \
+-H "Authorization: [[apiKey]]" \
+ -H "Accept: application/json" \
+ -H "Content-Type: application/json" \
+ "http://localhost/api/v2/boards-and-blocks" \
+ -d '{
+  &quot;boardIDs&quot; : [ &quot;boardIDs&quot;, &quot;boardIDs&quot; ],
+  &quot;boardPatches&quot; : [ {
+    &quot;showDescription&quot; : true,
+    &quot;updatedProperties&quot; : {
+      &quot;key&quot; : &quot;{}&quot;
+    },
+    &quot;deletedColumnCalculations&quot; : [ &quot;deletedColumnCalculations&quot;, &quot;deletedColumnCalculations&quot; ],
+    &quot;icon&quot; : &quot;icon&quot;,
+    &quot;updatedColumnCalculations&quot; : {
+      &quot;key&quot; : &quot;{}&quot;
+    },
+    &quot;deletedCardProperties&quot; : [ &quot;deletedCardProperties&quot;, &quot;deletedCardProperties&quot; ],
+    &quot;description&quot; : &quot;description&quot;,
+    &quot;updatedCardProperties&quot; : [ {
+      &quot;key&quot; : &quot;{}&quot;
+    }, {
+      &quot;key&quot; : &quot;{}&quot;
+    } ],
+    &quot;title&quot; : &quot;title&quot;,
+    &quot;type&quot; : &quot;type&quot;,
+    &quot;deletedProperties&quot; : [ &quot;deletedProperties&quot;, &quot;deletedProperties&quot; ]
+  }, {
+    &quot;showDescription&quot; : true,
+    &quot;updatedProperties&quot; : {
+      &quot;key&quot; : &quot;{}&quot;
+    },
+    &quot;deletedColumnCalculations&quot; : [ &quot;deletedColumnCalculations&quot;, &quot;deletedColumnCalculations&quot; ],
+    &quot;icon&quot; : &quot;icon&quot;,
+    &quot;updatedColumnCalculations&quot; : {
+      &quot;key&quot; : &quot;{}&quot;
+    },
+    &quot;deletedCardProperties&quot; : [ &quot;deletedCardProperties&quot;, &quot;deletedCardProperties&quot; ],
+    &quot;description&quot; : &quot;description&quot;,
+    &quot;updatedCardProperties&quot; : [ {
+      &quot;key&quot; : &quot;{}&quot;
+    }, {
+      &quot;key&quot; : &quot;{}&quot;
+    } ],
+    &quot;title&quot; : &quot;title&quot;,
+    &quot;type&quot; : &quot;type&quot;,
+    &quot;deletedProperties&quot; : [ &quot;deletedProperties&quot;, &quot;deletedProperties&quot; ]
+  } ],
+  &quot;blockIDs&quot; : [ &quot;blockIDs&quot;, &quot;blockIDs&quot; ],
+  &quot;blockPatches&quot; : [ {
+    &quot;schema&quot; : 0,
+    &quot;updatedFields&quot; : {
+      &quot;key&quot; : &quot;{}&quot;
+    },
+    &quot;boardId&quot; : &quot;boardId&quot;,
+    &quot;title&quot; : &quot;title&quot;,
+    &quot;type&quot; : &quot;type&quot;,
+    &quot;deletedFields&quot; : [ &quot;deletedFields&quot;, &quot;deletedFields&quot; ],
+    &quot;parentId&quot; : &quot;parentId&quot;
+  }, {
+    &quot;schema&quot; : 0,
+    &quot;updatedFields&quot; : {
+      &quot;key&quot; : &quot;{}&quot;
+    },
+    &quot;boardId&quot; : &quot;boardId&quot;,
+    &quot;title&quot; : &quot;title&quot;,
+    &quot;type&quot; : &quot;type&quot;,
+    &quot;deletedFields&quot; : [ &quot;deletedFields&quot;, &quot;deletedFields&quot; ],
+    &quot;parentId&quot; : &quot;parentId&quot;
+  } ]
+}'
+</code></pre>
+                          </div>
+                          <div class="tab-pane" id="examples-Default-patchBoardsAndBlocks-0-java">
+                            <pre class="prettyprint"><code class="language-java">import org.openapitools.client.*;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.model.*;
+import org.openapitools.client.api.DefaultApi;
+
+import java.io.File;
+import java.util.*;
+
+public class DefaultApiExample {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        
+        // Configure API key authorization: BearerAuth
+        ApiKeyAuth BearerAuth = (ApiKeyAuth) defaultClient.getAuthentication("BearerAuth");
+        BearerAuth.setApiKey("YOUR API KEY");
+        // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+        //BearerAuth.setApiKeyPrefix("Token");
+
+        // Create an instance of the API class
+        DefaultApi apiInstance = new DefaultApi();
+        PatchBoardsAndBlocks body = ; // PatchBoardsAndBlocks | 
+
+        try {
+            BoardsAndBlocks result = apiInstance.patchBoardsAndBlocks(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling DefaultApi#patchBoardsAndBlocks");
+            e.printStackTrace();
+        }
+    }
+}
+</code></pre>
+                          </div>
+
+                          <div class="tab-pane" id="examples-Default-patchBoardsAndBlocks-0-android">
+                            <pre class="prettyprint"><code class="language-java">import org.openapitools.client.api.DefaultApi;
+
+public class DefaultApiExample {
+    public static void main(String[] args) {
+        DefaultApi apiInstance = new DefaultApi();
+        PatchBoardsAndBlocks body = ; // PatchBoardsAndBlocks | 
+
+        try {
+            BoardsAndBlocks result = apiInstance.patchBoardsAndBlocks(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling DefaultApi#patchBoardsAndBlocks");
+            e.printStackTrace();
+        }
+    }
+}</code></pre>
+                          </div>
+  <!--
+  <div class="tab-pane" id="examples-Default-patchBoardsAndBlocks-0-groovy">
+  <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
+  </div> -->
+                            <div class="tab-pane" id="examples-Default-patchBoardsAndBlocks-0-objc">
+                              <pre class="prettyprint"><code class="language-cpp">Configuration *apiConfig = [Configuration sharedConfig];
+
+// Configure API key authorization: (authentication scheme: BearerAuth)
+[apiConfig setApiKey:@"YOUR_API_KEY" forApiKeyIdentifier:@"Authorization"];
+// Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+//[apiConfig setApiKeyPrefix:@"Bearer" forApiKeyIdentifier:@"Authorization"];
+
+
+// Create an instance of the API class
+DefaultApi *apiInstance = [[DefaultApi alloc] init];
+PatchBoardsAndBlocks *body = ; // 
+
+[apiInstance patchBoardsAndBlocksWith:body
+              completionHandler: ^(BoardsAndBlocks output, NSError* error) {
+    if (output) {
+        NSLog(@"%@", output);
+    }
+    if (error) {
+        NSLog(@"Error: %@", error);
+    }
+}];
+</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-patchBoardsAndBlocks-0-javascript">
+                              <pre class="prettyprint"><code class="language-js">var FocalboardServer = require('focalboard_server');
+var defaultClient = FocalboardServer.ApiClient.instance;
+
+// Configure API key authorization: BearerAuth
+var BearerAuth = defaultClient.authentications['BearerAuth'];
+BearerAuth.apiKey = "YOUR API KEY";
+// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+//BearerAuth.apiKeyPrefix['Authorization'] = "Token";
+
+// Create an instance of the API class
+var api = new FocalboardServer.DefaultApi()
+var body = ; // {PatchBoardsAndBlocks} 
+
+var callback = function(error, data, response) {
+  if (error) {
+    console.error(error);
+  } else {
+    console.log('API called successfully. Returned data: ' + data);
+  }
+};
+api.patchBoardsAndBlocks(body, callback);
+</code></pre>
+                            </div>
+
+                            <!--<div class="tab-pane" id="examples-Default-patchBoardsAndBlocks-0-angular">
+              <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
+            </div>-->
+                            <div class="tab-pane" id="examples-Default-patchBoardsAndBlocks-0-csharp">
+                              <pre class="prettyprint"><code class="language-cs">using System;
+using System.Diagnostics;
+using Org.OpenAPITools.Api;
+using Org.OpenAPITools.Client;
+using Org.OpenAPITools.Model;
+
+namespace Example
+{
+    public class patchBoardsAndBlocksExample
+    {
+        public void main()
+        {
+            // Configure API key authorization: BearerAuth
+            Configuration.Default.ApiKey.Add("Authorization", "YOUR_API_KEY");
+            // Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+            // Configuration.Default.ApiKeyPrefix.Add("Authorization", "Bearer");
+
+            // Create an instance of the API class
+            var apiInstance = new DefaultApi();
+            var body = new PatchBoardsAndBlocks(); // PatchBoardsAndBlocks | 
+
+            try {
+                BoardsAndBlocks result = apiInstance.patchBoardsAndBlocks(body);
+                Debug.WriteLine(result);
+            } catch (Exception e) {
+                Debug.Print("Exception when calling DefaultApi.patchBoardsAndBlocks: " + e.Message );
+            }
+        }
+    }
+}
+</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-patchBoardsAndBlocks-0-php">
+                              <pre class="prettyprint"><code class="language-php"><&#63;php
+require_once(__DIR__ . '/vendor/autoload.php');
+
+// Configure API key authorization: BearerAuth
+OpenAPITools\Client\Configuration::getDefaultConfiguration()->setApiKey('Authorization', 'YOUR_API_KEY');
+// Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+// OpenAPITools\Client\Configuration::getDefaultConfiguration()->setApiKeyPrefix('Authorization', 'Bearer');
+
+// Create an instance of the API class
+$api_instance = new OpenAPITools\Client\Api\DefaultApi();
+$body = ; // PatchBoardsAndBlocks | 
+
+try {
+    $result = $api_instance->patchBoardsAndBlocks($body);
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling DefaultApi->patchBoardsAndBlocks: ', $e->getMessage(), PHP_EOL;
+}
+?></code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-patchBoardsAndBlocks-0-perl">
+                              <pre class="prettyprint"><code class="language-perl">use Data::Dumper;
+use WWW::OPenAPIClient::Configuration;
+use WWW::OPenAPIClient::DefaultApi;
+
+# Configure API key authorization: BearerAuth
+$WWW::OPenAPIClient::Configuration::api_key->{'Authorization'} = 'YOUR_API_KEY';
+# uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+#$WWW::OPenAPIClient::Configuration::api_key_prefix->{'Authorization'} = "Bearer";
+
+# Create an instance of the API class
+my $api_instance = WWW::OPenAPIClient::DefaultApi->new();
+my $body = WWW::OPenAPIClient::Object::PatchBoardsAndBlocks->new(); # PatchBoardsAndBlocks | 
+
+eval {
+    my $result = $api_instance->patchBoardsAndBlocks(body => $body);
+    print Dumper($result);
+};
+if ($@) {
+    warn "Exception when calling DefaultApi->patchBoardsAndBlocks: $@\n";
+}</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-patchBoardsAndBlocks-0-python">
+                              <pre class="prettyprint"><code class="language-python">from __future__ import print_statement
+import time
+import openapi_client
+from openapi_client.rest import ApiException
+from pprint import pprint
+
+# Configure API key authorization: BearerAuth
+openapi_client.configuration.api_key['Authorization'] = 'YOUR_API_KEY'
+# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+# openapi_client.configuration.api_key_prefix['Authorization'] = 'Bearer'
+
+# Create an instance of the API class
+api_instance = openapi_client.DefaultApi()
+body =  # PatchBoardsAndBlocks | 
+
+try:
+    api_response = api_instance.patch_boards_and_blocks(body)
+    pprint(api_response)
+except ApiException as e:
+    print("Exception when calling DefaultApi->patchBoardsAndBlocks: %s\n" % e)</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-patchBoardsAndBlocks-0-rust">
+                              <pre class="prettyprint"><code class="language-rust">extern crate DefaultApi;
+
+pub fn main() {
+    let body = ; // PatchBoardsAndBlocks
+
+    let mut context = DefaultApi::Context::default();
+    let result = client.patchBoardsAndBlocks(body, &context).wait();
+
+    println!("{:?}", result);
+}
+</code></pre>
+                            </div>
+                          </div>
+
+                          <h2>Scopes</h2>
+                          <table>
+                            
+                          </table>
+
+                          <h2>Parameters</h2>
+
+
+
+                            <div class="methodsubtabletitle">Body parameters</div>
+                            <table id="methodsubtable">
+                              <tr>
+                                <th width="150px">Name</th>
+                                <th>Description</th>
+                              </tr>
+                                <tr><td style="width:150px;">body <span style="color:red;">*</span></td>
+<td>
+<p class="marked">the patches for the boards and blocks</p>
+<script>
+$(document).ready(function() {
+  var schemaWrapper = {
+  "description" : "the patches for the boards and blocks",
+  "content" : {
+    "application/json" : {
+      "schema" : {
+        "$ref" : "#/components/schemas/PatchBoardsAndBlocks"
+      }
+    }
+  },
+  "required" : true
+};
+
+  var schema = findNode('schema',schemaWrapper).schema;
+  if (!schema) {
+    schema = schemaWrapper.schema;
+  }
+  if (schema.$ref != null) {
+    schema = defsParser.$refs.get(schema.$ref);
+  } else {
+    schemaWrapper.definitions = Object.assign({}, defs);
+    $RefParser.dereference(schemaWrapper).catch(function(err) {
+      console.log(err);
+    });
+  }
+
+  var view = new JSONSchemaView(schema,2,{isBodyParam: true});
+  var result = $('#d2e199_patchBoardsAndBlocks_body');
+  result.empty();
+  result.append(view.render());
+});
+</script>
+<div id="d2e199_patchBoardsAndBlocks_body"></div>
+</td>
+</tr>
+
+                            </table>
+
+
+
+                          <h2>Responses</h2>
+                            <h3 id="examples-Default-patchBoardsAndBlocks-title-200"></h3>
+                            <p id="examples-Default-patchBoardsAndBlocks-description-200" class="marked"></p>
+                            <script>
+                              var responseDefault200_description = `success`;
+                              var responseDefault200_description_break = responseDefault200_description.indexOf('\n');
+                              if (responseDefault200_description_break == -1) {
+                                $("#examples-Default-patchBoardsAndBlocks-title-200").text("Status: 200 - " + responseDefault200_description);
+                              } else {
+                                $("#examples-Default-patchBoardsAndBlocks-title-200").text("Status: 200 - " + responseDefault200_description.substring(0, responseDefault200_description_break));
+                                $("#examples-Default-patchBoardsAndBlocks-description-200").html(responseDefault200_description.substring(responseDefault200_description_break));
+                              }
+                            </script>
+
+
+                            <ul id="responses-detail-Default-patchBoardsAndBlocks-200" class="nav nav-tabs nav-tabs-examples" >
+                                <li class="active">
+                                  <a data-toggle="tab" href="#responses-Default-patchBoardsAndBlocks-200-schema">Schema</a>
+                                </li>
+
+
+
+
+                            </ul>
+
+
+                            <div class="tab-content" id="responses-Default-patchBoardsAndBlocks-200-wrapper" style='margin-bottom: 10px;'>
+                                <div class="tab-pane active" id="responses-Default-patchBoardsAndBlocks-200-schema">
+                                  <div id="responses-Default-patchBoardsAndBlocks-schema-200" class="exampleStyle">
+                                    <script>
+                                      $(document).ready(function() {
+                                        var schemaWrapper = {
+  "description" : "success",
+  "content" : {
+    "application/json" : {
+      "schema" : {
+        "$ref" : "#/components/schemas/BoardsAndBlocks"
+      }
+    }
+  }
+};
+                                        var schema = findNode('schema',schemaWrapper).schema;
+                                        if (!schema) {
+                                          schema = schemaWrapper.schema;
+                                        }
+                                        if (schema.$ref != null) {
+                                          schema = defsParser.$refs.get(schema.$ref);
+                                        } else if (schema.items != null && schema.items.$ref != null) {
+                                            schema.items = defsParser.$refs.get(schema.items.$ref);
+                                        } else {
+                                          schemaWrapper.definitions = Object.assign({}, defs);
+                                          $RefParser.dereference(schemaWrapper).catch(function(err) {
+                                            console.log(err);
+                                          });
+                                        }
+
+                                        var view = new JSONSchemaView(schema, 3);
+                                        $('#responses-Default-patchBoardsAndBlocks-200-schema-data').val(JSON.stringify(schema));
+                                        var result = $('#responses-Default-patchBoardsAndBlocks-schema-200');
+                                        result.empty();
+                                        result.append(view.render());
+                                      });
+                                    </script>
+                                  </div>
+                                  <input id='responses-Default-patchBoardsAndBlocks-200-schema-data' type='hidden' value=''></input>
+                                </div>
+                            </div>
+                            <h3 id="examples-Default-patchBoardsAndBlocks-title-default"></h3>
+                            <p id="examples-Default-patchBoardsAndBlocks-description-default" class="marked"></p>
+                            <script>
+                              var responseDefaultdefault_description = `internal error`;
+                              var responseDefaultdefault_description_break = responseDefaultdefault_description.indexOf('\n');
+                              if (responseDefaultdefault_description_break == -1) {
+                                $("#examples-Default-patchBoardsAndBlocks-title-default").text("Status: default - " + responseDefaultdefault_description);
+                              } else {
+                                $("#examples-Default-patchBoardsAndBlocks-title-default").text("Status: default - " + responseDefaultdefault_description.substring(0, responseDefaultdefault_description_break));
+                                $("#examples-Default-patchBoardsAndBlocks-description-default").html(responseDefaultdefault_description.substring(responseDefaultdefault_description_break));
+                              }
+                            </script>
+
+
+                            <ul id="responses-detail-Default-patchBoardsAndBlocks-default" class="nav nav-tabs nav-tabs-examples" >
+                                <li class="active">
+                                  <a data-toggle="tab" href="#responses-Default-patchBoardsAndBlocks-default-schema">Schema</a>
+                                </li>
+
+
+
+
+                            </ul>
+
+
+                            <div class="tab-content" id="responses-Default-patchBoardsAndBlocks-default-wrapper" style='margin-bottom: 10px;'>
+                                <div class="tab-pane active" id="responses-Default-patchBoardsAndBlocks-default-schema">
+                                  <div id="responses-Default-patchBoardsAndBlocks-schema-default" class="exampleStyle">
+                                    <script>
+                                      $(document).ready(function() {
+                                        var schemaWrapper = {
+  "description" : "internal error",
+  "content" : {
+    "application/json" : {
+      "schema" : {
+        "$ref" : "#/components/schemas/ErrorResponse"
+      }
+    }
+  }
+};
+                                        var schema = findNode('schema',schemaWrapper).schema;
+                                        if (!schema) {
+                                          schema = schemaWrapper.schema;
+                                        }
+                                        if (schema.$ref != null) {
+                                          schema = defsParser.$refs.get(schema.$ref);
+                                        } else if (schema.items != null && schema.items.$ref != null) {
+                                            schema.items = defsParser.$refs.get(schema.items.$ref);
+                                        } else {
+                                          schemaWrapper.definitions = Object.assign({}, defs);
+                                          $RefParser.dereference(schemaWrapper).catch(function(err) {
+                                            console.log(err);
+                                          });
+                                        }
+
+                                        var view = new JSONSchemaView(schema, 3);
+                                        $('#responses-Default-patchBoardsAndBlocks-default-schema-data').val(JSON.stringify(schema));
+                                        var result = $('#responses-Default-patchBoardsAndBlocks-schema-default');
+                                        result.empty();
+                                        result.append(view.render());
+                                      });
+                                    </script>
+                                  </div>
+                                  <input id='responses-Default-patchBoardsAndBlocks-default-schema-data' type='hidden' value=''></input>
+                                </div>
+                            </div>
+                        </article>
+                      </div>
+                      <hr>
                     <div id="api-Default-postSharing">
                       <article id="api-Default-postSharing-0" data-group="User" data-name="postSharing" data-version="0">
                         <div class="pull-left">
@@ -10341,10 +19471,10 @@ $(document).ready(function() {
                         <div class="pull-right"></div>
                         <div class="clearfix"></div>
                         <p></p>
-                        <p class="marked">Sets sharing information for a root block</p>
+                        <p class="marked">Sets sharing information for a board</p>
                         <p></p>
                         <br />
-                        <pre class="prettyprint language-html prettyprinted" data-type="post"><code><span class="pln">/api/v1/workspaces/{workspaceID}/sharing/{rootID}</span></code></pre>
+                        <pre class="prettyprint language-html prettyprinted" data-type="post"><code><span class="pln">/boards/{boardID}/sharing</span></code></pre>
                         <p>
                           <h3>Usage and SDK Samples</h3>
                         </p>
@@ -10369,7 +19499,7 @@ $(document).ready(function() {
 -H "Authorization: [[apiKey]]" \
  -H "Accept: application/json" \
  -H "Content-Type: application/json" \
- "http://localhost/api/v1/api/v1/workspaces/{workspaceID}/sharing/{rootID}" \
+ "http://localhost/api/v2/boards/{boardID}/sharing" \
  -d '{
   &quot;update_at&quot; : 0,
   &quot;modifiedBy&quot; : &quot;modifiedBy&quot;,
@@ -10400,12 +19530,11 @@ public class DefaultApiExample {
 
         // Create an instance of the API class
         DefaultApi apiInstance = new DefaultApi();
-        String workspaceID = workspaceID_example; // String | Workspace ID
-        String rootID = rootID_example; // String | ID of the root block
+        String boardID = boardID_example; // String | Board ID
         Sharing body = ; // Sharing | 
 
         try {
-            apiInstance.postSharing(workspaceID, rootID, body);
+            apiInstance.postSharing(boardID, body);
         } catch (ApiException e) {
             System.err.println("Exception when calling DefaultApi#postSharing");
             e.printStackTrace();
@@ -10421,12 +19550,11 @@ public class DefaultApiExample {
 public class DefaultApiExample {
     public static void main(String[] args) {
         DefaultApi apiInstance = new DefaultApi();
-        String workspaceID = workspaceID_example; // String | Workspace ID
-        String rootID = rootID_example; // String | ID of the root block
+        String boardID = boardID_example; // String | Board ID
         Sharing body = ; // Sharing | 
 
         try {
-            apiInstance.postSharing(workspaceID, rootID, body);
+            apiInstance.postSharing(boardID, body);
         } catch (ApiException e) {
             System.err.println("Exception when calling DefaultApi#postSharing");
             e.printStackTrace();
@@ -10449,12 +19577,10 @@ public class DefaultApiExample {
 
 // Create an instance of the API class
 DefaultApi *apiInstance = [[DefaultApi alloc] init];
-String *workspaceID = workspaceID_example; // Workspace ID (default to null)
-String *rootID = rootID_example; // ID of the root block (default to null)
+String *boardID = boardID_example; // Board ID (default to null)
 Sharing *body = ; // 
 
-[apiInstance postSharingWith:workspaceID
-    rootID:rootID
+[apiInstance postSharingWith:boardID
     body:body
               completionHandler: ^(NSError* error) {
     if (error) {
@@ -10476,8 +19602,7 @@ BearerAuth.apiKey = "YOUR API KEY";
 
 // Create an instance of the API class
 var api = new FocalboardServer.DefaultApi()
-var workspaceID = workspaceID_example; // {String} Workspace ID
-var rootID = rootID_example; // {String} ID of the root block
+var boardID = boardID_example; // {String} Board ID
 var body = ; // {Sharing} 
 
 var callback = function(error, data, response) {
@@ -10487,7 +19612,7 @@ var callback = function(error, data, response) {
     console.log('API called successfully.');
   }
 };
-api.postSharing(workspaceID, rootID, body, callback);
+api.postSharing(boardID, body, callback);
 </code></pre>
                             </div>
 
@@ -10514,12 +19639,11 @@ namespace Example
 
             // Create an instance of the API class
             var apiInstance = new DefaultApi();
-            var workspaceID = workspaceID_example;  // String | Workspace ID (default to null)
-            var rootID = rootID_example;  // String | ID of the root block (default to null)
+            var boardID = boardID_example;  // String | Board ID (default to null)
             var body = new Sharing(); // Sharing | 
 
             try {
-                apiInstance.postSharing(workspaceID, rootID, body);
+                apiInstance.postSharing(boardID, body);
             } catch (Exception e) {
                 Debug.Print("Exception when calling DefaultApi.postSharing: " + e.Message );
             }
@@ -10540,12 +19664,11 @@ OpenAPITools\Client\Configuration::getDefaultConfiguration()->setApiKey('Authori
 
 // Create an instance of the API class
 $api_instance = new OpenAPITools\Client\Api\DefaultApi();
-$workspaceID = workspaceID_example; // String | Workspace ID
-$rootID = rootID_example; // String | ID of the root block
+$boardID = boardID_example; // String | Board ID
 $body = ; // Sharing | 
 
 try {
-    $api_instance->postSharing($workspaceID, $rootID, $body);
+    $api_instance->postSharing($boardID, $body);
 } catch (Exception $e) {
     echo 'Exception when calling DefaultApi->postSharing: ', $e->getMessage(), PHP_EOL;
 }
@@ -10564,12 +19687,11 @@ $WWW::OPenAPIClient::Configuration::api_key->{'Authorization'} = 'YOUR_API_KEY';
 
 # Create an instance of the API class
 my $api_instance = WWW::OPenAPIClient::DefaultApi->new();
-my $workspaceID = workspaceID_example; # String | Workspace ID
-my $rootID = rootID_example; # String | ID of the root block
+my $boardID = boardID_example; # String | Board ID
 my $body = WWW::OPenAPIClient::Object::Sharing->new(); # Sharing | 
 
 eval {
-    $api_instance->postSharing(workspaceID => $workspaceID, rootID => $rootID, body => $body);
+    $api_instance->postSharing(boardID => $boardID, body => $body);
 };
 if ($@) {
     warn "Exception when calling DefaultApi->postSharing: $@\n";
@@ -10590,12 +19712,11 @@ openapi_client.configuration.api_key['Authorization'] = 'YOUR_API_KEY'
 
 # Create an instance of the API class
 api_instance = openapi_client.DefaultApi()
-workspaceID = workspaceID_example # String | Workspace ID (default to null)
-rootID = rootID_example # String | ID of the root block (default to null)
+boardID = boardID_example # String | Board ID (default to null)
 body =  # Sharing | 
 
 try:
-    api_instance.post_sharing(workspaceID, rootID, body)
+    api_instance.post_sharing(boardID, body)
 except ApiException as e:
     print("Exception when calling DefaultApi->postSharing: %s\n" % e)</code></pre>
                             </div>
@@ -10604,12 +19725,11 @@ except ApiException as e:
                               <pre class="prettyprint"><code class="language-rust">extern crate DefaultApi;
 
 pub fn main() {
-    let workspaceID = workspaceID_example; // String
-    let rootID = rootID_example; // String
+    let boardID = boardID_example; // String
     let body = ; // Sharing
 
     let mut context = DefaultApi::Context::default();
-    let result = client.postSharing(workspaceID, rootID, body, &context).wait();
+    let result = client.postSharing(boardID, body, &context).wait();
 
     println!("{:?}", result);
 }
@@ -10630,11 +19750,11 @@ pub fn main() {
                                   <th width="150px">Name</th>
                                   <th>Description</th>
                                 </tr>
-                                  <tr><td style="width:150px;">workspaceID*</td>
+                                  <tr><td style="width:150px;">boardID*</td>
 <td>
 
 
-    <div id="d2e199_postSharing_workspaceID">
+    <div id="d2e199_postSharing_boardID">
         <div class="json-schema-view">
             <div class="primitive">
                 <span class="type">
@@ -10642,30 +19762,7 @@ pub fn main() {
                 </span>
 
                     <div class="inner description marked">
-Workspace ID
-                    </div>
-            </div>
-                <div class="inner required">
-                    Required
-                </div>
-        </div>
-    </div>
-</td>
-</tr>
-
-                                  <tr><td style="width:150px;">rootID*</td>
-<td>
-
-
-    <div id="d2e199_postSharing_rootID">
-        <div class="json-schema-view">
-            <div class="primitive">
-                <span class="type">
-                    String
-                </span>
-
-                    <div class="inner description marked">
-ID of the root block
+Board ID
                     </div>
             </div>
                 <div class="inner required">
@@ -10830,10 +19927,10 @@ $(document).ready(function() {
                         <div class="pull-right"></div>
                         <div class="clearfix"></div>
                         <p></p>
-                        <p class="marked">Regenerates the signup token for the root workspace</p>
+                        <p class="marked">Regenerates the signup token for the root team</p>
                         <p></p>
                         <br />
-                        <pre class="prettyprint language-html prettyprinted" data-type="post"><code><span class="pln">/api/v1/workspaces/{workspaceID}/regenerate_signup_token</span></code></pre>
+                        <pre class="prettyprint language-html prettyprinted" data-type="post"><code><span class="pln">/teams/{teamID}/regenerate_signup_token</span></code></pre>
                         <p>
                           <h3>Usage and SDK Samples</h3>
                         </p>
@@ -10857,7 +19954,7 @@ $(document).ready(function() {
                             <pre class="prettyprint"><code class="language-bsh">curl -X POST \
 -H "Authorization: [[apiKey]]" \
  -H "Accept: application/json" \
- "http://localhost/api/v1/api/v1/workspaces/{workspaceID}/regenerate_signup_token"
+ "http://localhost/api/v2/teams/{teamID}/regenerate_signup_token"
 </code></pre>
                           </div>
                           <div class="tab-pane" id="examples-Default-regenerateSignupToken-0-java">
@@ -10881,10 +19978,10 @@ public class DefaultApiExample {
 
         // Create an instance of the API class
         DefaultApi apiInstance = new DefaultApi();
-        String workspaceID = workspaceID_example; // String | Workspace ID
+        String teamID = teamID_example; // String | Team ID
 
         try {
-            apiInstance.regenerateSignupToken(workspaceID);
+            apiInstance.regenerateSignupToken(teamID);
         } catch (ApiException e) {
             System.err.println("Exception when calling DefaultApi#regenerateSignupToken");
             e.printStackTrace();
@@ -10900,10 +19997,10 @@ public class DefaultApiExample {
 public class DefaultApiExample {
     public static void main(String[] args) {
         DefaultApi apiInstance = new DefaultApi();
-        String workspaceID = workspaceID_example; // String | Workspace ID
+        String teamID = teamID_example; // String | Team ID
 
         try {
-            apiInstance.regenerateSignupToken(workspaceID);
+            apiInstance.regenerateSignupToken(teamID);
         } catch (ApiException e) {
             System.err.println("Exception when calling DefaultApi#regenerateSignupToken");
             e.printStackTrace();
@@ -10926,9 +20023,9 @@ public class DefaultApiExample {
 
 // Create an instance of the API class
 DefaultApi *apiInstance = [[DefaultApi alloc] init];
-String *workspaceID = workspaceID_example; // Workspace ID (default to null)
+String *teamID = teamID_example; // Team ID (default to null)
 
-[apiInstance regenerateSignupTokenWith:workspaceID
+[apiInstance regenerateSignupTokenWith:teamID
               completionHandler: ^(NSError* error) {
     if (error) {
         NSLog(@"Error: %@", error);
@@ -10949,7 +20046,7 @@ BearerAuth.apiKey = "YOUR API KEY";
 
 // Create an instance of the API class
 var api = new FocalboardServer.DefaultApi()
-var workspaceID = workspaceID_example; // {String} Workspace ID
+var teamID = teamID_example; // {String} Team ID
 
 var callback = function(error, data, response) {
   if (error) {
@@ -10958,7 +20055,7 @@ var callback = function(error, data, response) {
     console.log('API called successfully.');
   }
 };
-api.regenerateSignupToken(workspaceID, callback);
+api.regenerateSignupToken(teamID, callback);
 </code></pre>
                             </div>
 
@@ -10985,10 +20082,10 @@ namespace Example
 
             // Create an instance of the API class
             var apiInstance = new DefaultApi();
-            var workspaceID = workspaceID_example;  // String | Workspace ID (default to null)
+            var teamID = teamID_example;  // String | Team ID (default to null)
 
             try {
-                apiInstance.regenerateSignupToken(workspaceID);
+                apiInstance.regenerateSignupToken(teamID);
             } catch (Exception e) {
                 Debug.Print("Exception when calling DefaultApi.regenerateSignupToken: " + e.Message );
             }
@@ -11009,10 +20106,10 @@ OpenAPITools\Client\Configuration::getDefaultConfiguration()->setApiKey('Authori
 
 // Create an instance of the API class
 $api_instance = new OpenAPITools\Client\Api\DefaultApi();
-$workspaceID = workspaceID_example; // String | Workspace ID
+$teamID = teamID_example; // String | Team ID
 
 try {
-    $api_instance->regenerateSignupToken($workspaceID);
+    $api_instance->regenerateSignupToken($teamID);
 } catch (Exception $e) {
     echo 'Exception when calling DefaultApi->regenerateSignupToken: ', $e->getMessage(), PHP_EOL;
 }
@@ -11031,10 +20128,10 @@ $WWW::OPenAPIClient::Configuration::api_key->{'Authorization'} = 'YOUR_API_KEY';
 
 # Create an instance of the API class
 my $api_instance = WWW::OPenAPIClient::DefaultApi->new();
-my $workspaceID = workspaceID_example; # String | Workspace ID
+my $teamID = teamID_example; # String | Team ID
 
 eval {
-    $api_instance->regenerateSignupToken(workspaceID => $workspaceID);
+    $api_instance->regenerateSignupToken(teamID => $teamID);
 };
 if ($@) {
     warn "Exception when calling DefaultApi->regenerateSignupToken: $@\n";
@@ -11055,10 +20152,10 @@ openapi_client.configuration.api_key['Authorization'] = 'YOUR_API_KEY'
 
 # Create an instance of the API class
 api_instance = openapi_client.DefaultApi()
-workspaceID = workspaceID_example # String | Workspace ID (default to null)
+teamID = teamID_example # String | Team ID (default to null)
 
 try:
-    api_instance.regenerate_signup_token(workspaceID)
+    api_instance.regenerate_signup_token(teamID)
 except ApiException as e:
     print("Exception when calling DefaultApi->regenerateSignupToken: %s\n" % e)</code></pre>
                             </div>
@@ -11067,10 +20164,10 @@ except ApiException as e:
                               <pre class="prettyprint"><code class="language-rust">extern crate DefaultApi;
 
 pub fn main() {
-    let workspaceID = workspaceID_example; // String
+    let teamID = teamID_example; // String
 
     let mut context = DefaultApi::Context::default();
-    let result = client.regenerateSignupToken(workspaceID, &context).wait();
+    let result = client.regenerateSignupToken(teamID, &context).wait();
 
     println!("{:?}", result);
 }
@@ -11091,11 +20188,11 @@ pub fn main() {
                                   <th width="150px">Name</th>
                                   <th>Description</th>
                                 </tr>
-                                  <tr><td style="width:150px;">workspaceID*</td>
+                                  <tr><td style="width:150px;">teamID*</td>
 <td>
 
 
-    <div id="d2e199_regenerateSignupToken_workspaceID">
+    <div id="d2e199_regenerateSignupToken_teamID">
         <div class="json-schema-view">
             <div class="primitive">
                 <span class="type">
@@ -11103,7 +20200,7 @@ pub fn main() {
                 </span>
 
                     <div class="inner description marked">
-Workspace ID
+Team ID
                     </div>
             </div>
                 <div class="inner required">
@@ -11224,7 +20321,7 @@ Workspace ID
                         <p class="marked">Register new user</p>
                         <p></p>
                         <br />
-                        <pre class="prettyprint language-html prettyprinted" data-type="post"><code><span class="pln">/api/v1/register</span></code></pre>
+                        <pre class="prettyprint language-html prettyprinted" data-type="post"><code><span class="pln">/register</span></code></pre>
                         <p>
                           <h3>Usage and SDK Samples</h3>
                         </p>
@@ -11248,7 +20345,7 @@ Workspace ID
                             <pre class="prettyprint"><code class="language-bsh">curl -X POST \
  -H "Accept: application/json" \
  -H "Content-Type: application/json" \
- "http://localhost/api/v1/api/v1/register" \
+ "http://localhost/api/v2/register" \
  -d '{
   &quot;password&quot; : &quot;password&quot;,
   &quot;email&quot; : &quot;email&quot;,
@@ -11609,6 +20706,1383 @@ $(document).ready(function() {
                         </article>
                       </div>
                       <hr>
+                    <div id="api-Default-searchBoards">
+                      <article id="api-Default-searchBoards-0" data-group="User" data-name="searchBoards" data-version="0">
+                        <div class="pull-left">
+                          <h1>searchBoards</h1>
+                          <p></p>
+                        </div>
+                        <div class="pull-right"></div>
+                        <div class="clearfix"></div>
+                        <p></p>
+                        <p class="marked">Returns the boards that match with a search term</p>
+                        <p></p>
+                        <br />
+                        <pre class="prettyprint language-html prettyprinted" data-type="get"><code><span class="pln">/teams/{teamID}/boards/search</span></code></pre>
+                        <p>
+                          <h3>Usage and SDK Samples</h3>
+                        </p>
+                        <ul class="nav nav-tabs nav-tabs-examples">
+                          <li class="active"><a href="#examples-Default-searchBoards-0-curl">Curl</a></li>
+                          <li class=""><a href="#examples-Default-searchBoards-0-java">Java</a></li>
+                          <li class=""><a href="#examples-Default-searchBoards-0-android">Android</a></li>
+                          <!--<li class=""><a href="#examples-Default-searchBoards-0-groovy">Groovy</a></li>-->
+                          <li class=""><a href="#examples-Default-searchBoards-0-objc">Obj-C</a></li>
+                          <li class=""><a href="#examples-Default-searchBoards-0-javascript">JavaScript</a></li>
+                          <!--<li class=""><a href="#examples-Default-searchBoards-0-angular">Angular</a></li>-->
+                          <li class=""><a href="#examples-Default-searchBoards-0-csharp">C#</a></li>
+                          <li class=""><a href="#examples-Default-searchBoards-0-php">PHP</a></li>
+                          <li class=""><a href="#examples-Default-searchBoards-0-perl">Perl</a></li>
+                          <li class=""><a href="#examples-Default-searchBoards-0-python">Python</a></li>
+                          <li class=""><a href="#examples-Default-searchBoards-0-rust">Rust</a></li>
+                        </ul>
+
+                        <div class="tab-content">
+                          <div class="tab-pane active" id="examples-Default-searchBoards-0-curl">
+                            <pre class="prettyprint"><code class="language-bsh">curl -X GET \
+-H "Authorization: [[apiKey]]" \
+ -H "Accept: application/json" \
+ "http://localhost/api/v2/teams/{teamID}/boards/search?q=q_example"
+</code></pre>
+                          </div>
+                          <div class="tab-pane" id="examples-Default-searchBoards-0-java">
+                            <pre class="prettyprint"><code class="language-java">import org.openapitools.client.*;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.model.*;
+import org.openapitools.client.api.DefaultApi;
+
+import java.io.File;
+import java.util.*;
+
+public class DefaultApiExample {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        
+        // Configure API key authorization: BearerAuth
+        ApiKeyAuth BearerAuth = (ApiKeyAuth) defaultClient.getAuthentication("BearerAuth");
+        BearerAuth.setApiKey("YOUR API KEY");
+        // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+        //BearerAuth.setApiKeyPrefix("Token");
+
+        // Create an instance of the API class
+        DefaultApi apiInstance = new DefaultApi();
+        String teamID = teamID_example; // String | Team ID
+        String q = q_example; // String | The search term. Must have at least one character
+
+        try {
+            array[Board] result = apiInstance.searchBoards(teamID, q);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling DefaultApi#searchBoards");
+            e.printStackTrace();
+        }
+    }
+}
+</code></pre>
+                          </div>
+
+                          <div class="tab-pane" id="examples-Default-searchBoards-0-android">
+                            <pre class="prettyprint"><code class="language-java">import org.openapitools.client.api.DefaultApi;
+
+public class DefaultApiExample {
+    public static void main(String[] args) {
+        DefaultApi apiInstance = new DefaultApi();
+        String teamID = teamID_example; // String | Team ID
+        String q = q_example; // String | The search term. Must have at least one character
+
+        try {
+            array[Board] result = apiInstance.searchBoards(teamID, q);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling DefaultApi#searchBoards");
+            e.printStackTrace();
+        }
+    }
+}</code></pre>
+                          </div>
+  <!--
+  <div class="tab-pane" id="examples-Default-searchBoards-0-groovy">
+  <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
+  </div> -->
+                            <div class="tab-pane" id="examples-Default-searchBoards-0-objc">
+                              <pre class="prettyprint"><code class="language-cpp">Configuration *apiConfig = [Configuration sharedConfig];
+
+// Configure API key authorization: (authentication scheme: BearerAuth)
+[apiConfig setApiKey:@"YOUR_API_KEY" forApiKeyIdentifier:@"Authorization"];
+// Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+//[apiConfig setApiKeyPrefix:@"Bearer" forApiKeyIdentifier:@"Authorization"];
+
+
+// Create an instance of the API class
+DefaultApi *apiInstance = [[DefaultApi alloc] init];
+String *teamID = teamID_example; // Team ID (default to null)
+String *q = q_example; // The search term. Must have at least one character (default to null)
+
+[apiInstance searchBoardsWith:teamID
+    q:q
+              completionHandler: ^(array[Board] output, NSError* error) {
+    if (output) {
+        NSLog(@"%@", output);
+    }
+    if (error) {
+        NSLog(@"Error: %@", error);
+    }
+}];
+</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-searchBoards-0-javascript">
+                              <pre class="prettyprint"><code class="language-js">var FocalboardServer = require('focalboard_server');
+var defaultClient = FocalboardServer.ApiClient.instance;
+
+// Configure API key authorization: BearerAuth
+var BearerAuth = defaultClient.authentications['BearerAuth'];
+BearerAuth.apiKey = "YOUR API KEY";
+// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+//BearerAuth.apiKeyPrefix['Authorization'] = "Token";
+
+// Create an instance of the API class
+var api = new FocalboardServer.DefaultApi()
+var teamID = teamID_example; // {String} Team ID
+var q = q_example; // {String} The search term. Must have at least one character
+
+var callback = function(error, data, response) {
+  if (error) {
+    console.error(error);
+  } else {
+    console.log('API called successfully. Returned data: ' + data);
+  }
+};
+api.searchBoards(teamID, q, callback);
+</code></pre>
+                            </div>
+
+                            <!--<div class="tab-pane" id="examples-Default-searchBoards-0-angular">
+              <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
+            </div>-->
+                            <div class="tab-pane" id="examples-Default-searchBoards-0-csharp">
+                              <pre class="prettyprint"><code class="language-cs">using System;
+using System.Diagnostics;
+using Org.OpenAPITools.Api;
+using Org.OpenAPITools.Client;
+using Org.OpenAPITools.Model;
+
+namespace Example
+{
+    public class searchBoardsExample
+    {
+        public void main()
+        {
+            // Configure API key authorization: BearerAuth
+            Configuration.Default.ApiKey.Add("Authorization", "YOUR_API_KEY");
+            // Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+            // Configuration.Default.ApiKeyPrefix.Add("Authorization", "Bearer");
+
+            // Create an instance of the API class
+            var apiInstance = new DefaultApi();
+            var teamID = teamID_example;  // String | Team ID (default to null)
+            var q = q_example;  // String | The search term. Must have at least one character (default to null)
+
+            try {
+                array[Board] result = apiInstance.searchBoards(teamID, q);
+                Debug.WriteLine(result);
+            } catch (Exception e) {
+                Debug.Print("Exception when calling DefaultApi.searchBoards: " + e.Message );
+            }
+        }
+    }
+}
+</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-searchBoards-0-php">
+                              <pre class="prettyprint"><code class="language-php"><&#63;php
+require_once(__DIR__ . '/vendor/autoload.php');
+
+// Configure API key authorization: BearerAuth
+OpenAPITools\Client\Configuration::getDefaultConfiguration()->setApiKey('Authorization', 'YOUR_API_KEY');
+// Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+// OpenAPITools\Client\Configuration::getDefaultConfiguration()->setApiKeyPrefix('Authorization', 'Bearer');
+
+// Create an instance of the API class
+$api_instance = new OpenAPITools\Client\Api\DefaultApi();
+$teamID = teamID_example; // String | Team ID
+$q = q_example; // String | The search term. Must have at least one character
+
+try {
+    $result = $api_instance->searchBoards($teamID, $q);
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling DefaultApi->searchBoards: ', $e->getMessage(), PHP_EOL;
+}
+?></code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-searchBoards-0-perl">
+                              <pre class="prettyprint"><code class="language-perl">use Data::Dumper;
+use WWW::OPenAPIClient::Configuration;
+use WWW::OPenAPIClient::DefaultApi;
+
+# Configure API key authorization: BearerAuth
+$WWW::OPenAPIClient::Configuration::api_key->{'Authorization'} = 'YOUR_API_KEY';
+# uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+#$WWW::OPenAPIClient::Configuration::api_key_prefix->{'Authorization'} = "Bearer";
+
+# Create an instance of the API class
+my $api_instance = WWW::OPenAPIClient::DefaultApi->new();
+my $teamID = teamID_example; # String | Team ID
+my $q = q_example; # String | The search term. Must have at least one character
+
+eval {
+    my $result = $api_instance->searchBoards(teamID => $teamID, q => $q);
+    print Dumper($result);
+};
+if ($@) {
+    warn "Exception when calling DefaultApi->searchBoards: $@\n";
+}</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-searchBoards-0-python">
+                              <pre class="prettyprint"><code class="language-python">from __future__ import print_statement
+import time
+import openapi_client
+from openapi_client.rest import ApiException
+from pprint import pprint
+
+# Configure API key authorization: BearerAuth
+openapi_client.configuration.api_key['Authorization'] = 'YOUR_API_KEY'
+# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+# openapi_client.configuration.api_key_prefix['Authorization'] = 'Bearer'
+
+# Create an instance of the API class
+api_instance = openapi_client.DefaultApi()
+teamID = teamID_example # String | Team ID (default to null)
+q = q_example # String | The search term. Must have at least one character (default to null)
+
+try:
+    api_response = api_instance.search_boards(teamID, q)
+    pprint(api_response)
+except ApiException as e:
+    print("Exception when calling DefaultApi->searchBoards: %s\n" % e)</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-searchBoards-0-rust">
+                              <pre class="prettyprint"><code class="language-rust">extern crate DefaultApi;
+
+pub fn main() {
+    let teamID = teamID_example; // String
+    let q = q_example; // String
+
+    let mut context = DefaultApi::Context::default();
+    let result = client.searchBoards(teamID, q, &context).wait();
+
+    println!("{:?}", result);
+}
+</code></pre>
+                            </div>
+                          </div>
+
+                          <h2>Scopes</h2>
+                          <table>
+                            
+                          </table>
+
+                          <h2>Parameters</h2>
+
+                            <div class="methodsubtabletitle">Path parameters</div>
+                            <table id="methodsubtable">
+                                <tr>
+                                  <th width="150px">Name</th>
+                                  <th>Description</th>
+                                </tr>
+                                  <tr><td style="width:150px;">teamID*</td>
+<td>
+
+
+    <div id="d2e199_searchBoards_teamID">
+        <div class="json-schema-view">
+            <div class="primitive">
+                <span class="type">
+                    String
+                </span>
+
+                    <div class="inner description marked">
+Team ID
+                    </div>
+            </div>
+                <div class="inner required">
+                    Required
+                </div>
+        </div>
+    </div>
+</td>
+</tr>
+
+                            </table>
+
+
+
+
+                            <div class="methodsubtabletitle">Query parameters</div>
+                            <table id="methodsubtable">
+                              <tr>
+                                <th width="150px">Name</th>
+                                <th>Description</th>
+                              </tr>
+                                <tr><td style="width:150px;">q*</td>
+<td>
+
+
+    <div id="d2e199_searchBoards_q">
+        <div class="json-schema-view">
+            <div class="primitive">
+                <span class="type">
+                    String
+                </span>
+
+                    <div class="inner description marked">
+The search term. Must have at least one character
+                    </div>
+            </div>
+                <div class="inner required">
+                    Required
+                </div>
+        </div>
+    </div>
+</td>
+</tr>
+
+                            </table>
+
+                          <h2>Responses</h2>
+                            <h3 id="examples-Default-searchBoards-title-200"></h3>
+                            <p id="examples-Default-searchBoards-description-200" class="marked"></p>
+                            <script>
+                              var responseDefault200_description = `success`;
+                              var responseDefault200_description_break = responseDefault200_description.indexOf('\n');
+                              if (responseDefault200_description_break == -1) {
+                                $("#examples-Default-searchBoards-title-200").text("Status: 200 - " + responseDefault200_description);
+                              } else {
+                                $("#examples-Default-searchBoards-title-200").text("Status: 200 - " + responseDefault200_description.substring(0, responseDefault200_description_break));
+                                $("#examples-Default-searchBoards-description-200").html(responseDefault200_description.substring(responseDefault200_description_break));
+                              }
+                            </script>
+
+
+                            <ul id="responses-detail-Default-searchBoards-200" class="nav nav-tabs nav-tabs-examples" >
+                                <li class="active">
+                                  <a data-toggle="tab" href="#responses-Default-searchBoards-200-schema">Schema</a>
+                                </li>
+
+
+
+
+                            </ul>
+
+
+                            <div class="tab-content" id="responses-Default-searchBoards-200-wrapper" style='margin-bottom: 10px;'>
+                                <div class="tab-pane active" id="responses-Default-searchBoards-200-schema">
+                                  <div id="responses-Default-searchBoards-schema-200" class="exampleStyle">
+                                    <script>
+                                      $(document).ready(function() {
+                                        var schemaWrapper = {
+  "description" : "success",
+  "content" : {
+    "application/json" : {
+      "schema" : {
+        "type" : "array",
+        "items" : {
+          "$ref" : "#/components/schemas/Board"
+        }
+      }
+    }
+  }
+};
+                                        var schema = findNode('schema',schemaWrapper).schema;
+                                        if (!schema) {
+                                          schema = schemaWrapper.schema;
+                                        }
+                                        if (schema.$ref != null) {
+                                          schema = defsParser.$refs.get(schema.$ref);
+                                        } else if (schema.items != null && schema.items.$ref != null) {
+                                            schema.items = defsParser.$refs.get(schema.items.$ref);
+                                        } else {
+                                          schemaWrapper.definitions = Object.assign({}, defs);
+                                          $RefParser.dereference(schemaWrapper).catch(function(err) {
+                                            console.log(err);
+                                          });
+                                        }
+
+                                        var view = new JSONSchemaView(schema, 3);
+                                        $('#responses-Default-searchBoards-200-schema-data').val(JSON.stringify(schema));
+                                        var result = $('#responses-Default-searchBoards-schema-200');
+                                        result.empty();
+                                        result.append(view.render());
+                                      });
+                                    </script>
+                                  </div>
+                                  <input id='responses-Default-searchBoards-200-schema-data' type='hidden' value=''></input>
+                                </div>
+                            </div>
+                            <h3 id="examples-Default-searchBoards-title-default"></h3>
+                            <p id="examples-Default-searchBoards-description-default" class="marked"></p>
+                            <script>
+                              var responseDefaultdefault_description = `internal error`;
+                              var responseDefaultdefault_description_break = responseDefaultdefault_description.indexOf('\n');
+                              if (responseDefaultdefault_description_break == -1) {
+                                $("#examples-Default-searchBoards-title-default").text("Status: default - " + responseDefaultdefault_description);
+                              } else {
+                                $("#examples-Default-searchBoards-title-default").text("Status: default - " + responseDefaultdefault_description.substring(0, responseDefaultdefault_description_break));
+                                $("#examples-Default-searchBoards-description-default").html(responseDefaultdefault_description.substring(responseDefaultdefault_description_break));
+                              }
+                            </script>
+
+
+                            <ul id="responses-detail-Default-searchBoards-default" class="nav nav-tabs nav-tabs-examples" >
+                                <li class="active">
+                                  <a data-toggle="tab" href="#responses-Default-searchBoards-default-schema">Schema</a>
+                                </li>
+
+
+
+
+                            </ul>
+
+
+                            <div class="tab-content" id="responses-Default-searchBoards-default-wrapper" style='margin-bottom: 10px;'>
+                                <div class="tab-pane active" id="responses-Default-searchBoards-default-schema">
+                                  <div id="responses-Default-searchBoards-schema-default" class="exampleStyle">
+                                    <script>
+                                      $(document).ready(function() {
+                                        var schemaWrapper = {
+  "description" : "internal error",
+  "content" : {
+    "application/json" : {
+      "schema" : {
+        "$ref" : "#/components/schemas/ErrorResponse"
+      }
+    }
+  }
+};
+                                        var schema = findNode('schema',schemaWrapper).schema;
+                                        if (!schema) {
+                                          schema = schemaWrapper.schema;
+                                        }
+                                        if (schema.$ref != null) {
+                                          schema = defsParser.$refs.get(schema.$ref);
+                                        } else if (schema.items != null && schema.items.$ref != null) {
+                                            schema.items = defsParser.$refs.get(schema.items.$ref);
+                                        } else {
+                                          schemaWrapper.definitions = Object.assign({}, defs);
+                                          $RefParser.dereference(schemaWrapper).catch(function(err) {
+                                            console.log(err);
+                                          });
+                                        }
+
+                                        var view = new JSONSchemaView(schema, 3);
+                                        $('#responses-Default-searchBoards-default-schema-data').val(JSON.stringify(schema));
+                                        var result = $('#responses-Default-searchBoards-schema-default');
+                                        result.empty();
+                                        result.append(view.render());
+                                      });
+                                    </script>
+                                  </div>
+                                  <input id='responses-Default-searchBoards-default-schema-data' type='hidden' value=''></input>
+                                </div>
+                            </div>
+                        </article>
+                      </div>
+                      <hr>
+                    <div id="api-Default-undeleteBlock">
+                      <article id="api-Default-undeleteBlock-0" data-group="User" data-name="undeleteBlock" data-version="0">
+                        <div class="pull-left">
+                          <h1>undeleteBlock</h1>
+                          <p></p>
+                        </div>
+                        <div class="pull-right"></div>
+                        <div class="clearfix"></div>
+                        <p></p>
+                        <p class="marked">Undeletes a block</p>
+                        <p></p>
+                        <br />
+                        <pre class="prettyprint language-html prettyprinted" data-type="post"><code><span class="pln">/boards/{boardID}/blocks/{blockID}/undelete</span></code></pre>
+                        <p>
+                          <h3>Usage and SDK Samples</h3>
+                        </p>
+                        <ul class="nav nav-tabs nav-tabs-examples">
+                          <li class="active"><a href="#examples-Default-undeleteBlock-0-curl">Curl</a></li>
+                          <li class=""><a href="#examples-Default-undeleteBlock-0-java">Java</a></li>
+                          <li class=""><a href="#examples-Default-undeleteBlock-0-android">Android</a></li>
+                          <!--<li class=""><a href="#examples-Default-undeleteBlock-0-groovy">Groovy</a></li>-->
+                          <li class=""><a href="#examples-Default-undeleteBlock-0-objc">Obj-C</a></li>
+                          <li class=""><a href="#examples-Default-undeleteBlock-0-javascript">JavaScript</a></li>
+                          <!--<li class=""><a href="#examples-Default-undeleteBlock-0-angular">Angular</a></li>-->
+                          <li class=""><a href="#examples-Default-undeleteBlock-0-csharp">C#</a></li>
+                          <li class=""><a href="#examples-Default-undeleteBlock-0-php">PHP</a></li>
+                          <li class=""><a href="#examples-Default-undeleteBlock-0-perl">Perl</a></li>
+                          <li class=""><a href="#examples-Default-undeleteBlock-0-python">Python</a></li>
+                          <li class=""><a href="#examples-Default-undeleteBlock-0-rust">Rust</a></li>
+                        </ul>
+
+                        <div class="tab-content">
+                          <div class="tab-pane active" id="examples-Default-undeleteBlock-0-curl">
+                            <pre class="prettyprint"><code class="language-bsh">curl -X POST \
+-H "Authorization: [[apiKey]]" \
+ -H "Accept: application/json" \
+ "http://localhost/api/v2/boards/{boardID}/blocks/{blockID}/undelete"
+</code></pre>
+                          </div>
+                          <div class="tab-pane" id="examples-Default-undeleteBlock-0-java">
+                            <pre class="prettyprint"><code class="language-java">import org.openapitools.client.*;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.model.*;
+import org.openapitools.client.api.DefaultApi;
+
+import java.io.File;
+import java.util.*;
+
+public class DefaultApiExample {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        
+        // Configure API key authorization: BearerAuth
+        ApiKeyAuth BearerAuth = (ApiKeyAuth) defaultClient.getAuthentication("BearerAuth");
+        BearerAuth.setApiKey("YOUR API KEY");
+        // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+        //BearerAuth.setApiKeyPrefix("Token");
+
+        // Create an instance of the API class
+        DefaultApi apiInstance = new DefaultApi();
+        String boardID = boardID_example; // String | Board ID
+        String blockID = blockID_example; // String | ID of block to undelete
+
+        try {
+            BlockPatch result = apiInstance.undeleteBlock(boardID, blockID);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling DefaultApi#undeleteBlock");
+            e.printStackTrace();
+        }
+    }
+}
+</code></pre>
+                          </div>
+
+                          <div class="tab-pane" id="examples-Default-undeleteBlock-0-android">
+                            <pre class="prettyprint"><code class="language-java">import org.openapitools.client.api.DefaultApi;
+
+public class DefaultApiExample {
+    public static void main(String[] args) {
+        DefaultApi apiInstance = new DefaultApi();
+        String boardID = boardID_example; // String | Board ID
+        String blockID = blockID_example; // String | ID of block to undelete
+
+        try {
+            BlockPatch result = apiInstance.undeleteBlock(boardID, blockID);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling DefaultApi#undeleteBlock");
+            e.printStackTrace();
+        }
+    }
+}</code></pre>
+                          </div>
+  <!--
+  <div class="tab-pane" id="examples-Default-undeleteBlock-0-groovy">
+  <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
+  </div> -->
+                            <div class="tab-pane" id="examples-Default-undeleteBlock-0-objc">
+                              <pre class="prettyprint"><code class="language-cpp">Configuration *apiConfig = [Configuration sharedConfig];
+
+// Configure API key authorization: (authentication scheme: BearerAuth)
+[apiConfig setApiKey:@"YOUR_API_KEY" forApiKeyIdentifier:@"Authorization"];
+// Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+//[apiConfig setApiKeyPrefix:@"Bearer" forApiKeyIdentifier:@"Authorization"];
+
+
+// Create an instance of the API class
+DefaultApi *apiInstance = [[DefaultApi alloc] init];
+String *boardID = boardID_example; // Board ID (default to null)
+String *blockID = blockID_example; // ID of block to undelete (default to null)
+
+[apiInstance undeleteBlockWith:boardID
+    blockID:blockID
+              completionHandler: ^(BlockPatch output, NSError* error) {
+    if (output) {
+        NSLog(@"%@", output);
+    }
+    if (error) {
+        NSLog(@"Error: %@", error);
+    }
+}];
+</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-undeleteBlock-0-javascript">
+                              <pre class="prettyprint"><code class="language-js">var FocalboardServer = require('focalboard_server');
+var defaultClient = FocalboardServer.ApiClient.instance;
+
+// Configure API key authorization: BearerAuth
+var BearerAuth = defaultClient.authentications['BearerAuth'];
+BearerAuth.apiKey = "YOUR API KEY";
+// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+//BearerAuth.apiKeyPrefix['Authorization'] = "Token";
+
+// Create an instance of the API class
+var api = new FocalboardServer.DefaultApi()
+var boardID = boardID_example; // {String} Board ID
+var blockID = blockID_example; // {String} ID of block to undelete
+
+var callback = function(error, data, response) {
+  if (error) {
+    console.error(error);
+  } else {
+    console.log('API called successfully. Returned data: ' + data);
+  }
+};
+api.undeleteBlock(boardID, blockID, callback);
+</code></pre>
+                            </div>
+
+                            <!--<div class="tab-pane" id="examples-Default-undeleteBlock-0-angular">
+              <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
+            </div>-->
+                            <div class="tab-pane" id="examples-Default-undeleteBlock-0-csharp">
+                              <pre class="prettyprint"><code class="language-cs">using System;
+using System.Diagnostics;
+using Org.OpenAPITools.Api;
+using Org.OpenAPITools.Client;
+using Org.OpenAPITools.Model;
+
+namespace Example
+{
+    public class undeleteBlockExample
+    {
+        public void main()
+        {
+            // Configure API key authorization: BearerAuth
+            Configuration.Default.ApiKey.Add("Authorization", "YOUR_API_KEY");
+            // Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+            // Configuration.Default.ApiKeyPrefix.Add("Authorization", "Bearer");
+
+            // Create an instance of the API class
+            var apiInstance = new DefaultApi();
+            var boardID = boardID_example;  // String | Board ID (default to null)
+            var blockID = blockID_example;  // String | ID of block to undelete (default to null)
+
+            try {
+                BlockPatch result = apiInstance.undeleteBlock(boardID, blockID);
+                Debug.WriteLine(result);
+            } catch (Exception e) {
+                Debug.Print("Exception when calling DefaultApi.undeleteBlock: " + e.Message );
+            }
+        }
+    }
+}
+</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-undeleteBlock-0-php">
+                              <pre class="prettyprint"><code class="language-php"><&#63;php
+require_once(__DIR__ . '/vendor/autoload.php');
+
+// Configure API key authorization: BearerAuth
+OpenAPITools\Client\Configuration::getDefaultConfiguration()->setApiKey('Authorization', 'YOUR_API_KEY');
+// Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+// OpenAPITools\Client\Configuration::getDefaultConfiguration()->setApiKeyPrefix('Authorization', 'Bearer');
+
+// Create an instance of the API class
+$api_instance = new OpenAPITools\Client\Api\DefaultApi();
+$boardID = boardID_example; // String | Board ID
+$blockID = blockID_example; // String | ID of block to undelete
+
+try {
+    $result = $api_instance->undeleteBlock($boardID, $blockID);
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling DefaultApi->undeleteBlock: ', $e->getMessage(), PHP_EOL;
+}
+?></code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-undeleteBlock-0-perl">
+                              <pre class="prettyprint"><code class="language-perl">use Data::Dumper;
+use WWW::OPenAPIClient::Configuration;
+use WWW::OPenAPIClient::DefaultApi;
+
+# Configure API key authorization: BearerAuth
+$WWW::OPenAPIClient::Configuration::api_key->{'Authorization'} = 'YOUR_API_KEY';
+# uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+#$WWW::OPenAPIClient::Configuration::api_key_prefix->{'Authorization'} = "Bearer";
+
+# Create an instance of the API class
+my $api_instance = WWW::OPenAPIClient::DefaultApi->new();
+my $boardID = boardID_example; # String | Board ID
+my $blockID = blockID_example; # String | ID of block to undelete
+
+eval {
+    my $result = $api_instance->undeleteBlock(boardID => $boardID, blockID => $blockID);
+    print Dumper($result);
+};
+if ($@) {
+    warn "Exception when calling DefaultApi->undeleteBlock: $@\n";
+}</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-undeleteBlock-0-python">
+                              <pre class="prettyprint"><code class="language-python">from __future__ import print_statement
+import time
+import openapi_client
+from openapi_client.rest import ApiException
+from pprint import pprint
+
+# Configure API key authorization: BearerAuth
+openapi_client.configuration.api_key['Authorization'] = 'YOUR_API_KEY'
+# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+# openapi_client.configuration.api_key_prefix['Authorization'] = 'Bearer'
+
+# Create an instance of the API class
+api_instance = openapi_client.DefaultApi()
+boardID = boardID_example # String | Board ID (default to null)
+blockID = blockID_example # String | ID of block to undelete (default to null)
+
+try:
+    api_response = api_instance.undelete_block(boardID, blockID)
+    pprint(api_response)
+except ApiException as e:
+    print("Exception when calling DefaultApi->undeleteBlock: %s\n" % e)</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-undeleteBlock-0-rust">
+                              <pre class="prettyprint"><code class="language-rust">extern crate DefaultApi;
+
+pub fn main() {
+    let boardID = boardID_example; // String
+    let blockID = blockID_example; // String
+
+    let mut context = DefaultApi::Context::default();
+    let result = client.undeleteBlock(boardID, blockID, &context).wait();
+
+    println!("{:?}", result);
+}
+</code></pre>
+                            </div>
+                          </div>
+
+                          <h2>Scopes</h2>
+                          <table>
+                            
+                          </table>
+
+                          <h2>Parameters</h2>
+
+                            <div class="methodsubtabletitle">Path parameters</div>
+                            <table id="methodsubtable">
+                                <tr>
+                                  <th width="150px">Name</th>
+                                  <th>Description</th>
+                                </tr>
+                                  <tr><td style="width:150px;">boardID*</td>
+<td>
+
+
+    <div id="d2e199_undeleteBlock_boardID">
+        <div class="json-schema-view">
+            <div class="primitive">
+                <span class="type">
+                    String
+                </span>
+
+                    <div class="inner description marked">
+Board ID
+                    </div>
+            </div>
+                <div class="inner required">
+                    Required
+                </div>
+        </div>
+    </div>
+</td>
+</tr>
+
+                                  <tr><td style="width:150px;">blockID*</td>
+<td>
+
+
+    <div id="d2e199_undeleteBlock_blockID">
+        <div class="json-schema-view">
+            <div class="primitive">
+                <span class="type">
+                    String
+                </span>
+
+                    <div class="inner description marked">
+ID of block to undelete
+                    </div>
+            </div>
+                <div class="inner required">
+                    Required
+                </div>
+        </div>
+    </div>
+</td>
+</tr>
+
+                            </table>
+
+
+
+
+
+                          <h2>Responses</h2>
+                            <h3 id="examples-Default-undeleteBlock-title-200"></h3>
+                            <p id="examples-Default-undeleteBlock-description-200" class="marked"></p>
+                            <script>
+                              var responseDefault200_description = `success`;
+                              var responseDefault200_description_break = responseDefault200_description.indexOf('\n');
+                              if (responseDefault200_description_break == -1) {
+                                $("#examples-Default-undeleteBlock-title-200").text("Status: 200 - " + responseDefault200_description);
+                              } else {
+                                $("#examples-Default-undeleteBlock-title-200").text("Status: 200 - " + responseDefault200_description.substring(0, responseDefault200_description_break));
+                                $("#examples-Default-undeleteBlock-description-200").html(responseDefault200_description.substring(responseDefault200_description_break));
+                              }
+                            </script>
+
+
+                            <ul id="responses-detail-Default-undeleteBlock-200" class="nav nav-tabs nav-tabs-examples" >
+                                <li class="active">
+                                  <a data-toggle="tab" href="#responses-Default-undeleteBlock-200-schema">Schema</a>
+                                </li>
+
+
+
+
+                            </ul>
+
+
+                            <div class="tab-content" id="responses-Default-undeleteBlock-200-wrapper" style='margin-bottom: 10px;'>
+                                <div class="tab-pane active" id="responses-Default-undeleteBlock-200-schema">
+                                  <div id="responses-Default-undeleteBlock-schema-200" class="exampleStyle">
+                                    <script>
+                                      $(document).ready(function() {
+                                        var schemaWrapper = {
+  "description" : "success",
+  "content" : {
+    "application/json" : {
+      "schema" : {
+        "$ref" : "#/components/schemas/BlockPatch"
+      }
+    }
+  }
+};
+                                        var schema = findNode('schema',schemaWrapper).schema;
+                                        if (!schema) {
+                                          schema = schemaWrapper.schema;
+                                        }
+                                        if (schema.$ref != null) {
+                                          schema = defsParser.$refs.get(schema.$ref);
+                                        } else if (schema.items != null && schema.items.$ref != null) {
+                                            schema.items = defsParser.$refs.get(schema.items.$ref);
+                                        } else {
+                                          schemaWrapper.definitions = Object.assign({}, defs);
+                                          $RefParser.dereference(schemaWrapper).catch(function(err) {
+                                            console.log(err);
+                                          });
+                                        }
+
+                                        var view = new JSONSchemaView(schema, 3);
+                                        $('#responses-Default-undeleteBlock-200-schema-data').val(JSON.stringify(schema));
+                                        var result = $('#responses-Default-undeleteBlock-schema-200');
+                                        result.empty();
+                                        result.append(view.render());
+                                      });
+                                    </script>
+                                  </div>
+                                  <input id='responses-Default-undeleteBlock-200-schema-data' type='hidden' value=''></input>
+                                </div>
+                            </div>
+                            <h3 id="examples-Default-undeleteBlock-title-404"></h3>
+                            <p id="examples-Default-undeleteBlock-description-404" class="marked"></p>
+                            <script>
+                              var responseDefault404_description = `block not found`;
+                              var responseDefault404_description_break = responseDefault404_description.indexOf('\n');
+                              if (responseDefault404_description_break == -1) {
+                                $("#examples-Default-undeleteBlock-title-404").text("Status: 404 - " + responseDefault404_description);
+                              } else {
+                                $("#examples-Default-undeleteBlock-title-404").text("Status: 404 - " + responseDefault404_description.substring(0, responseDefault404_description_break));
+                                $("#examples-Default-undeleteBlock-description-404").html(responseDefault404_description.substring(responseDefault404_description_break));
+                              }
+                            </script>
+
+
+                            <ul id="responses-detail-Default-undeleteBlock-404" class="nav nav-tabs nav-tabs-examples" >
+
+
+                            </ul>
+
+
+                            <div class="tab-content" id="responses-Default-undeleteBlock-404-wrapper" style='margin-bottom: 10px;'>
+                            </div>
+                            <h3 id="examples-Default-undeleteBlock-title-default"></h3>
+                            <p id="examples-Default-undeleteBlock-description-default" class="marked"></p>
+                            <script>
+                              var responseDefaultdefault_description = `internal error`;
+                              var responseDefaultdefault_description_break = responseDefaultdefault_description.indexOf('\n');
+                              if (responseDefaultdefault_description_break == -1) {
+                                $("#examples-Default-undeleteBlock-title-default").text("Status: default - " + responseDefaultdefault_description);
+                              } else {
+                                $("#examples-Default-undeleteBlock-title-default").text("Status: default - " + responseDefaultdefault_description.substring(0, responseDefaultdefault_description_break));
+                                $("#examples-Default-undeleteBlock-description-default").html(responseDefaultdefault_description.substring(responseDefaultdefault_description_break));
+                              }
+                            </script>
+
+
+                            <ul id="responses-detail-Default-undeleteBlock-default" class="nav nav-tabs nav-tabs-examples" >
+                                <li class="active">
+                                  <a data-toggle="tab" href="#responses-Default-undeleteBlock-default-schema">Schema</a>
+                                </li>
+
+
+
+
+                            </ul>
+
+
+                            <div class="tab-content" id="responses-Default-undeleteBlock-default-wrapper" style='margin-bottom: 10px;'>
+                                <div class="tab-pane active" id="responses-Default-undeleteBlock-default-schema">
+                                  <div id="responses-Default-undeleteBlock-schema-default" class="exampleStyle">
+                                    <script>
+                                      $(document).ready(function() {
+                                        var schemaWrapper = {
+  "description" : "internal error",
+  "content" : {
+    "application/json" : {
+      "schema" : {
+        "$ref" : "#/components/schemas/ErrorResponse"
+      }
+    }
+  }
+};
+                                        var schema = findNode('schema',schemaWrapper).schema;
+                                        if (!schema) {
+                                          schema = schemaWrapper.schema;
+                                        }
+                                        if (schema.$ref != null) {
+                                          schema = defsParser.$refs.get(schema.$ref);
+                                        } else if (schema.items != null && schema.items.$ref != null) {
+                                            schema.items = defsParser.$refs.get(schema.items.$ref);
+                                        } else {
+                                          schemaWrapper.definitions = Object.assign({}, defs);
+                                          $RefParser.dereference(schemaWrapper).catch(function(err) {
+                                            console.log(err);
+                                          });
+                                        }
+
+                                        var view = new JSONSchemaView(schema, 3);
+                                        $('#responses-Default-undeleteBlock-default-schema-data').val(JSON.stringify(schema));
+                                        var result = $('#responses-Default-undeleteBlock-schema-default');
+                                        result.empty();
+                                        result.append(view.render());
+                                      });
+                                    </script>
+                                  </div>
+                                  <input id='responses-Default-undeleteBlock-default-schema-data' type='hidden' value=''></input>
+                                </div>
+                            </div>
+                        </article>
+                      </div>
+                      <hr>
+                    <div id="api-Default-undeleteBoard">
+                      <article id="api-Default-undeleteBoard-0" data-group="User" data-name="undeleteBoard" data-version="0">
+                        <div class="pull-left">
+                          <h1>undeleteBoard</h1>
+                          <p></p>
+                        </div>
+                        <div class="pull-right"></div>
+                        <div class="clearfix"></div>
+                        <p></p>
+                        <p class="marked">Undeletes a board</p>
+                        <p></p>
+                        <br />
+                        <pre class="prettyprint language-html prettyprinted" data-type="post"><code><span class="pln">/boards/{boardID}/undelete</span></code></pre>
+                        <p>
+                          <h3>Usage and SDK Samples</h3>
+                        </p>
+                        <ul class="nav nav-tabs nav-tabs-examples">
+                          <li class="active"><a href="#examples-Default-undeleteBoard-0-curl">Curl</a></li>
+                          <li class=""><a href="#examples-Default-undeleteBoard-0-java">Java</a></li>
+                          <li class=""><a href="#examples-Default-undeleteBoard-0-android">Android</a></li>
+                          <!--<li class=""><a href="#examples-Default-undeleteBoard-0-groovy">Groovy</a></li>-->
+                          <li class=""><a href="#examples-Default-undeleteBoard-0-objc">Obj-C</a></li>
+                          <li class=""><a href="#examples-Default-undeleteBoard-0-javascript">JavaScript</a></li>
+                          <!--<li class=""><a href="#examples-Default-undeleteBoard-0-angular">Angular</a></li>-->
+                          <li class=""><a href="#examples-Default-undeleteBoard-0-csharp">C#</a></li>
+                          <li class=""><a href="#examples-Default-undeleteBoard-0-php">PHP</a></li>
+                          <li class=""><a href="#examples-Default-undeleteBoard-0-perl">Perl</a></li>
+                          <li class=""><a href="#examples-Default-undeleteBoard-0-python">Python</a></li>
+                          <li class=""><a href="#examples-Default-undeleteBoard-0-rust">Rust</a></li>
+                        </ul>
+
+                        <div class="tab-content">
+                          <div class="tab-pane active" id="examples-Default-undeleteBoard-0-curl">
+                            <pre class="prettyprint"><code class="language-bsh">curl -X POST \
+-H "Authorization: [[apiKey]]" \
+ -H "Accept: application/json" \
+ "http://localhost/api/v2/boards/{boardID}/undelete"
+</code></pre>
+                          </div>
+                          <div class="tab-pane" id="examples-Default-undeleteBoard-0-java">
+                            <pre class="prettyprint"><code class="language-java">import org.openapitools.client.*;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.model.*;
+import org.openapitools.client.api.DefaultApi;
+
+import java.io.File;
+import java.util.*;
+
+public class DefaultApiExample {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        
+        // Configure API key authorization: BearerAuth
+        ApiKeyAuth BearerAuth = (ApiKeyAuth) defaultClient.getAuthentication("BearerAuth");
+        BearerAuth.setApiKey("YOUR API KEY");
+        // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+        //BearerAuth.setApiKeyPrefix("Token");
+
+        // Create an instance of the API class
+        DefaultApi apiInstance = new DefaultApi();
+        String boardID = boardID_example; // String | ID of board to undelete
+
+        try {
+            apiInstance.undeleteBoard(boardID);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling DefaultApi#undeleteBoard");
+            e.printStackTrace();
+        }
+    }
+}
+</code></pre>
+                          </div>
+
+                          <div class="tab-pane" id="examples-Default-undeleteBoard-0-android">
+                            <pre class="prettyprint"><code class="language-java">import org.openapitools.client.api.DefaultApi;
+
+public class DefaultApiExample {
+    public static void main(String[] args) {
+        DefaultApi apiInstance = new DefaultApi();
+        String boardID = boardID_example; // String | ID of board to undelete
+
+        try {
+            apiInstance.undeleteBoard(boardID);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling DefaultApi#undeleteBoard");
+            e.printStackTrace();
+        }
+    }
+}</code></pre>
+                          </div>
+  <!--
+  <div class="tab-pane" id="examples-Default-undeleteBoard-0-groovy">
+  <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
+  </div> -->
+                            <div class="tab-pane" id="examples-Default-undeleteBoard-0-objc">
+                              <pre class="prettyprint"><code class="language-cpp">Configuration *apiConfig = [Configuration sharedConfig];
+
+// Configure API key authorization: (authentication scheme: BearerAuth)
+[apiConfig setApiKey:@"YOUR_API_KEY" forApiKeyIdentifier:@"Authorization"];
+// Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+//[apiConfig setApiKeyPrefix:@"Bearer" forApiKeyIdentifier:@"Authorization"];
+
+
+// Create an instance of the API class
+DefaultApi *apiInstance = [[DefaultApi alloc] init];
+String *boardID = boardID_example; // ID of board to undelete (default to null)
+
+[apiInstance undeleteBoardWith:boardID
+              completionHandler: ^(NSError* error) {
+    if (error) {
+        NSLog(@"Error: %@", error);
+    }
+}];
+</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-undeleteBoard-0-javascript">
+                              <pre class="prettyprint"><code class="language-js">var FocalboardServer = require('focalboard_server');
+var defaultClient = FocalboardServer.ApiClient.instance;
+
+// Configure API key authorization: BearerAuth
+var BearerAuth = defaultClient.authentications['BearerAuth'];
+BearerAuth.apiKey = "YOUR API KEY";
+// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+//BearerAuth.apiKeyPrefix['Authorization'] = "Token";
+
+// Create an instance of the API class
+var api = new FocalboardServer.DefaultApi()
+var boardID = boardID_example; // {String} ID of board to undelete
+
+var callback = function(error, data, response) {
+  if (error) {
+    console.error(error);
+  } else {
+    console.log('API called successfully.');
+  }
+};
+api.undeleteBoard(boardID, callback);
+</code></pre>
+                            </div>
+
+                            <!--<div class="tab-pane" id="examples-Default-undeleteBoard-0-angular">
+              <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
+            </div>-->
+                            <div class="tab-pane" id="examples-Default-undeleteBoard-0-csharp">
+                              <pre class="prettyprint"><code class="language-cs">using System;
+using System.Diagnostics;
+using Org.OpenAPITools.Api;
+using Org.OpenAPITools.Client;
+using Org.OpenAPITools.Model;
+
+namespace Example
+{
+    public class undeleteBoardExample
+    {
+        public void main()
+        {
+            // Configure API key authorization: BearerAuth
+            Configuration.Default.ApiKey.Add("Authorization", "YOUR_API_KEY");
+            // Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+            // Configuration.Default.ApiKeyPrefix.Add("Authorization", "Bearer");
+
+            // Create an instance of the API class
+            var apiInstance = new DefaultApi();
+            var boardID = boardID_example;  // String | ID of board to undelete (default to null)
+
+            try {
+                apiInstance.undeleteBoard(boardID);
+            } catch (Exception e) {
+                Debug.Print("Exception when calling DefaultApi.undeleteBoard: " + e.Message );
+            }
+        }
+    }
+}
+</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-undeleteBoard-0-php">
+                              <pre class="prettyprint"><code class="language-php"><&#63;php
+require_once(__DIR__ . '/vendor/autoload.php');
+
+// Configure API key authorization: BearerAuth
+OpenAPITools\Client\Configuration::getDefaultConfiguration()->setApiKey('Authorization', 'YOUR_API_KEY');
+// Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+// OpenAPITools\Client\Configuration::getDefaultConfiguration()->setApiKeyPrefix('Authorization', 'Bearer');
+
+// Create an instance of the API class
+$api_instance = new OpenAPITools\Client\Api\DefaultApi();
+$boardID = boardID_example; // String | ID of board to undelete
+
+try {
+    $api_instance->undeleteBoard($boardID);
+} catch (Exception $e) {
+    echo 'Exception when calling DefaultApi->undeleteBoard: ', $e->getMessage(), PHP_EOL;
+}
+?></code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-undeleteBoard-0-perl">
+                              <pre class="prettyprint"><code class="language-perl">use Data::Dumper;
+use WWW::OPenAPIClient::Configuration;
+use WWW::OPenAPIClient::DefaultApi;
+
+# Configure API key authorization: BearerAuth
+$WWW::OPenAPIClient::Configuration::api_key->{'Authorization'} = 'YOUR_API_KEY';
+# uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+#$WWW::OPenAPIClient::Configuration::api_key_prefix->{'Authorization'} = "Bearer";
+
+# Create an instance of the API class
+my $api_instance = WWW::OPenAPIClient::DefaultApi->new();
+my $boardID = boardID_example; # String | ID of board to undelete
+
+eval {
+    $api_instance->undeleteBoard(boardID => $boardID);
+};
+if ($@) {
+    warn "Exception when calling DefaultApi->undeleteBoard: $@\n";
+}</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-undeleteBoard-0-python">
+                              <pre class="prettyprint"><code class="language-python">from __future__ import print_statement
+import time
+import openapi_client
+from openapi_client.rest import ApiException
+from pprint import pprint
+
+# Configure API key authorization: BearerAuth
+openapi_client.configuration.api_key['Authorization'] = 'YOUR_API_KEY'
+# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+# openapi_client.configuration.api_key_prefix['Authorization'] = 'Bearer'
+
+# Create an instance of the API class
+api_instance = openapi_client.DefaultApi()
+boardID = boardID_example # String | ID of board to undelete (default to null)
+
+try:
+    api_instance.undelete_board(boardID)
+except ApiException as e:
+    print("Exception when calling DefaultApi->undeleteBoard: %s\n" % e)</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-undeleteBoard-0-rust">
+                              <pre class="prettyprint"><code class="language-rust">extern crate DefaultApi;
+
+pub fn main() {
+    let boardID = boardID_example; // String
+
+    let mut context = DefaultApi::Context::default();
+    let result = client.undeleteBoard(boardID, &context).wait();
+
+    println!("{:?}", result);
+}
+</code></pre>
+                            </div>
+                          </div>
+
+                          <h2>Scopes</h2>
+                          <table>
+                            
+                          </table>
+
+                          <h2>Parameters</h2>
+
+                            <div class="methodsubtabletitle">Path parameters</div>
+                            <table id="methodsubtable">
+                                <tr>
+                                  <th width="150px">Name</th>
+                                  <th>Description</th>
+                                </tr>
+                                  <tr><td style="width:150px;">boardID*</td>
+<td>
+
+
+    <div id="d2e199_undeleteBoard_boardID">
+        <div class="json-schema-view">
+            <div class="primitive">
+                <span class="type">
+                    String
+                </span>
+
+                    <div class="inner description marked">
+ID of board to undelete
+                    </div>
+            </div>
+                <div class="inner required">
+                    Required
+                </div>
+        </div>
+    </div>
+</td>
+</tr>
+
+                            </table>
+
+
+
+
+
+                          <h2>Responses</h2>
+                            <h3 id="examples-Default-undeleteBoard-title-200"></h3>
+                            <p id="examples-Default-undeleteBoard-description-200" class="marked"></p>
+                            <script>
+                              var responseDefault200_description = `success`;
+                              var responseDefault200_description_break = responseDefault200_description.indexOf('\n');
+                              if (responseDefault200_description_break == -1) {
+                                $("#examples-Default-undeleteBoard-title-200").text("Status: 200 - " + responseDefault200_description);
+                              } else {
+                                $("#examples-Default-undeleteBoard-title-200").text("Status: 200 - " + responseDefault200_description.substring(0, responseDefault200_description_break));
+                                $("#examples-Default-undeleteBoard-description-200").html(responseDefault200_description.substring(responseDefault200_description_break));
+                              }
+                            </script>
+
+
+                            <ul id="responses-detail-Default-undeleteBoard-200" class="nav nav-tabs nav-tabs-examples" >
+
+
+                            </ul>
+
+
+                            <div class="tab-content" id="responses-Default-undeleteBoard-200-wrapper" style='margin-bottom: 10px;'>
+                            </div>
+                            <h3 id="examples-Default-undeleteBoard-title-default"></h3>
+                            <p id="examples-Default-undeleteBoard-description-default" class="marked"></p>
+                            <script>
+                              var responseDefaultdefault_description = `internal error`;
+                              var responseDefaultdefault_description_break = responseDefaultdefault_description.indexOf('\n');
+                              if (responseDefaultdefault_description_break == -1) {
+                                $("#examples-Default-undeleteBoard-title-default").text("Status: default - " + responseDefaultdefault_description);
+                              } else {
+                                $("#examples-Default-undeleteBoard-title-default").text("Status: default - " + responseDefaultdefault_description.substring(0, responseDefaultdefault_description_break));
+                                $("#examples-Default-undeleteBoard-description-default").html(responseDefaultdefault_description.substring(responseDefaultdefault_description_break));
+                              }
+                            </script>
+
+
+                            <ul id="responses-detail-Default-undeleteBoard-default" class="nav nav-tabs nav-tabs-examples" >
+                                <li class="active">
+                                  <a data-toggle="tab" href="#responses-Default-undeleteBoard-default-schema">Schema</a>
+                                </li>
+
+
+
+
+                            </ul>
+
+
+                            <div class="tab-content" id="responses-Default-undeleteBoard-default-wrapper" style='margin-bottom: 10px;'>
+                                <div class="tab-pane active" id="responses-Default-undeleteBoard-default-schema">
+                                  <div id="responses-Default-undeleteBoard-schema-default" class="exampleStyle">
+                                    <script>
+                                      $(document).ready(function() {
+                                        var schemaWrapper = {
+  "description" : "internal error",
+  "content" : {
+    "application/json" : {
+      "schema" : {
+        "$ref" : "#/components/schemas/ErrorResponse"
+      }
+    }
+  }
+};
+                                        var schema = findNode('schema',schemaWrapper).schema;
+                                        if (!schema) {
+                                          schema = schemaWrapper.schema;
+                                        }
+                                        if (schema.$ref != null) {
+                                          schema = defsParser.$refs.get(schema.$ref);
+                                        } else if (schema.items != null && schema.items.$ref != null) {
+                                            schema.items = defsParser.$refs.get(schema.items.$ref);
+                                        } else {
+                                          schemaWrapper.definitions = Object.assign({}, defs);
+                                          $RefParser.dereference(schemaWrapper).catch(function(err) {
+                                            console.log(err);
+                                          });
+                                        }
+
+                                        var view = new JSONSchemaView(schema, 3);
+                                        $('#responses-Default-undeleteBoard-default-schema-data').val(JSON.stringify(schema));
+                                        var result = $('#responses-Default-undeleteBoard-schema-default');
+                                        result.empty();
+                                        result.append(view.render());
+                                      });
+                                    </script>
+                                  </div>
+                                  <input id='responses-Default-undeleteBoard-default-schema-data' type='hidden' value=''></input>
+                                </div>
+                            </div>
+                        </article>
+                      </div>
+                      <hr>
                     <div id="api-Default-updateBlocks">
                       <article id="api-Default-updateBlocks-0" data-group="User" data-name="updateBlocks" data-version="0">
                         <div class="pull-left">
@@ -11623,7 +22097,7 @@ blocks with existing ones, the rest will be replaced by server
 generated IDs</p>
                         <p></p>
                         <br />
-                        <pre class="prettyprint language-html prettyprinted" data-type="post"><code><span class="pln">/api/v1/workspaces/{workspaceID}/blocks</span></code></pre>
+                        <pre class="prettyprint language-html prettyprinted" data-type="post"><code><span class="pln">/boards/{boardID}/blocks</span></code></pre>
                         <p>
                           <h3>Usage and SDK Samples</h3>
                         </p>
@@ -11648,23 +22122,22 @@ generated IDs</p>
 -H "Authorization: [[apiKey]]" \
  -H "Accept: application/json" \
  -H "Content-Type: application/json" \
- "http://localhost/api/v1/api/v1/workspaces/{workspaceID}/blocks" \
+ "http://localhost/api/v2/boards/{boardID}/blocks" \
  -d '{
   &quot;schema&quot; : 1,
-  &quot;deleteAt&quot; : 6,
-  &quot;rootId&quot; : &quot;rootId&quot;,
-  &quot;updateAt&quot; : 5,
-  &quot;title&quot; : &quot;title&quot;,
-  &quot;type&quot; : &quot;type&quot;,
-  &quot;createAt&quot; : 0,
-  &quot;parentId&quot; : &quot;parentId&quot;,
   &quot;createdBy&quot; : &quot;createdBy&quot;,
+  &quot;deleteAt&quot; : 6,
+  &quot;boardId&quot; : &quot;boardId&quot;,
+  &quot;updateAt&quot; : 5,
   &quot;modifiedBy&quot; : &quot;modifiedBy&quot;,
   &quot;id&quot; : &quot;id&quot;,
   &quot;fields&quot; : {
     &quot;key&quot; : &quot;{}&quot;
   },
-  &quot;workspaceId&quot; : &quot;workspaceId&quot;
+  &quot;title&quot; : &quot;title&quot;,
+  &quot;type&quot; : &quot;type&quot;,
+  &quot;createAt&quot; : 0,
+  &quot;parentId&quot; : &quot;parentId&quot;
 }'
 </code></pre>
                           </div>
@@ -11689,11 +22162,11 @@ public class DefaultApiExample {
 
         // Create an instance of the API class
         DefaultApi apiInstance = new DefaultApi();
-        String workspaceID = workspaceID_example; // String | Workspace ID
+        String boardID = boardID_example; // String | Board ID
         array[Block] body = ; // array[Block] | 
 
         try {
-            array[Block] result = apiInstance.updateBlocks(workspaceID, body);
+            array[Block] result = apiInstance.updateBlocks(boardID, body);
             System.out.println(result);
         } catch (ApiException e) {
             System.err.println("Exception when calling DefaultApi#updateBlocks");
@@ -11710,11 +22183,11 @@ public class DefaultApiExample {
 public class DefaultApiExample {
     public static void main(String[] args) {
         DefaultApi apiInstance = new DefaultApi();
-        String workspaceID = workspaceID_example; // String | Workspace ID
+        String boardID = boardID_example; // String | Board ID
         array[Block] body = ; // array[Block] | 
 
         try {
-            array[Block] result = apiInstance.updateBlocks(workspaceID, body);
+            array[Block] result = apiInstance.updateBlocks(boardID, body);
             System.out.println(result);
         } catch (ApiException e) {
             System.err.println("Exception when calling DefaultApi#updateBlocks");
@@ -11738,10 +22211,10 @@ public class DefaultApiExample {
 
 // Create an instance of the API class
 DefaultApi *apiInstance = [[DefaultApi alloc] init];
-String *workspaceID = workspaceID_example; // Workspace ID (default to null)
+String *boardID = boardID_example; // Board ID (default to null)
 array[Block] *body = ; // 
 
-[apiInstance updateBlocksWith:workspaceID
+[apiInstance updateBlocksWith:boardID
     body:body
               completionHandler: ^(array[Block] output, NSError* error) {
     if (output) {
@@ -11766,7 +22239,7 @@ BearerAuth.apiKey = "YOUR API KEY";
 
 // Create an instance of the API class
 var api = new FocalboardServer.DefaultApi()
-var workspaceID = workspaceID_example; // {String} Workspace ID
+var boardID = boardID_example; // {String} Board ID
 var body = ; // {array[Block]} 
 
 var callback = function(error, data, response) {
@@ -11776,7 +22249,7 @@ var callback = function(error, data, response) {
     console.log('API called successfully. Returned data: ' + data);
   }
 };
-api.updateBlocks(workspaceID, body, callback);
+api.updateBlocks(boardID, body, callback);
 </code></pre>
                             </div>
 
@@ -11803,11 +22276,11 @@ namespace Example
 
             // Create an instance of the API class
             var apiInstance = new DefaultApi();
-            var workspaceID = workspaceID_example;  // String | Workspace ID (default to null)
+            var boardID = boardID_example;  // String | Board ID (default to null)
             var body = new array[Block](); // array[Block] | 
 
             try {
-                array[Block] result = apiInstance.updateBlocks(workspaceID, body);
+                array[Block] result = apiInstance.updateBlocks(boardID, body);
                 Debug.WriteLine(result);
             } catch (Exception e) {
                 Debug.Print("Exception when calling DefaultApi.updateBlocks: " + e.Message );
@@ -11829,11 +22302,11 @@ OpenAPITools\Client\Configuration::getDefaultConfiguration()->setApiKey('Authori
 
 // Create an instance of the API class
 $api_instance = new OpenAPITools\Client\Api\DefaultApi();
-$workspaceID = workspaceID_example; // String | Workspace ID
+$boardID = boardID_example; // String | Board ID
 $body = ; // array[Block] | 
 
 try {
-    $result = $api_instance->updateBlocks($workspaceID, $body);
+    $result = $api_instance->updateBlocks($boardID, $body);
     print_r($result);
 } catch (Exception $e) {
     echo 'Exception when calling DefaultApi->updateBlocks: ', $e->getMessage(), PHP_EOL;
@@ -11853,11 +22326,11 @@ $WWW::OPenAPIClient::Configuration::api_key->{'Authorization'} = 'YOUR_API_KEY';
 
 # Create an instance of the API class
 my $api_instance = WWW::OPenAPIClient::DefaultApi->new();
-my $workspaceID = workspaceID_example; # String | Workspace ID
+my $boardID = boardID_example; # String | Board ID
 my $body = [WWW::OPenAPIClient::Object::array[Block]->new()]; # array[Block] | 
 
 eval {
-    my $result = $api_instance->updateBlocks(workspaceID => $workspaceID, body => $body);
+    my $result = $api_instance->updateBlocks(boardID => $boardID, body => $body);
     print Dumper($result);
 };
 if ($@) {
@@ -11879,11 +22352,11 @@ openapi_client.configuration.api_key['Authorization'] = 'YOUR_API_KEY'
 
 # Create an instance of the API class
 api_instance = openapi_client.DefaultApi()
-workspaceID = workspaceID_example # String | Workspace ID (default to null)
+boardID = boardID_example # String | Board ID (default to null)
 body =  # array[Block] | 
 
 try:
-    api_response = api_instance.update_blocks(workspaceID, body)
+    api_response = api_instance.update_blocks(boardID, body)
     pprint(api_response)
 except ApiException as e:
     print("Exception when calling DefaultApi->updateBlocks: %s\n" % e)</code></pre>
@@ -11893,11 +22366,11 @@ except ApiException as e:
                               <pre class="prettyprint"><code class="language-rust">extern crate DefaultApi;
 
 pub fn main() {
-    let workspaceID = workspaceID_example; // String
+    let boardID = boardID_example; // String
     let body = ; // array[Block]
 
     let mut context = DefaultApi::Context::default();
-    let result = client.updateBlocks(workspaceID, body, &context).wait();
+    let result = client.updateBlocks(boardID, body, &context).wait();
 
     println!("{:?}", result);
 }
@@ -11918,11 +22391,11 @@ pub fn main() {
                                   <th width="150px">Name</th>
                                   <th>Description</th>
                                 </tr>
-                                  <tr><td style="width:150px;">workspaceID*</td>
+                                  <tr><td style="width:150px;">boardID*</td>
 <td>
 
 
-    <div id="d2e199_updateBlocks_workspaceID">
+    <div id="d2e199_updateBlocks_boardID">
         <div class="json-schema-view">
             <div class="primitive">
                 <span class="type">
@@ -11930,7 +22403,7 @@ pub fn main() {
                 </span>
 
                     <div class="inner description marked">
-Workspace ID
+Board ID
                     </div>
             </div>
                 <div class="inner required">
@@ -12136,6 +22609,1005 @@ $(document).ready(function() {
                         </article>
                       </div>
                       <hr>
+                    <div id="api-Default-updateMember">
+                      <article id="api-Default-updateMember-0" data-group="User" data-name="updateMember" data-version="0">
+                        <div class="pull-left">
+                          <h1>updateMember</h1>
+                          <p></p>
+                        </div>
+                        <div class="pull-right"></div>
+                        <div class="clearfix"></div>
+                        <p></p>
+                        <p class="marked">Updates a board member</p>
+                        <p></p>
+                        <br />
+                        <pre class="prettyprint language-html prettyprinted" data-type="put"><code><span class="pln">/boards/{boardID}/members/{userID}</span></code></pre>
+                        <p>
+                          <h3>Usage and SDK Samples</h3>
+                        </p>
+                        <ul class="nav nav-tabs nav-tabs-examples">
+                          <li class="active"><a href="#examples-Default-updateMember-0-curl">Curl</a></li>
+                          <li class=""><a href="#examples-Default-updateMember-0-java">Java</a></li>
+                          <li class=""><a href="#examples-Default-updateMember-0-android">Android</a></li>
+                          <!--<li class=""><a href="#examples-Default-updateMember-0-groovy">Groovy</a></li>-->
+                          <li class=""><a href="#examples-Default-updateMember-0-objc">Obj-C</a></li>
+                          <li class=""><a href="#examples-Default-updateMember-0-javascript">JavaScript</a></li>
+                          <!--<li class=""><a href="#examples-Default-updateMember-0-angular">Angular</a></li>-->
+                          <li class=""><a href="#examples-Default-updateMember-0-csharp">C#</a></li>
+                          <li class=""><a href="#examples-Default-updateMember-0-php">PHP</a></li>
+                          <li class=""><a href="#examples-Default-updateMember-0-perl">Perl</a></li>
+                          <li class=""><a href="#examples-Default-updateMember-0-python">Python</a></li>
+                          <li class=""><a href="#examples-Default-updateMember-0-rust">Rust</a></li>
+                        </ul>
+
+                        <div class="tab-content">
+                          <div class="tab-pane active" id="examples-Default-updateMember-0-curl">
+                            <pre class="prettyprint"><code class="language-bsh">curl -X PUT \
+-H "Authorization: [[apiKey]]" \
+ -H "Accept: application/json" \
+ -H "Content-Type: application/json" \
+ "http://localhost/api/v2/boards/{boardID}/members/{userID}" \
+ -d '{
+  &quot;schemeAdmin&quot; : true,
+  &quot;schemeCommenter&quot; : true,
+  &quot;schemeViewer&quot; : true,
+  &quot;roles&quot; : &quot;roles&quot;,
+  &quot;schemeEditor&quot; : true,
+  &quot;boardId&quot; : &quot;boardId&quot;,
+  &quot;userId&quot; : &quot;userId&quot;
+}'
+</code></pre>
+                          </div>
+                          <div class="tab-pane" id="examples-Default-updateMember-0-java">
+                            <pre class="prettyprint"><code class="language-java">import org.openapitools.client.*;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.model.*;
+import org.openapitools.client.api.DefaultApi;
+
+import java.io.File;
+import java.util.*;
+
+public class DefaultApiExample {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        
+        // Configure API key authorization: BearerAuth
+        ApiKeyAuth BearerAuth = (ApiKeyAuth) defaultClient.getAuthentication("BearerAuth");
+        BearerAuth.setApiKey("YOUR API KEY");
+        // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+        //BearerAuth.setApiKeyPrefix("Token");
+
+        // Create an instance of the API class
+        DefaultApi apiInstance = new DefaultApi();
+        String boardID = boardID_example; // String | Board ID
+        String userID = userID_example; // String | User ID
+        BoardMember body = ; // BoardMember | 
+
+        try {
+            BoardMember result = apiInstance.updateMember(boardID, userID, body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling DefaultApi#updateMember");
+            e.printStackTrace();
+        }
+    }
+}
+</code></pre>
+                          </div>
+
+                          <div class="tab-pane" id="examples-Default-updateMember-0-android">
+                            <pre class="prettyprint"><code class="language-java">import org.openapitools.client.api.DefaultApi;
+
+public class DefaultApiExample {
+    public static void main(String[] args) {
+        DefaultApi apiInstance = new DefaultApi();
+        String boardID = boardID_example; // String | Board ID
+        String userID = userID_example; // String | User ID
+        BoardMember body = ; // BoardMember | 
+
+        try {
+            BoardMember result = apiInstance.updateMember(boardID, userID, body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling DefaultApi#updateMember");
+            e.printStackTrace();
+        }
+    }
+}</code></pre>
+                          </div>
+  <!--
+  <div class="tab-pane" id="examples-Default-updateMember-0-groovy">
+  <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
+  </div> -->
+                            <div class="tab-pane" id="examples-Default-updateMember-0-objc">
+                              <pre class="prettyprint"><code class="language-cpp">Configuration *apiConfig = [Configuration sharedConfig];
+
+// Configure API key authorization: (authentication scheme: BearerAuth)
+[apiConfig setApiKey:@"YOUR_API_KEY" forApiKeyIdentifier:@"Authorization"];
+// Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+//[apiConfig setApiKeyPrefix:@"Bearer" forApiKeyIdentifier:@"Authorization"];
+
+
+// Create an instance of the API class
+DefaultApi *apiInstance = [[DefaultApi alloc] init];
+String *boardID = boardID_example; // Board ID (default to null)
+String *userID = userID_example; // User ID (default to null)
+BoardMember *body = ; // 
+
+[apiInstance updateMemberWith:boardID
+    userID:userID
+    body:body
+              completionHandler: ^(BoardMember output, NSError* error) {
+    if (output) {
+        NSLog(@"%@", output);
+    }
+    if (error) {
+        NSLog(@"Error: %@", error);
+    }
+}];
+</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-updateMember-0-javascript">
+                              <pre class="prettyprint"><code class="language-js">var FocalboardServer = require('focalboard_server');
+var defaultClient = FocalboardServer.ApiClient.instance;
+
+// Configure API key authorization: BearerAuth
+var BearerAuth = defaultClient.authentications['BearerAuth'];
+BearerAuth.apiKey = "YOUR API KEY";
+// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+//BearerAuth.apiKeyPrefix['Authorization'] = "Token";
+
+// Create an instance of the API class
+var api = new FocalboardServer.DefaultApi()
+var boardID = boardID_example; // {String} Board ID
+var userID = userID_example; // {String} User ID
+var body = ; // {BoardMember} 
+
+var callback = function(error, data, response) {
+  if (error) {
+    console.error(error);
+  } else {
+    console.log('API called successfully. Returned data: ' + data);
+  }
+};
+api.updateMember(boardID, userID, body, callback);
+</code></pre>
+                            </div>
+
+                            <!--<div class="tab-pane" id="examples-Default-updateMember-0-angular">
+              <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
+            </div>-->
+                            <div class="tab-pane" id="examples-Default-updateMember-0-csharp">
+                              <pre class="prettyprint"><code class="language-cs">using System;
+using System.Diagnostics;
+using Org.OpenAPITools.Api;
+using Org.OpenAPITools.Client;
+using Org.OpenAPITools.Model;
+
+namespace Example
+{
+    public class updateMemberExample
+    {
+        public void main()
+        {
+            // Configure API key authorization: BearerAuth
+            Configuration.Default.ApiKey.Add("Authorization", "YOUR_API_KEY");
+            // Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+            // Configuration.Default.ApiKeyPrefix.Add("Authorization", "Bearer");
+
+            // Create an instance of the API class
+            var apiInstance = new DefaultApi();
+            var boardID = boardID_example;  // String | Board ID (default to null)
+            var userID = userID_example;  // String | User ID (default to null)
+            var body = new BoardMember(); // BoardMember | 
+
+            try {
+                BoardMember result = apiInstance.updateMember(boardID, userID, body);
+                Debug.WriteLine(result);
+            } catch (Exception e) {
+                Debug.Print("Exception when calling DefaultApi.updateMember: " + e.Message );
+            }
+        }
+    }
+}
+</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-updateMember-0-php">
+                              <pre class="prettyprint"><code class="language-php"><&#63;php
+require_once(__DIR__ . '/vendor/autoload.php');
+
+// Configure API key authorization: BearerAuth
+OpenAPITools\Client\Configuration::getDefaultConfiguration()->setApiKey('Authorization', 'YOUR_API_KEY');
+// Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+// OpenAPITools\Client\Configuration::getDefaultConfiguration()->setApiKeyPrefix('Authorization', 'Bearer');
+
+// Create an instance of the API class
+$api_instance = new OpenAPITools\Client\Api\DefaultApi();
+$boardID = boardID_example; // String | Board ID
+$userID = userID_example; // String | User ID
+$body = ; // BoardMember | 
+
+try {
+    $result = $api_instance->updateMember($boardID, $userID, $body);
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling DefaultApi->updateMember: ', $e->getMessage(), PHP_EOL;
+}
+?></code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-updateMember-0-perl">
+                              <pre class="prettyprint"><code class="language-perl">use Data::Dumper;
+use WWW::OPenAPIClient::Configuration;
+use WWW::OPenAPIClient::DefaultApi;
+
+# Configure API key authorization: BearerAuth
+$WWW::OPenAPIClient::Configuration::api_key->{'Authorization'} = 'YOUR_API_KEY';
+# uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+#$WWW::OPenAPIClient::Configuration::api_key_prefix->{'Authorization'} = "Bearer";
+
+# Create an instance of the API class
+my $api_instance = WWW::OPenAPIClient::DefaultApi->new();
+my $boardID = boardID_example; # String | Board ID
+my $userID = userID_example; # String | User ID
+my $body = WWW::OPenAPIClient::Object::BoardMember->new(); # BoardMember | 
+
+eval {
+    my $result = $api_instance->updateMember(boardID => $boardID, userID => $userID, body => $body);
+    print Dumper($result);
+};
+if ($@) {
+    warn "Exception when calling DefaultApi->updateMember: $@\n";
+}</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-updateMember-0-python">
+                              <pre class="prettyprint"><code class="language-python">from __future__ import print_statement
+import time
+import openapi_client
+from openapi_client.rest import ApiException
+from pprint import pprint
+
+# Configure API key authorization: BearerAuth
+openapi_client.configuration.api_key['Authorization'] = 'YOUR_API_KEY'
+# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+# openapi_client.configuration.api_key_prefix['Authorization'] = 'Bearer'
+
+# Create an instance of the API class
+api_instance = openapi_client.DefaultApi()
+boardID = boardID_example # String | Board ID (default to null)
+userID = userID_example # String | User ID (default to null)
+body =  # BoardMember | 
+
+try:
+    api_response = api_instance.update_member(boardID, userID, body)
+    pprint(api_response)
+except ApiException as e:
+    print("Exception when calling DefaultApi->updateMember: %s\n" % e)</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-updateMember-0-rust">
+                              <pre class="prettyprint"><code class="language-rust">extern crate DefaultApi;
+
+pub fn main() {
+    let boardID = boardID_example; // String
+    let userID = userID_example; // String
+    let body = ; // BoardMember
+
+    let mut context = DefaultApi::Context::default();
+    let result = client.updateMember(boardID, userID, body, &context).wait();
+
+    println!("{:?}", result);
+}
+</code></pre>
+                            </div>
+                          </div>
+
+                          <h2>Scopes</h2>
+                          <table>
+                            
+                          </table>
+
+                          <h2>Parameters</h2>
+
+                            <div class="methodsubtabletitle">Path parameters</div>
+                            <table id="methodsubtable">
+                                <tr>
+                                  <th width="150px">Name</th>
+                                  <th>Description</th>
+                                </tr>
+                                  <tr><td style="width:150px;">boardID*</td>
+<td>
+
+
+    <div id="d2e199_updateMember_boardID">
+        <div class="json-schema-view">
+            <div class="primitive">
+                <span class="type">
+                    String
+                </span>
+
+                    <div class="inner description marked">
+Board ID
+                    </div>
+            </div>
+                <div class="inner required">
+                    Required
+                </div>
+        </div>
+    </div>
+</td>
+</tr>
+
+                                  <tr><td style="width:150px;">userID*</td>
+<td>
+
+
+    <div id="d2e199_updateMember_userID">
+        <div class="json-schema-view">
+            <div class="primitive">
+                <span class="type">
+                    String
+                </span>
+
+                    <div class="inner description marked">
+User ID
+                    </div>
+            </div>
+                <div class="inner required">
+                    Required
+                </div>
+        </div>
+    </div>
+</td>
+</tr>
+
+                            </table>
+
+
+                            <div class="methodsubtabletitle">Body parameters</div>
+                            <table id="methodsubtable">
+                              <tr>
+                                <th width="150px">Name</th>
+                                <th>Description</th>
+                              </tr>
+                                <tr><td style="width:150px;">body <span style="color:red;">*</span></td>
+<td>
+<p class="marked">membership to replace the current one with</p>
+<script>
+$(document).ready(function() {
+  var schemaWrapper = {
+  "description" : "membership to replace the current one with",
+  "content" : {
+    "application/json" : {
+      "schema" : {
+        "$ref" : "#/components/schemas/BoardMember"
+      }
+    }
+  },
+  "required" : true
+};
+
+  var schema = findNode('schema',schemaWrapper).schema;
+  if (!schema) {
+    schema = schemaWrapper.schema;
+  }
+  if (schema.$ref != null) {
+    schema = defsParser.$refs.get(schema.$ref);
+  } else {
+    schemaWrapper.definitions = Object.assign({}, defs);
+    $RefParser.dereference(schemaWrapper).catch(function(err) {
+      console.log(err);
+    });
+  }
+
+  var view = new JSONSchemaView(schema,2,{isBodyParam: true});
+  var result = $('#d2e199_updateMember_body');
+  result.empty();
+  result.append(view.render());
+});
+</script>
+<div id="d2e199_updateMember_body"></div>
+</td>
+</tr>
+
+                            </table>
+
+
+
+                          <h2>Responses</h2>
+                            <h3 id="examples-Default-updateMember-title-200"></h3>
+                            <p id="examples-Default-updateMember-description-200" class="marked"></p>
+                            <script>
+                              var responseDefault200_description = `success`;
+                              var responseDefault200_description_break = responseDefault200_description.indexOf('\n');
+                              if (responseDefault200_description_break == -1) {
+                                $("#examples-Default-updateMember-title-200").text("Status: 200 - " + responseDefault200_description);
+                              } else {
+                                $("#examples-Default-updateMember-title-200").text("Status: 200 - " + responseDefault200_description.substring(0, responseDefault200_description_break));
+                                $("#examples-Default-updateMember-description-200").html(responseDefault200_description.substring(responseDefault200_description_break));
+                              }
+                            </script>
+
+
+                            <ul id="responses-detail-Default-updateMember-200" class="nav nav-tabs nav-tabs-examples" >
+                                <li class="active">
+                                  <a data-toggle="tab" href="#responses-Default-updateMember-200-schema">Schema</a>
+                                </li>
+
+
+
+
+                            </ul>
+
+
+                            <div class="tab-content" id="responses-Default-updateMember-200-wrapper" style='margin-bottom: 10px;'>
+                                <div class="tab-pane active" id="responses-Default-updateMember-200-schema">
+                                  <div id="responses-Default-updateMember-schema-200" class="exampleStyle">
+                                    <script>
+                                      $(document).ready(function() {
+                                        var schemaWrapper = {
+  "description" : "success",
+  "content" : {
+    "application/json" : {
+      "schema" : {
+        "$ref" : "#/components/schemas/BoardMember"
+      }
+    }
+  }
+};
+                                        var schema = findNode('schema',schemaWrapper).schema;
+                                        if (!schema) {
+                                          schema = schemaWrapper.schema;
+                                        }
+                                        if (schema.$ref != null) {
+                                          schema = defsParser.$refs.get(schema.$ref);
+                                        } else if (schema.items != null && schema.items.$ref != null) {
+                                            schema.items = defsParser.$refs.get(schema.items.$ref);
+                                        } else {
+                                          schemaWrapper.definitions = Object.assign({}, defs);
+                                          $RefParser.dereference(schemaWrapper).catch(function(err) {
+                                            console.log(err);
+                                          });
+                                        }
+
+                                        var view = new JSONSchemaView(schema, 3);
+                                        $('#responses-Default-updateMember-200-schema-data').val(JSON.stringify(schema));
+                                        var result = $('#responses-Default-updateMember-schema-200');
+                                        result.empty();
+                                        result.append(view.render());
+                                      });
+                                    </script>
+                                  </div>
+                                  <input id='responses-Default-updateMember-200-schema-data' type='hidden' value=''></input>
+                                </div>
+                            </div>
+                            <h3 id="examples-Default-updateMember-title-default"></h3>
+                            <p id="examples-Default-updateMember-description-default" class="marked"></p>
+                            <script>
+                              var responseDefaultdefault_description = `internal error`;
+                              var responseDefaultdefault_description_break = responseDefaultdefault_description.indexOf('\n');
+                              if (responseDefaultdefault_description_break == -1) {
+                                $("#examples-Default-updateMember-title-default").text("Status: default - " + responseDefaultdefault_description);
+                              } else {
+                                $("#examples-Default-updateMember-title-default").text("Status: default - " + responseDefaultdefault_description.substring(0, responseDefaultdefault_description_break));
+                                $("#examples-Default-updateMember-description-default").html(responseDefaultdefault_description.substring(responseDefaultdefault_description_break));
+                              }
+                            </script>
+
+
+                            <ul id="responses-detail-Default-updateMember-default" class="nav nav-tabs nav-tabs-examples" >
+                                <li class="active">
+                                  <a data-toggle="tab" href="#responses-Default-updateMember-default-schema">Schema</a>
+                                </li>
+
+
+
+
+                            </ul>
+
+
+                            <div class="tab-content" id="responses-Default-updateMember-default-wrapper" style='margin-bottom: 10px;'>
+                                <div class="tab-pane active" id="responses-Default-updateMember-default-schema">
+                                  <div id="responses-Default-updateMember-schema-default" class="exampleStyle">
+                                    <script>
+                                      $(document).ready(function() {
+                                        var schemaWrapper = {
+  "description" : "internal error",
+  "content" : {
+    "application/json" : {
+      "schema" : {
+        "$ref" : "#/components/schemas/ErrorResponse"
+      }
+    }
+  }
+};
+                                        var schema = findNode('schema',schemaWrapper).schema;
+                                        if (!schema) {
+                                          schema = schemaWrapper.schema;
+                                        }
+                                        if (schema.$ref != null) {
+                                          schema = defsParser.$refs.get(schema.$ref);
+                                        } else if (schema.items != null && schema.items.$ref != null) {
+                                            schema.items = defsParser.$refs.get(schema.items.$ref);
+                                        } else {
+                                          schemaWrapper.definitions = Object.assign({}, defs);
+                                          $RefParser.dereference(schemaWrapper).catch(function(err) {
+                                            console.log(err);
+                                          });
+                                        }
+
+                                        var view = new JSONSchemaView(schema, 3);
+                                        $('#responses-Default-updateMember-default-schema-data').val(JSON.stringify(schema));
+                                        var result = $('#responses-Default-updateMember-schema-default');
+                                        result.empty();
+                                        result.append(view.render());
+                                      });
+                                    </script>
+                                  </div>
+                                  <input id='responses-Default-updateMember-default-schema-data' type='hidden' value=''></input>
+                                </div>
+                            </div>
+                        </article>
+                      </div>
+                      <hr>
+                    <div id="api-Default-updateUserConfig">
+                      <article id="api-Default-updateUserConfig-0" data-group="User" data-name="updateUserConfig" data-version="0">
+                        <div class="pull-left">
+                          <h1>updateUserConfig</h1>
+                          <p></p>
+                        </div>
+                        <div class="pull-right"></div>
+                        <div class="clearfix"></div>
+                        <p></p>
+                        <p class="marked">Updates user config</p>
+                        <p></p>
+                        <br />
+                        <pre class="prettyprint language-html prettyprinted" data-type="patch"><code><span class="pln">/users/{userID}/config</span></code></pre>
+                        <p>
+                          <h3>Usage and SDK Samples</h3>
+                        </p>
+                        <ul class="nav nav-tabs nav-tabs-examples">
+                          <li class="active"><a href="#examples-Default-updateUserConfig-0-curl">Curl</a></li>
+                          <li class=""><a href="#examples-Default-updateUserConfig-0-java">Java</a></li>
+                          <li class=""><a href="#examples-Default-updateUserConfig-0-android">Android</a></li>
+                          <!--<li class=""><a href="#examples-Default-updateUserConfig-0-groovy">Groovy</a></li>-->
+                          <li class=""><a href="#examples-Default-updateUserConfig-0-objc">Obj-C</a></li>
+                          <li class=""><a href="#examples-Default-updateUserConfig-0-javascript">JavaScript</a></li>
+                          <!--<li class=""><a href="#examples-Default-updateUserConfig-0-angular">Angular</a></li>-->
+                          <li class=""><a href="#examples-Default-updateUserConfig-0-csharp">C#</a></li>
+                          <li class=""><a href="#examples-Default-updateUserConfig-0-php">PHP</a></li>
+                          <li class=""><a href="#examples-Default-updateUserConfig-0-perl">Perl</a></li>
+                          <li class=""><a href="#examples-Default-updateUserConfig-0-python">Python</a></li>
+                          <li class=""><a href="#examples-Default-updateUserConfig-0-rust">Rust</a></li>
+                        </ul>
+
+                        <div class="tab-content">
+                          <div class="tab-pane active" id="examples-Default-updateUserConfig-0-curl">
+                            <pre class="prettyprint"><code class="language-bsh">curl -X PATCH \
+-H "Authorization: [[apiKey]]" \
+ -H "Accept: application/json" \
+ -H "Content-Type: application/json" \
+ "http://localhost/api/v2/users/{userID}/config" \
+ -d '{
+  &quot;updatedFields&quot; : {
+    &quot;key&quot; : &quot;updatedFields&quot;
+  },
+  &quot;deletedFields&quot; : [ &quot;deletedFields&quot;, &quot;deletedFields&quot; ]
+}'
+</code></pre>
+                          </div>
+                          <div class="tab-pane" id="examples-Default-updateUserConfig-0-java">
+                            <pre class="prettyprint"><code class="language-java">import org.openapitools.client.*;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.model.*;
+import org.openapitools.client.api.DefaultApi;
+
+import java.io.File;
+import java.util.*;
+
+public class DefaultApiExample {
+    public static void main(String[] args) {
+        ApiClient defaultClient = Configuration.getDefaultApiClient();
+        
+        // Configure API key authorization: BearerAuth
+        ApiKeyAuth BearerAuth = (ApiKeyAuth) defaultClient.getAuthentication("BearerAuth");
+        BearerAuth.setApiKey("YOUR API KEY");
+        // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+        //BearerAuth.setApiKeyPrefix("Token");
+
+        // Create an instance of the API class
+        DefaultApi apiInstance = new DefaultApi();
+        String userID = userID_example; // String | User ID
+        UserPropPatch body = ; // UserPropPatch | 
+
+        try {
+            apiInstance.updateUserConfig(userID, body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling DefaultApi#updateUserConfig");
+            e.printStackTrace();
+        }
+    }
+}
+</code></pre>
+                          </div>
+
+                          <div class="tab-pane" id="examples-Default-updateUserConfig-0-android">
+                            <pre class="prettyprint"><code class="language-java">import org.openapitools.client.api.DefaultApi;
+
+public class DefaultApiExample {
+    public static void main(String[] args) {
+        DefaultApi apiInstance = new DefaultApi();
+        String userID = userID_example; // String | User ID
+        UserPropPatch body = ; // UserPropPatch | 
+
+        try {
+            apiInstance.updateUserConfig(userID, body);
+        } catch (ApiException e) {
+            System.err.println("Exception when calling DefaultApi#updateUserConfig");
+            e.printStackTrace();
+        }
+    }
+}</code></pre>
+                          </div>
+  <!--
+  <div class="tab-pane" id="examples-Default-updateUserConfig-0-groovy">
+  <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
+  </div> -->
+                            <div class="tab-pane" id="examples-Default-updateUserConfig-0-objc">
+                              <pre class="prettyprint"><code class="language-cpp">Configuration *apiConfig = [Configuration sharedConfig];
+
+// Configure API key authorization: (authentication scheme: BearerAuth)
+[apiConfig setApiKey:@"YOUR_API_KEY" forApiKeyIdentifier:@"Authorization"];
+// Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+//[apiConfig setApiKeyPrefix:@"Bearer" forApiKeyIdentifier:@"Authorization"];
+
+
+// Create an instance of the API class
+DefaultApi *apiInstance = [[DefaultApi alloc] init];
+String *userID = userID_example; // User ID (default to null)
+UserPropPatch *body = ; // 
+
+[apiInstance updateUserConfigWith:userID
+    body:body
+              completionHandler: ^(NSError* error) {
+    if (error) {
+        NSLog(@"Error: %@", error);
+    }
+}];
+</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-updateUserConfig-0-javascript">
+                              <pre class="prettyprint"><code class="language-js">var FocalboardServer = require('focalboard_server');
+var defaultClient = FocalboardServer.ApiClient.instance;
+
+// Configure API key authorization: BearerAuth
+var BearerAuth = defaultClient.authentications['BearerAuth'];
+BearerAuth.apiKey = "YOUR API KEY";
+// Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+//BearerAuth.apiKeyPrefix['Authorization'] = "Token";
+
+// Create an instance of the API class
+var api = new FocalboardServer.DefaultApi()
+var userID = userID_example; // {String} User ID
+var body = ; // {UserPropPatch} 
+
+var callback = function(error, data, response) {
+  if (error) {
+    console.error(error);
+  } else {
+    console.log('API called successfully.');
+  }
+};
+api.updateUserConfig(userID, body, callback);
+</code></pre>
+                            </div>
+
+                            <!--<div class="tab-pane" id="examples-Default-updateUserConfig-0-angular">
+              <pre class="prettyprint language-json prettyprinted" data-type="json"><code>Coming Soon!</code></pre>
+            </div>-->
+                            <div class="tab-pane" id="examples-Default-updateUserConfig-0-csharp">
+                              <pre class="prettyprint"><code class="language-cs">using System;
+using System.Diagnostics;
+using Org.OpenAPITools.Api;
+using Org.OpenAPITools.Client;
+using Org.OpenAPITools.Model;
+
+namespace Example
+{
+    public class updateUserConfigExample
+    {
+        public void main()
+        {
+            // Configure API key authorization: BearerAuth
+            Configuration.Default.ApiKey.Add("Authorization", "YOUR_API_KEY");
+            // Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+            // Configuration.Default.ApiKeyPrefix.Add("Authorization", "Bearer");
+
+            // Create an instance of the API class
+            var apiInstance = new DefaultApi();
+            var userID = userID_example;  // String | User ID (default to null)
+            var body = new UserPropPatch(); // UserPropPatch | 
+
+            try {
+                apiInstance.updateUserConfig(userID, body);
+            } catch (Exception e) {
+                Debug.Print("Exception when calling DefaultApi.updateUserConfig: " + e.Message );
+            }
+        }
+    }
+}
+</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-updateUserConfig-0-php">
+                              <pre class="prettyprint"><code class="language-php"><&#63;php
+require_once(__DIR__ . '/vendor/autoload.php');
+
+// Configure API key authorization: BearerAuth
+OpenAPITools\Client\Configuration::getDefaultConfiguration()->setApiKey('Authorization', 'YOUR_API_KEY');
+// Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+// OpenAPITools\Client\Configuration::getDefaultConfiguration()->setApiKeyPrefix('Authorization', 'Bearer');
+
+// Create an instance of the API class
+$api_instance = new OpenAPITools\Client\Api\DefaultApi();
+$userID = userID_example; // String | User ID
+$body = ; // UserPropPatch | 
+
+try {
+    $api_instance->updateUserConfig($userID, $body);
+} catch (Exception $e) {
+    echo 'Exception when calling DefaultApi->updateUserConfig: ', $e->getMessage(), PHP_EOL;
+}
+?></code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-updateUserConfig-0-perl">
+                              <pre class="prettyprint"><code class="language-perl">use Data::Dumper;
+use WWW::OPenAPIClient::Configuration;
+use WWW::OPenAPIClient::DefaultApi;
+
+# Configure API key authorization: BearerAuth
+$WWW::OPenAPIClient::Configuration::api_key->{'Authorization'} = 'YOUR_API_KEY';
+# uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+#$WWW::OPenAPIClient::Configuration::api_key_prefix->{'Authorization'} = "Bearer";
+
+# Create an instance of the API class
+my $api_instance = WWW::OPenAPIClient::DefaultApi->new();
+my $userID = userID_example; # String | User ID
+my $body = WWW::OPenAPIClient::Object::UserPropPatch->new(); # UserPropPatch | 
+
+eval {
+    $api_instance->updateUserConfig(userID => $userID, body => $body);
+};
+if ($@) {
+    warn "Exception when calling DefaultApi->updateUserConfig: $@\n";
+}</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-updateUserConfig-0-python">
+                              <pre class="prettyprint"><code class="language-python">from __future__ import print_statement
+import time
+import openapi_client
+from openapi_client.rest import ApiException
+from pprint import pprint
+
+# Configure API key authorization: BearerAuth
+openapi_client.configuration.api_key['Authorization'] = 'YOUR_API_KEY'
+# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+# openapi_client.configuration.api_key_prefix['Authorization'] = 'Bearer'
+
+# Create an instance of the API class
+api_instance = openapi_client.DefaultApi()
+userID = userID_example # String | User ID (default to null)
+body =  # UserPropPatch | 
+
+try:
+    api_instance.update_user_config(userID, body)
+except ApiException as e:
+    print("Exception when calling DefaultApi->updateUserConfig: %s\n" % e)</code></pre>
+                            </div>
+
+                            <div class="tab-pane" id="examples-Default-updateUserConfig-0-rust">
+                              <pre class="prettyprint"><code class="language-rust">extern crate DefaultApi;
+
+pub fn main() {
+    let userID = userID_example; // String
+    let body = ; // UserPropPatch
+
+    let mut context = DefaultApi::Context::default();
+    let result = client.updateUserConfig(userID, body, &context).wait();
+
+    println!("{:?}", result);
+}
+</code></pre>
+                            </div>
+                          </div>
+
+                          <h2>Scopes</h2>
+                          <table>
+                            
+                          </table>
+
+                          <h2>Parameters</h2>
+
+                            <div class="methodsubtabletitle">Path parameters</div>
+                            <table id="methodsubtable">
+                                <tr>
+                                  <th width="150px">Name</th>
+                                  <th>Description</th>
+                                </tr>
+                                  <tr><td style="width:150px;">userID*</td>
+<td>
+
+
+    <div id="d2e199_updateUserConfig_userID">
+        <div class="json-schema-view">
+            <div class="primitive">
+                <span class="type">
+                    String
+                </span>
+
+                    <div class="inner description marked">
+User ID
+                    </div>
+            </div>
+                <div class="inner required">
+                    Required
+                </div>
+        </div>
+    </div>
+</td>
+</tr>
+
+                            </table>
+
+
+                            <div class="methodsubtabletitle">Body parameters</div>
+                            <table id="methodsubtable">
+                              <tr>
+                                <th width="150px">Name</th>
+                                <th>Description</th>
+                              </tr>
+                                <tr><td style="width:150px;">body <span style="color:red;">*</span></td>
+<td>
+<p class="marked">User config patch to apply</p>
+<script>
+$(document).ready(function() {
+  var schemaWrapper = {
+  "description" : "User config patch to apply",
+  "content" : {
+    "application/json" : {
+      "schema" : {
+        "$ref" : "#/components/schemas/UserPropPatch"
+      }
+    }
+  },
+  "required" : true
+};
+
+  var schema = findNode('schema',schemaWrapper).schema;
+  if (!schema) {
+    schema = schemaWrapper.schema;
+  }
+  if (schema.$ref != null) {
+    schema = defsParser.$refs.get(schema.$ref);
+  } else {
+    schemaWrapper.definitions = Object.assign({}, defs);
+    $RefParser.dereference(schemaWrapper).catch(function(err) {
+      console.log(err);
+    });
+  }
+
+  var view = new JSONSchemaView(schema,2,{isBodyParam: true});
+  var result = $('#d2e199_updateUserConfig_body');
+  result.empty();
+  result.append(view.render());
+});
+</script>
+<div id="d2e199_updateUserConfig_body"></div>
+</td>
+</tr>
+
+                            </table>
+
+
+
+                          <h2>Responses</h2>
+                            <h3 id="examples-Default-updateUserConfig-title-200"></h3>
+                            <p id="examples-Default-updateUserConfig-description-200" class="marked"></p>
+                            <script>
+                              var responseDefault200_description = `success`;
+                              var responseDefault200_description_break = responseDefault200_description.indexOf('\n');
+                              if (responseDefault200_description_break == -1) {
+                                $("#examples-Default-updateUserConfig-title-200").text("Status: 200 - " + responseDefault200_description);
+                              } else {
+                                $("#examples-Default-updateUserConfig-title-200").text("Status: 200 - " + responseDefault200_description.substring(0, responseDefault200_description_break));
+                                $("#examples-Default-updateUserConfig-description-200").html(responseDefault200_description.substring(responseDefault200_description_break));
+                              }
+                            </script>
+
+
+                            <ul id="responses-detail-Default-updateUserConfig-200" class="nav nav-tabs nav-tabs-examples" >
+
+
+                            </ul>
+
+
+                            <div class="tab-content" id="responses-Default-updateUserConfig-200-wrapper" style='margin-bottom: 10px;'>
+                            </div>
+                            <h3 id="examples-Default-updateUserConfig-title-default"></h3>
+                            <p id="examples-Default-updateUserConfig-description-default" class="marked"></p>
+                            <script>
+                              var responseDefaultdefault_description = `internal error`;
+                              var responseDefaultdefault_description_break = responseDefaultdefault_description.indexOf('\n');
+                              if (responseDefaultdefault_description_break == -1) {
+                                $("#examples-Default-updateUserConfig-title-default").text("Status: default - " + responseDefaultdefault_description);
+                              } else {
+                                $("#examples-Default-updateUserConfig-title-default").text("Status: default - " + responseDefaultdefault_description.substring(0, responseDefaultdefault_description_break));
+                                $("#examples-Default-updateUserConfig-description-default").html(responseDefaultdefault_description.substring(responseDefaultdefault_description_break));
+                              }
+                            </script>
+
+
+                            <ul id="responses-detail-Default-updateUserConfig-default" class="nav nav-tabs nav-tabs-examples" >
+                                <li class="active">
+                                  <a data-toggle="tab" href="#responses-Default-updateUserConfig-default-schema">Schema</a>
+                                </li>
+
+
+
+
+                            </ul>
+
+
+                            <div class="tab-content" id="responses-Default-updateUserConfig-default-wrapper" style='margin-bottom: 10px;'>
+                                <div class="tab-pane active" id="responses-Default-updateUserConfig-default-schema">
+                                  <div id="responses-Default-updateUserConfig-schema-default" class="exampleStyle">
+                                    <script>
+                                      $(document).ready(function() {
+                                        var schemaWrapper = {
+  "description" : "internal error",
+  "content" : {
+    "application/json" : {
+      "schema" : {
+        "$ref" : "#/components/schemas/ErrorResponse"
+      }
+    }
+  }
+};
+                                        var schema = findNode('schema',schemaWrapper).schema;
+                                        if (!schema) {
+                                          schema = schemaWrapper.schema;
+                                        }
+                                        if (schema.$ref != null) {
+                                          schema = defsParser.$refs.get(schema.$ref);
+                                        } else if (schema.items != null && schema.items.$ref != null) {
+                                            schema.items = defsParser.$refs.get(schema.items.$ref);
+                                        } else {
+                                          schemaWrapper.definitions = Object.assign({}, defs);
+                                          $RefParser.dereference(schemaWrapper).catch(function(err) {
+                                            console.log(err);
+                                          });
+                                        }
+
+                                        var view = new JSONSchemaView(schema, 3);
+                                        $('#responses-Default-updateUserConfig-default-schema-data').val(JSON.stringify(schema));
+                                        var result = $('#responses-Default-updateUserConfig-schema-default');
+                                        result.empty();
+                                        result.append(view.render());
+                                      });
+                                    </script>
+                                  </div>
+                                  <input id='responses-Default-updateUserConfig-default-schema-data' type='hidden' value=''></input>
+                                </div>
+                            </div>
+                        </article>
+                      </div>
+                      <hr>
                     <div id="api-Default-uploadFile">
                       <article id="api-Default-uploadFile-0" data-group="User" data-name="uploadFile" data-version="0">
                         <div class="pull-left">
@@ -12148,7 +23620,7 @@ $(document).ready(function() {
                         <p class="marked">Upload a binary file, attached to a root block</p>
                         <p></p>
                         <br />
-                        <pre class="prettyprint language-html prettyprinted" data-type="post"><code><span class="pln">/api/v1/workspaces/{workspaceID}/{rootID}/files</span></code></pre>
+                        <pre class="prettyprint language-html prettyprinted" data-type="post"><code><span class="pln">/teams/{teamID}/boards/{boardID}/files</span></code></pre>
                         <p>
                           <h3>Usage and SDK Samples</h3>
                         </p>
@@ -12173,7 +23645,7 @@ $(document).ready(function() {
 -H "Authorization: [[apiKey]]" \
  -H "Accept: application/json" \
  -H "Content-Type: multipart/form-data" \
- "http://localhost/api/v1/api/v1/workspaces/{workspaceID}/{rootID}/files"
+ "http://localhost/api/v2/teams/{teamID}/boards/{boardID}/files"
 </code></pre>
                           </div>
                           <div class="tab-pane" id="examples-Default-uploadFile-0-java">
@@ -12197,12 +23669,12 @@ public class DefaultApiExample {
 
         // Create an instance of the API class
         DefaultApi apiInstance = new DefaultApi();
-        String workspaceID = workspaceID_example; // String | Workspace ID
-        String rootID = rootID_example; // String | ID of the root block
+        String teamID = teamID_example; // String | ID of the team
+        String boardID = boardID_example; // String | Board ID
         File uploaded file = BINARY_DATA_HERE; // File | The file to upload
 
         try {
-            FileUploadResponse result = apiInstance.uploadFile(workspaceID, rootID, uploaded file);
+            FileUploadResponse result = apiInstance.uploadFile(teamID, boardID, uploaded file);
             System.out.println(result);
         } catch (ApiException e) {
             System.err.println("Exception when calling DefaultApi#uploadFile");
@@ -12219,12 +23691,12 @@ public class DefaultApiExample {
 public class DefaultApiExample {
     public static void main(String[] args) {
         DefaultApi apiInstance = new DefaultApi();
-        String workspaceID = workspaceID_example; // String | Workspace ID
-        String rootID = rootID_example; // String | ID of the root block
+        String teamID = teamID_example; // String | ID of the team
+        String boardID = boardID_example; // String | Board ID
         File uploaded file = BINARY_DATA_HERE; // File | The file to upload
 
         try {
-            FileUploadResponse result = apiInstance.uploadFile(workspaceID, rootID, uploaded file);
+            FileUploadResponse result = apiInstance.uploadFile(teamID, boardID, uploaded file);
             System.out.println(result);
         } catch (ApiException e) {
             System.err.println("Exception when calling DefaultApi#uploadFile");
@@ -12248,12 +23720,12 @@ public class DefaultApiExample {
 
 // Create an instance of the API class
 DefaultApi *apiInstance = [[DefaultApi alloc] init];
-String *workspaceID = workspaceID_example; // Workspace ID (default to null)
-String *rootID = rootID_example; // ID of the root block (default to null)
+String *teamID = teamID_example; // ID of the team (default to null)
+String *boardID = boardID_example; // Board ID (default to null)
 File *uploaded file = BINARY_DATA_HERE; // The file to upload (optional) (default to null)
 
-[apiInstance uploadFileWith:workspaceID
-    rootID:rootID
+[apiInstance uploadFileWith:teamID
+    boardID:boardID
     uploaded file:uploaded file
               completionHandler: ^(FileUploadResponse output, NSError* error) {
     if (output) {
@@ -12278,8 +23750,8 @@ BearerAuth.apiKey = "YOUR API KEY";
 
 // Create an instance of the API class
 var api = new FocalboardServer.DefaultApi()
-var workspaceID = workspaceID_example; // {String} Workspace ID
-var rootID = rootID_example; // {String} ID of the root block
+var teamID = teamID_example; // {String} ID of the team
+var boardID = boardID_example; // {String} Board ID
 var opts = {
   'uploaded file': BINARY_DATA_HERE // {File} The file to upload
 };
@@ -12291,7 +23763,7 @@ var callback = function(error, data, response) {
     console.log('API called successfully. Returned data: ' + data);
   }
 };
-api.uploadFile(workspaceID, rootID, opts, callback);
+api.uploadFile(teamID, boardID, opts, callback);
 </code></pre>
                             </div>
 
@@ -12318,12 +23790,12 @@ namespace Example
 
             // Create an instance of the API class
             var apiInstance = new DefaultApi();
-            var workspaceID = workspaceID_example;  // String | Workspace ID (default to null)
-            var rootID = rootID_example;  // String | ID of the root block (default to null)
+            var teamID = teamID_example;  // String | ID of the team (default to null)
+            var boardID = boardID_example;  // String | Board ID (default to null)
             var uploaded file = BINARY_DATA_HERE;  // File | The file to upload (optional)  (default to null)
 
             try {
-                FileUploadResponse result = apiInstance.uploadFile(workspaceID, rootID, uploaded file);
+                FileUploadResponse result = apiInstance.uploadFile(teamID, boardID, uploaded file);
                 Debug.WriteLine(result);
             } catch (Exception e) {
                 Debug.Print("Exception when calling DefaultApi.uploadFile: " + e.Message );
@@ -12345,12 +23817,12 @@ OpenAPITools\Client\Configuration::getDefaultConfiguration()->setApiKey('Authori
 
 // Create an instance of the API class
 $api_instance = new OpenAPITools\Client\Api\DefaultApi();
-$workspaceID = workspaceID_example; // String | Workspace ID
-$rootID = rootID_example; // String | ID of the root block
+$teamID = teamID_example; // String | ID of the team
+$boardID = boardID_example; // String | Board ID
 $uploaded file = BINARY_DATA_HERE; // File | The file to upload
 
 try {
-    $result = $api_instance->uploadFile($workspaceID, $rootID, $uploaded file);
+    $result = $api_instance->uploadFile($teamID, $boardID, $uploaded file);
     print_r($result);
 } catch (Exception $e) {
     echo 'Exception when calling DefaultApi->uploadFile: ', $e->getMessage(), PHP_EOL;
@@ -12370,12 +23842,12 @@ $WWW::OPenAPIClient::Configuration::api_key->{'Authorization'} = 'YOUR_API_KEY';
 
 # Create an instance of the API class
 my $api_instance = WWW::OPenAPIClient::DefaultApi->new();
-my $workspaceID = workspaceID_example; # String | Workspace ID
-my $rootID = rootID_example; # String | ID of the root block
+my $teamID = teamID_example; # String | ID of the team
+my $boardID = boardID_example; # String | Board ID
 my $uploaded file = BINARY_DATA_HERE; # File | The file to upload
 
 eval {
-    my $result = $api_instance->uploadFile(workspaceID => $workspaceID, rootID => $rootID, uploaded file => $uploaded file);
+    my $result = $api_instance->uploadFile(teamID => $teamID, boardID => $boardID, uploaded file => $uploaded file);
     print Dumper($result);
 };
 if ($@) {
@@ -12397,12 +23869,12 @@ openapi_client.configuration.api_key['Authorization'] = 'YOUR_API_KEY'
 
 # Create an instance of the API class
 api_instance = openapi_client.DefaultApi()
-workspaceID = workspaceID_example # String | Workspace ID (default to null)
-rootID = rootID_example # String | ID of the root block (default to null)
+teamID = teamID_example # String | ID of the team (default to null)
+boardID = boardID_example # String | Board ID (default to null)
 uploaded file = BINARY_DATA_HERE # File | The file to upload (optional) (default to null)
 
 try:
-    api_response = api_instance.upload_file(workspaceID, rootID, uploaded file=uploaded file)
+    api_response = api_instance.upload_file(teamID, boardID, uploaded file=uploaded file)
     pprint(api_response)
 except ApiException as e:
     print("Exception when calling DefaultApi->uploadFile: %s\n" % e)</code></pre>
@@ -12412,12 +23884,12 @@ except ApiException as e:
                               <pre class="prettyprint"><code class="language-rust">extern crate DefaultApi;
 
 pub fn main() {
-    let workspaceID = workspaceID_example; // String
-    let rootID = rootID_example; // String
+    let teamID = teamID_example; // String
+    let boardID = boardID_example; // String
     let uploaded file = BINARY_DATA_HERE; // File
 
     let mut context = DefaultApi::Context::default();
-    let result = client.uploadFile(workspaceID, rootID, uploaded file, &context).wait();
+    let result = client.uploadFile(teamID, boardID, uploaded file, &context).wait();
 
     println!("{:?}", result);
 }
@@ -12438,11 +23910,11 @@ pub fn main() {
                                   <th width="150px">Name</th>
                                   <th>Description</th>
                                 </tr>
-                                  <tr><td style="width:150px;">workspaceID*</td>
+                                  <tr><td style="width:150px;">teamID*</td>
 <td>
 
 
-    <div id="d2e199_uploadFile_workspaceID">
+    <div id="d2e199_uploadFile_teamID">
         <div class="json-schema-view">
             <div class="primitive">
                 <span class="type">
@@ -12450,7 +23922,7 @@ pub fn main() {
                 </span>
 
                     <div class="inner description marked">
-Workspace ID
+ID of the team
                     </div>
             </div>
                 <div class="inner required">
@@ -12461,11 +23933,11 @@ Workspace ID
 </td>
 </tr>
 
-                                  <tr><td style="width:150px;">rootID*</td>
+                                  <tr><td style="width:150px;">boardID*</td>
 <td>
 
 
-    <div id="d2e199_uploadFile_rootID">
+    <div id="d2e199_uploadFile_boardID">
         <div class="json-schema-view">
             <div class="primitive">
                 <span class="type">
@@ -12473,7 +23945,7 @@ Workspace ID
                 </span>
 
                     <div class="inner description marked">
-ID of the root block
+Board ID
                     </div>
             </div>
                 <div class="inner required">
@@ -12586,6 +24058,28 @@ The file to upload
                                   </div>
                                   <input id='responses-Default-uploadFile-200-schema-data' type='hidden' value=''></input>
                                 </div>
+                            </div>
+                            <h3 id="examples-Default-uploadFile-title-404"></h3>
+                            <p id="examples-Default-uploadFile-description-404" class="marked"></p>
+                            <script>
+                              var responseDefault404_description = `board not found`;
+                              var responseDefault404_description_break = responseDefault404_description.indexOf('\n');
+                              if (responseDefault404_description_break == -1) {
+                                $("#examples-Default-uploadFile-title-404").text("Status: 404 - " + responseDefault404_description);
+                              } else {
+                                $("#examples-Default-uploadFile-title-404").text("Status: 404 - " + responseDefault404_description.substring(0, responseDefault404_description_break));
+                                $("#examples-Default-uploadFile-description-404").html(responseDefault404_description.substring(responseDefault404_description_break));
+                              }
+                            </script>
+
+
+                            <ul id="responses-detail-Default-uploadFile-404" class="nav nav-tabs nav-tabs-examples" >
+
+
+                            </ul>
+
+
+                            <div class="tab-content" id="responses-Default-uploadFile-404-wrapper" style='margin-bottom: 10px;'>
                             </div>
                             <h3 id="examples-Default-uploadFile-title-default"></h3>
                             <p id="examples-Default-uploadFile-description-default" class="marked"></p>

--- a/server/swagger/swagger.yml
+++ b/server/swagger/swagger.yml
@@ -1,4 +1,4 @@
-basePath: /api/v1
+basePath: /api/v2
 consumes:
 - application/json
 definitions:
@@ -221,7 +221,8 @@ definitions:
     type: object
     x-go-package: github.com/mattermost/focalboard/server/model
   BoardMember:
-    description: BoardMember stores the information of the membership of a user on a board
+    description: BoardMember stores the information of the membership of a user on
+      a board
     properties:
       boardId:
         description: The ID of the board
@@ -261,7 +262,8 @@ definitions:
     type: object
     x-go-package: github.com/mattermost/focalboard/server/model
   BoardMemberHistoryEntry:
-    description: BoardMemberHistoryEntry stores the information of the membership of a user on a board
+    description: BoardMemberHistoryEntry stores the information of the membership
+      of a user on a board
     properties:
       action:
         description: The action that added this history entry (created or deleted)
@@ -298,17 +300,20 @@ definitions:
         type: string
         x-go-name: CreatedBy
       descendantFirstUpdateAt:
-        description: The earliest time a descendant of this board was added, modified, or deleted
+        description: The earliest time a descendant of this board was added, modified,
+          or deleted
         format: int64
         type: integer
         x-go-name: DescendantFirstUpdateAt
       descendantLastUpdateAt:
-        description: The most recent time a descendant of this board was added, modified, or deleted
+        description: The most recent time a descendant of this board was added, modified,
+          or deleted
         format: int64
         type: integer
         x-go-name: DescendantLastUpdateAt
       lastModifiedBy:
-        description: The ID of the user that last modified the most recently modified descendant
+        description: The ID of the user that last modified the most recently modified
+          descendant
         type: string
         x-go-name: LastModifiedBy
     required:
@@ -627,7 +632,8 @@ definitions:
     type: object
     x-go-package: github.com/mattermost/focalboard/server/model
   Subscriber:
-    description: Subscriber is an entity (e.g. user, channel) that can subscribe to events from boards, cards, etc
+    description: Subscriber is an entity (e.g. user, channel) that can subscribe to
+      events from boards, cards, etc
     properties:
       notified_at:
         description: NotifiedAt is the timestamp this subscriber was last notified
@@ -662,12 +668,14 @@ definitions:
         type: integer
         x-go-name: CreateAt
       deleteAt:
-        description: DeleteAt is the timestamp this subscription was deleted, or zero if not deleted
+        description: DeleteAt is the timestamp this subscription was deleted, or zero
+          if not deleted
         format: int64
         type: integer
         x-go-name: DeleteAt
       notifiedAt:
-        description: NotifiedAt is the timestamp of the last notification sent for this subscription
+        description: NotifiedAt is the timestamp of the last notification sent for
+          this subscription
         format: int64
         type: integer
         x-go-name: NotifiedAt
@@ -746,6 +754,10 @@ definitions:
         description: If the user is a bot or not
         type: boolean
         x-go-name: IsBot
+      is_guest:
+        description: If the user is a guest or not
+        type: boolean
+        x-go-name: IsGuest
       props:
         additionalProperties:
           type: object
@@ -769,6 +781,7 @@ definitions:
     - update_at
     - delete_at
     - is_bot
+    - is_guest
     type: object
     x-go-package: github.com/mattermost/focalboard/server/model
   UserPropPatch:
@@ -801,7 +814,7 @@ info:
   title: Focalboard Server
   version: 1.0.0
 paths:
-  /api/v1/boards:
+  /boards:
     post:
       description: Creates a new board
       operationId: createBoard
@@ -825,7 +838,7 @@ paths:
             $ref: '#/definitions/ErrorResponse'
       security:
       - BearerAuth: []
-  /api/v1/boards-and-blocks:
+  /boards-and-blocks:
     delete:
       description: Deletes boards and blocks
       operationId: deleteBoardsAndBlocks
@@ -893,7 +906,7 @@ paths:
             $ref: '#/definitions/ErrorResponse'
       security:
       - BearerAuth: []
-  /api/v1/boards/{boardID}:
+  /boards/{boardID}:
     delete:
       description: Removes a board
       operationId: deleteBoard
@@ -970,7 +983,7 @@ paths:
             $ref: '#/definitions/ErrorResponse'
       security:
       - BearerAuth: []
-  /api/v1/boards/{boardID}/archive/export:
+  /boards/{boardID}/archive/export:
     get:
       operationId: archiveExportBoard
       parameters:
@@ -991,7 +1004,7 @@ paths:
       security:
       - BearerAuth: []
       summary: Exports an archive of all blocks for one boards.
-  /api/v1/boards/{boardID}/blocks:
+  /boards/{boardID}/blocks:
     get:
       description: Returns blocks
       operationId: getBlocks
@@ -1061,7 +1074,7 @@ paths:
             $ref: '#/definitions/ErrorResponse'
       security:
       - BearerAuth: []
-  /api/v1/boards/{boardID}/blocks/:
+  /boards/{boardID}/blocks/:
     patch:
       description: Partially updates batch of blocks
       operationId: patchBlocks
@@ -1088,7 +1101,7 @@ paths:
             $ref: '#/definitions/ErrorResponse'
       security:
       - BearerAuth: []
-  /api/v1/boards/{boardID}/blocks/{blockID}:
+  /boards/{boardID}/blocks/{blockID}:
     delete:
       description: Deletes a block
       operationId: deleteBlock
@@ -1149,7 +1162,7 @@ paths:
             $ref: '#/definitions/ErrorResponse'
       security:
       - BearerAuth: []
-  /api/v1/boards/{boardID}/blocks/{blockID}/duplicate:
+  /boards/{boardID}/blocks/{blockID}/duplicate:
     post:
       description: Returns the new created blocks
       operationId: duplicateBlock
@@ -1181,43 +1194,7 @@ paths:
             $ref: '#/definitions/ErrorResponse'
       security:
       - BearerAuth: []
-  /api/v1/boards/{boardID}/blocks/{blockID}/subtree:
-    get:
-      description: Returns the blocks of a subtree
-      operationId: getSubTree
-      parameters:
-      - description: Board ID
-        in: path
-        name: boardID
-        required: true
-        type: string
-      - description: The ID of the root block of the subtree
-        in: path
-        name: blockID
-        required: true
-        type: string
-      - description: The number of levels to return. 2 or 3. Defaults to 2.
-        in: query
-        maximum: 3
-        minimum: 2
-        name: l
-        type: integer
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: success
-          schema:
-            items:
-              $ref: '#/definitions/Block'
-            type: array
-        default:
-          description: internal error
-          schema:
-            $ref: '#/definitions/ErrorResponse'
-      security:
-      - BearerAuth: []
-  /api/v1/boards/{boardID}/blocks/{blockID}/undelete:
+  /boards/{boardID}/blocks/{blockID}/undelete:
     post:
       description: Undeletes a block
       operationId: undeleteBlock
@@ -1247,61 +1224,7 @@ paths:
             $ref: '#/definitions/ErrorResponse'
       security:
       - BearerAuth: []
-  /api/v1/boards/{boardID}/blocks/export:
-    get:
-      description: Returns all blocks of a board
-      operationId: exportBlocks
-      parameters:
-      - description: Board ID
-        in: path
-        name: boardID
-        required: true
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: success
-          schema:
-            items:
-              $ref: '#/definitions/Block'
-            type: array
-        default:
-          description: internal error
-          schema:
-            $ref: '#/definitions/ErrorResponse'
-      security:
-      - BearerAuth: []
-  /api/v1/boards/{boardID}/blocks/import:
-    post:
-      description: Import blocks on a given board
-      operationId: importBlocks
-      parameters:
-      - description: Board ID
-        in: path
-        name: boardID
-        required: true
-        type: string
-      - description: array of blocks to import
-        in: body
-        name: Body
-        required: true
-        schema:
-          items:
-            $ref: '#/definitions/Block'
-          type: array
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: success
-        default:
-          description: internal error
-          schema:
-            $ref: '#/definitions/ErrorResponse'
-      security:
-      - BearerAuth: []
-  /api/v1/boards/{boardID}/duplicate:
+  /boards/{boardID}/duplicate:
     post:
       description: Returns the new created board and all the blocks
       operationId: duplicateBoard
@@ -1320,672 +1243,6 @@ paths:
             $ref: '#/definitions/BoardsAndBlocks'
         "404":
           description: board not found
-        default:
-          description: internal error
-          schema:
-            $ref: '#/definitions/ErrorResponse'
-      security:
-      - BearerAuth: []
-  /api/v1/boards/{boardID}/members:
-    get:
-      description: Returns the members of the board
-      operationId: getMembersForBoard
-      parameters:
-      - description: Board ID
-        in: path
-        name: boardID
-        required: true
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: success
-          schema:
-            items:
-              $ref: '#/definitions/BoardMember'
-            type: array
-        default:
-          description: internal error
-          schema:
-            $ref: '#/definitions/ErrorResponse'
-      security:
-      - BearerAuth: []
-  /api/v1/boards/{boardID}/members/{userID}:
-    delete:
-      description: Deletes a member from a board
-      operationId: deleteMember
-      parameters:
-      - description: Board ID
-        in: path
-        name: boardID
-        required: true
-        type: string
-      - description: User ID
-        in: path
-        name: userID
-        required: true
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: success
-        "404":
-          description: board not found
-        default:
-          description: internal error
-          schema:
-            $ref: '#/definitions/ErrorResponse'
-      security:
-      - BearerAuth: []
-  /api/v1/boards/{boardID}/metadata:
-    get:
-      description: Returns a board's metadata
-      operationId: getBoardMetadata
-      parameters:
-      - description: Board ID
-        in: path
-        name: boardID
-        required: true
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: success
-          schema:
-            $ref: '#/definitions/BoardMetadata'
-        "404":
-          description: board not found
-        "501":
-          description: required license not found
-        default:
-          description: internal error
-          schema:
-            $ref: '#/definitions/ErrorResponse'
-      security:
-      - BearerAuth: []
-  /api/v1/boards/{boardID}/sharing:
-    get:
-      description: Returns sharing information for a board
-      operationId: getSharing
-      parameters:
-      - description: Board ID
-        in: path
-        name: boardID
-        required: true
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: success
-          schema:
-            $ref: '#/definitions/Sharing'
-        "404":
-          description: board not found
-        default:
-          description: internal error
-          schema:
-            $ref: '#/definitions/ErrorResponse'
-      security:
-      - BearerAuth: []
-    post:
-      description: Sets sharing information for a board
-      operationId: postSharing
-      parameters:
-      - description: Board ID
-        in: path
-        name: boardID
-        required: true
-        type: string
-      - description: sharing information for a root block
-        in: body
-        name: Body
-        required: true
-        schema:
-          $ref: '#/definitions/Sharing'
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: success
-        default:
-          description: internal error
-          schema:
-            $ref: '#/definitions/ErrorResponse'
-      security:
-      - BearerAuth: []
-  /api/v1/login:
-    post:
-      description: Login user
-      operationId: login
-      parameters:
-      - description: Login request
-        in: body
-        name: body
-        required: true
-        schema:
-          $ref: '#/definitions/LoginRequest'
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: success
-          schema:
-            $ref: '#/definitions/LoginResponse'
-        "401":
-          description: invalid login
-          schema:
-            $ref: '#/definitions/ErrorResponse'
-        "500":
-          description: internal error
-          schema:
-            $ref: '#/definitions/ErrorResponse'
-  /api/v1/logout:
-    post:
-      description: Logout user
-      operationId: logout
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: success
-        "500":
-          description: internal error
-          schema:
-            $ref: '#/definitions/ErrorResponse'
-      security:
-      - BearerAuth: []
-  /api/v1/register:
-    post:
-      description: Register new user
-      operationId: register
-      parameters:
-      - description: Register request
-        in: body
-        name: body
-        required: true
-        schema:
-          $ref: '#/definitions/RegisterRequest'
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: success
-        "401":
-          description: invalid registration token
-        "500":
-          description: internal error
-          schema:
-            $ref: '#/definitions/ErrorResponse'
-  /api/v1/subscriptions:
-    post:
-      operationId: createSubscription
-      parameters:
-      - description: subscription definition
-        in: body
-        name: Body
-        required: true
-        schema:
-          $ref: '#/definitions/Subscription'
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: success
-          schema:
-            $ref: '#/definitions/User'
-        default:
-          description: internal error
-          schema:
-            $ref: '#/definitions/ErrorResponse'
-      security:
-      - BearerAuth: []
-      summary: Creates a subscription to a block for a user. The user will receive change notifications for the block.
-  /api/v1/subscriptions/{blockID}/{subscriberID}:
-    delete:
-      operationId: deleteSubscription
-      parameters:
-      - description: Block ID
-        in: path
-        name: blockID
-        required: true
-        type: string
-      - description: Subscriber ID
-        in: path
-        name: subscriberID
-        required: true
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: success
-        default:
-          description: internal error
-          schema:
-            $ref: '#/definitions/ErrorResponse'
-      security:
-      - BearerAuth: []
-      summary: Deletes a subscription a user has for a a block. The user will no longer receive change notifications for the block.
-  /api/v1/subscriptions/{subscriberID}:
-    get:
-      operationId: getSubscriptions
-      parameters:
-      - description: Subscriber ID
-        in: path
-        name: subscriberID
-        required: true
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: success
-          schema:
-            items:
-              $ref: '#/definitions/User'
-            type: array
-        default:
-          description: internal error
-          schema:
-            $ref: '#/definitions/ErrorResponse'
-      security:
-      - BearerAuth: []
-      summary: Gets subscriptions for a user.
-  /api/v1/team/{teamID}/onboard:
-    post:
-      operationId: onboard
-      parameters:
-      - description: Team ID
-        in: path
-        name: teamID
-        required: true
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: success
-          schema:
-            $ref: '#/definitions/OnboardingResponse'
-        default:
-          description: internal error
-          schema:
-            $ref: '#/definitions/ErrorResponse'
-      security:
-      - BearerAuth: []
-      summary: Onboards a user on Boards.
-  /api/v1/teams:
-    get:
-      description: Returns information of all the teams
-      operationId: getTeams
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: success
-          schema:
-            items:
-              $ref: '#/definitions/Team'
-            type: array
-        default:
-          description: internal error
-          schema:
-            $ref: '#/definitions/ErrorResponse'
-      security:
-      - BearerAuth: []
-  /api/v1/teams/{teamID}:
-    get:
-      description: Returns information of the root team
-      operationId: getTeam
-      parameters:
-      - description: Team ID
-        in: path
-        name: teamID
-        required: true
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: success
-          schema:
-            $ref: '#/definitions/Team'
-        default:
-          description: internal error
-          schema:
-            $ref: '#/definitions/ErrorResponse'
-      security:
-      - BearerAuth: []
-  /api/v1/teams/{teamID}/archive/export:
-    get:
-      operationId: archiveExportTeam
-      parameters:
-      - description: Id of team
-        in: path
-        name: teamID
-        required: true
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: success
-        default:
-          description: internal error
-          schema:
-            $ref: '#/definitions/ErrorResponse'
-      security:
-      - BearerAuth: []
-      summary: Exports an archive of all blocks for all the boards in a team.
-  /api/v1/teams/{teamID}/archive/import:
-    post:
-      consumes:
-      - multipart/form-data
-      operationId: archiveImport
-      parameters:
-      - description: Team ID
-        in: path
-        name: teamID
-        required: true
-        type: string
-      - description: archive file to import
-        in: formData
-        name: file
-        required: true
-        type: file
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: success
-        default:
-          description: internal error
-          schema:
-            $ref: '#/definitions/ErrorResponse'
-      security:
-      - BearerAuth: []
-      summary: Import an archive of boards.
-  /api/v1/teams/{teamID}/boards:
-    get:
-      description: Returns team boards
-      operationId: getBoards
-      parameters:
-      - description: Team ID
-        in: path
-        name: teamID
-        required: true
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: success
-          schema:
-            items:
-              $ref: '#/definitions/Board'
-            type: array
-        default:
-          description: internal error
-          schema:
-            $ref: '#/definitions/ErrorResponse'
-      security:
-      - BearerAuth: []
-  /api/v1/teams/{teamID}/boards/{boardID}/files:
-    post:
-      consumes:
-      - multipart/form-data
-      description: Upload a binary file, attached to a root block
-      operationId: uploadFile
-      parameters:
-      - description: ID of the team
-        in: path
-        name: teamID
-        required: true
-        type: string
-      - description: Board ID
-        in: path
-        name: boardID
-        required: true
-        type: string
-      - description: The file to upload
-        in: formData
-        name: uploaded file
-        type: file
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: success
-          schema:
-            $ref: '#/definitions/FileUploadResponse'
-        "404":
-          description: board not found
-        default:
-          description: internal error
-          schema:
-            $ref: '#/definitions/ErrorResponse'
-      security:
-      - BearerAuth: []
-  /api/v1/teams/{teamID}/boards/search:
-    get:
-      description: Returns the boards that match with a search term
-      operationId: searchBoards
-      parameters:
-      - description: Team ID
-        in: path
-        name: teamID
-        required: true
-        type: string
-      - description: The search term. Must have at least one character
-        in: query
-        name: q
-        required: true
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: success
-          schema:
-            items:
-              $ref: '#/definitions/Board'
-            type: array
-        default:
-          description: internal error
-          schema:
-            $ref: '#/definitions/ErrorResponse'
-      security:
-      - BearerAuth: []
-  /api/v1/teams/{teamID}/regenerate_signup_token:
-    post:
-      description: Regenerates the signup token for the root team
-      operationId: regenerateSignupToken
-      parameters:
-      - description: Team ID
-        in: path
-        name: teamID
-        required: true
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: success
-        default:
-          description: internal error
-          schema:
-            $ref: '#/definitions/ErrorResponse'
-      security:
-      - BearerAuth: []
-  /api/v1/teams/{teamID}/templates:
-    get:
-      description: Returns team templates
-      operationId: getTemplates
-      parameters:
-      - description: Team ID
-        in: path
-        name: teamID
-        required: true
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: success
-          schema:
-            items:
-              $ref: '#/definitions/Board'
-            type: array
-        default:
-          description: internal error
-          schema:
-            $ref: '#/definitions/ErrorResponse'
-      security:
-      - BearerAuth: []
-  /api/v1/teams/{teamID}/users:
-    get:
-      description: Returns team users
-      operationId: getTeamUsers
-      parameters:
-      - description: Team ID
-        in: path
-        name: teamID
-        required: true
-        type: string
-      - description: string to filter users list
-        in: query
-        name: search
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: success
-          schema:
-            items:
-              $ref: '#/definitions/User'
-            type: array
-        default:
-          description: internal error
-          schema:
-            $ref: '#/definitions/ErrorResponse'
-      security:
-      - BearerAuth: []
-  /api/v1/users/{userID}:
-    get:
-      description: Returns a user
-      operationId: getUser
-      parameters:
-      - description: User ID
-        in: path
-        name: userID
-        required: true
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: success
-          schema:
-            $ref: '#/definitions/User'
-        default:
-          description: internal error
-          schema:
-            $ref: '#/definitions/ErrorResponse'
-      security:
-      - BearerAuth: []
-  /api/v1/users/{userID}/changepassword:
-    post:
-      description: Change a user's password
-      operationId: changePassword
-      parameters:
-      - description: User ID
-        in: path
-        name: userID
-        required: true
-        type: string
-      - description: Change password request
-        in: body
-        name: body
-        required: true
-        schema:
-          $ref: '#/definitions/ChangePasswordRequest'
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: success
-        "400":
-          description: invalid request
-          schema:
-            $ref: '#/definitions/ErrorResponse'
-        "500":
-          description: internal error
-          schema:
-            $ref: '#/definitions/ErrorResponse'
-      security:
-      - BearerAuth: []
-  /api/v1/users/{userID}/config:
-    patch:
-      description: Updates user config
-      operationId: updateUserConfig
-      parameters:
-      - description: User ID
-        in: path
-        name: userID
-        required: true
-        type: string
-      - description: User config patch to apply
-        in: body
-        name: Body
-        required: true
-        schema:
-          $ref: '#/definitions/UserPropPatch'
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: success
-        default:
-          description: internal error
-          schema:
-            $ref: '#/definitions/ErrorResponse'
-      security:
-      - BearerAuth: []
-  /api/v1/users/me:
-    get:
-      description: Returns the currently logged-in user
-      operationId: getMe
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: success
-          schema:
-            $ref: '#/definitions/User'
-        default:
-          description: internal error
-          schema:
-            $ref: '#/definitions/ErrorResponse'
-      security:
-      - BearerAuth: []
-  /api/v1/users/me/memberships:
-    get:
-      description: Returns the currently users board memberships
-      operationId: getMyMemberships
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: success
-          schema:
-            items:
-              $ref: '#/definitions/BoardMember'
-            type: array
         default:
           description: internal error
           schema:
@@ -2045,6 +1302,30 @@ paths:
       security:
       - BearerAuth: []
   /boards/{boardID}/members:
+    get:
+      description: Returns the members of the board
+      operationId: getMembersForBoard
+      parameters:
+      - description: Board ID
+        in: path
+        name: boardID
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: success
+          schema:
+            items:
+              $ref: '#/definitions/BoardMember'
+            type: array
+        default:
+          description: internal error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+      security:
+      - BearerAuth: []
     post:
       description: Adds a new member to a board
       operationId: addMember
@@ -2076,6 +1357,33 @@ paths:
       security:
       - BearerAuth: []
   /boards/{boardID}/members/{userID}:
+    delete:
+      description: Deletes a member from a board
+      operationId: deleteMember
+      parameters:
+      - description: Board ID
+        in: path
+        name: boardID
+        required: true
+        type: string
+      - description: User ID
+        in: path
+        name: userID
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: success
+        "404":
+          description: board not found
+        default:
+          description: internal error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+      security:
+      - BearerAuth: []
     put:
       description: Updates a board member
       operationId: updateMember
@@ -2109,6 +1417,642 @@ paths:
             $ref: '#/definitions/ErrorResponse'
       security:
       - BearerAuth: []
+  /boards/{boardID}/metadata:
+    get:
+      description: Returns a board's metadata
+      operationId: getBoardMetadata
+      parameters:
+      - description: Board ID
+        in: path
+        name: boardID
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: success
+          schema:
+            $ref: '#/definitions/BoardMetadata'
+        "404":
+          description: board not found
+        "501":
+          description: required license not found
+        default:
+          description: internal error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+      security:
+      - BearerAuth: []
+  /boards/{boardID}/sharing:
+    get:
+      description: Returns sharing information for a board
+      operationId: getSharing
+      parameters:
+      - description: Board ID
+        in: path
+        name: boardID
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: success
+          schema:
+            $ref: '#/definitions/Sharing'
+        "404":
+          description: board not found
+        default:
+          description: internal error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+      security:
+      - BearerAuth: []
+    post:
+      description: Sets sharing information for a board
+      operationId: postSharing
+      parameters:
+      - description: Board ID
+        in: path
+        name: boardID
+        required: true
+        type: string
+      - description: sharing information for a root block
+        in: body
+        name: Body
+        required: true
+        schema:
+          $ref: '#/definitions/Sharing'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: success
+        default:
+          description: internal error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+      security:
+      - BearerAuth: []
+  /boards/{boardID}/undelete:
+    post:
+      description: Undeletes a board
+      operationId: undeleteBoard
+      parameters:
+      - description: ID of board to undelete
+        in: path
+        name: boardID
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: success
+        default:
+          description: internal error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+      security:
+      - BearerAuth: []
+  /login:
+    post:
+      description: Login user
+      operationId: login
+      parameters:
+      - description: Login request
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/LoginRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: success
+          schema:
+            $ref: '#/definitions/LoginResponse'
+        "401":
+          description: invalid login
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+        "500":
+          description: internal error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+  /logout:
+    post:
+      description: Logout user
+      operationId: logout
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: success
+        "500":
+          description: internal error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+      security:
+      - BearerAuth: []
+  /register:
+    post:
+      description: Register new user
+      operationId: register
+      parameters:
+      - description: Register request
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/RegisterRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: success
+        "401":
+          description: invalid registration token
+        "500":
+          description: internal error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+  /subscriptions:
+    post:
+      operationId: createSubscription
+      parameters:
+      - description: subscription definition
+        in: body
+        name: Body
+        required: true
+        schema:
+          $ref: '#/definitions/Subscription'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: success
+          schema:
+            $ref: '#/definitions/User'
+        default:
+          description: internal error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Creates a subscription to a block for a user. The user will receive
+        change notifications for the block.
+  /subscriptions/{blockID}/{subscriberID}:
+    delete:
+      operationId: deleteSubscription
+      parameters:
+      - description: Block ID
+        in: path
+        name: blockID
+        required: true
+        type: string
+      - description: Subscriber ID
+        in: path
+        name: subscriberID
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: success
+        default:
+          description: internal error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Deletes a subscription a user has for a a block. The user will no longer
+        receive change notifications for the block.
+  /subscriptions/{subscriberID}:
+    get:
+      operationId: getSubscriptions
+      parameters:
+      - description: Subscriber ID
+        in: path
+        name: subscriberID
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: success
+          schema:
+            items:
+              $ref: '#/definitions/User'
+            type: array
+        default:
+          description: internal error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Gets subscriptions for a user.
+  /team/{teamID}/onboard:
+    post:
+      operationId: onboard
+      parameters:
+      - description: Team ID
+        in: path
+        name: teamID
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: success
+          schema:
+            $ref: '#/definitions/OnboardingResponse'
+        default:
+          description: internal error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Onboards a user on Boards.
+  /teams:
+    get:
+      description: Returns information of all the teams
+      operationId: getTeams
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: success
+          schema:
+            items:
+              $ref: '#/definitions/Team'
+            type: array
+        default:
+          description: internal error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+      security:
+      - BearerAuth: []
+  /teams/{teamID}:
+    get:
+      description: Returns information of the root team
+      operationId: getTeam
+      parameters:
+      - description: Team ID
+        in: path
+        name: teamID
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: success
+          schema:
+            $ref: '#/definitions/Team'
+        default:
+          description: internal error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+      security:
+      - BearerAuth: []
+  /teams/{teamID}/archive/export:
+    get:
+      operationId: archiveExportTeam
+      parameters:
+      - description: Id of team
+        in: path
+        name: teamID
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: success
+        default:
+          description: internal error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Exports an archive of all blocks for all the boards in a team.
+  /teams/{teamID}/archive/import:
+    post:
+      consumes:
+      - multipart/form-data
+      operationId: archiveImport
+      parameters:
+      - description: Team ID
+        in: path
+        name: teamID
+        required: true
+        type: string
+      - description: archive file to import
+        in: formData
+        name: file
+        required: true
+        type: file
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: success
+        default:
+          description: internal error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Import an archive of boards.
+  /teams/{teamID}/boards:
+    get:
+      description: Returns team boards
+      operationId: getBoards
+      parameters:
+      - description: Team ID
+        in: path
+        name: teamID
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: success
+          schema:
+            items:
+              $ref: '#/definitions/Board'
+            type: array
+        default:
+          description: internal error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+      security:
+      - BearerAuth: []
+  /teams/{teamID}/boards/{boardID}/files:
+    post:
+      consumes:
+      - multipart/form-data
+      description: Upload a binary file, attached to a root block
+      operationId: uploadFile
+      parameters:
+      - description: ID of the team
+        in: path
+        name: teamID
+        required: true
+        type: string
+      - description: Board ID
+        in: path
+        name: boardID
+        required: true
+        type: string
+      - description: The file to upload
+        in: formData
+        name: uploaded file
+        type: file
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: success
+          schema:
+            $ref: '#/definitions/FileUploadResponse'
+        "404":
+          description: board not found
+        default:
+          description: internal error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+      security:
+      - BearerAuth: []
+  /teams/{teamID}/boards/search:
+    get:
+      description: Returns the boards that match with a search term
+      operationId: searchBoards
+      parameters:
+      - description: Team ID
+        in: path
+        name: teamID
+        required: true
+        type: string
+      - description: The search term. Must have at least one character
+        in: query
+        name: q
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: success
+          schema:
+            items:
+              $ref: '#/definitions/Board'
+            type: array
+        default:
+          description: internal error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+      security:
+      - BearerAuth: []
+  /teams/{teamID}/regenerate_signup_token:
+    post:
+      description: Regenerates the signup token for the root team
+      operationId: regenerateSignupToken
+      parameters:
+      - description: Team ID
+        in: path
+        name: teamID
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: success
+        default:
+          description: internal error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+      security:
+      - BearerAuth: []
+  /teams/{teamID}/templates:
+    get:
+      description: Returns team templates
+      operationId: getTemplates
+      parameters:
+      - description: Team ID
+        in: path
+        name: teamID
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: success
+          schema:
+            items:
+              $ref: '#/definitions/Board'
+            type: array
+        default:
+          description: internal error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+      security:
+      - BearerAuth: []
+  /teams/{teamID}/users:
+    get:
+      description: Returns team users
+      operationId: getTeamUsers
+      parameters:
+      - description: Team ID
+        in: path
+        name: teamID
+        required: true
+        type: string
+      - description: string to filter users list
+        in: query
+        name: search
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: success
+          schema:
+            items:
+              $ref: '#/definitions/User'
+            type: array
+        default:
+          description: internal error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+      security:
+      - BearerAuth: []
+  /users/{userID}:
+    get:
+      description: Returns a user
+      operationId: getUser
+      parameters:
+      - description: User ID
+        in: path
+        name: userID
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: success
+          schema:
+            $ref: '#/definitions/User'
+        default:
+          description: internal error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+      security:
+      - BearerAuth: []
+  /users/{userID}/changepassword:
+    post:
+      description: Change a user's password
+      operationId: changePassword
+      parameters:
+      - description: User ID
+        in: path
+        name: userID
+        required: true
+        type: string
+      - description: Change password request
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/ChangePasswordRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: success
+        "400":
+          description: invalid request
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+        "500":
+          description: internal error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+      security:
+      - BearerAuth: []
+  /users/{userID}/config:
+    patch:
+      description: Updates user config
+      operationId: updateUserConfig
+      parameters:
+      - description: User ID
+        in: path
+        name: userID
+        required: true
+        type: string
+      - description: User config patch to apply
+        in: body
+        name: Body
+        required: true
+        schema:
+          $ref: '#/definitions/UserPropPatch'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: success
+        default:
+          description: internal error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+      security:
+      - BearerAuth: []
+  /users/me:
+    get:
+      description: Returns the currently logged-in user
+      operationId: getMe
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: success
+          schema:
+            $ref: '#/definitions/User'
+        default:
+          description: internal error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+      security:
+      - BearerAuth: []
+  /users/me/memberships:
+    get:
+      description: Returns the currently users board memberships
+      operationId: getMyMemberships
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: success
+          schema:
+            items:
+              $ref: '#/definitions/BoardMember'
+            type: array
+        default:
+          description: internal error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+      security:
+      - BearerAuth: []
 produces:
 - application/json
 schemes:
@@ -2116,7 +2060,8 @@ schemes:
 - https
 securityDefinitions:
   BearerAuth:
-    description: 'Pass session token using Bearer authentication, e.g. set header "Authorization: Bearer <session token>"'
+    description: 'Pass session token using Bearer authentication, e.g. set header
+      "Authorization: Bearer <session token>"'
     in: header
     name: Authorization
     type: apiKey

--- a/webapp/cypress/support/api_commands.ts
+++ b/webapp/cypress/support/api_commands.ts
@@ -7,7 +7,7 @@ import {UserConfigPatch} from '../../src/user'
 Cypress.Commands.add('apiRegisterUser', (data: Cypress.UserData, token?: string, failOnError?: boolean) => {
     return cy.request({
         method: 'POST',
-        url: '/api/v1/register',
+        url: '/api/v2/register',
         body: {
             ...data,
             token,
@@ -22,7 +22,7 @@ Cypress.Commands.add('apiRegisterUser', (data: Cypress.UserData, token?: string,
 Cypress.Commands.add('apiLoginUser', (data: Cypress.LoginData) => {
     return cy.request({
         method: 'POST',
-        url: '/api/v1/login',
+        url: '/api/v2/login',
         body: {
             ...data,
             type: 'normal',
@@ -55,7 +55,7 @@ Cypress.Commands.add('apiInitServer', () => {
 Cypress.Commands.add('apiDeleteBoard', (id: string) => {
     return cy.request({
         method: 'DELETE',
-        url: `/api/v1/boards/${encodeURIComponent(id)}`,
+        url: `/api/v2/boards/${encodeURIComponent(id)}`,
         ...headers(),
     })
 })
@@ -71,7 +71,7 @@ const deleteBoards = (ids: string[]) => {
 Cypress.Commands.add('apiResetBoards', () => {
     return cy.request({
         method: 'GET',
-        url: '/api/v1/teams/0/boards',
+        url: '/api/v2/teams/0/boards',
         ...headers(),
     }).then((response) => {
         if (Array.isArray(response.body)) {
@@ -91,7 +91,7 @@ Cypress.Commands.add('apiSkipTour', (userID: string) => {
 
     return cy.request({
         method: 'PUT',
-        url: `/api/v1/users/${encodeURIComponent(userID)}/config`,
+        url: `/api/v2/users/${encodeURIComponent(userID)}/config`,
         ...headers(),
         body,
     })
@@ -100,7 +100,7 @@ Cypress.Commands.add('apiSkipTour', (userID: string) => {
 Cypress.Commands.add('apiGetMe', () => {
     return cy.request({
         method: 'GET',
-        url: '/api/v1/users/me',
+        url: '/api/v2/users/me',
         ...headers(),
     }).then((response) => response.body.id)
 })
@@ -109,7 +109,7 @@ Cypress.Commands.add('apiChangePassword', (userId: string, oldPassword: string, 
     const body = {oldPassword, newPassword}
     return cy.request({
         method: 'POST',
-        url: `/api/v1/users/${encodeURIComponent(userId)}/changepassword`,
+        url: `/api/v2/users/${encodeURIComponent(userId)}/changepassword`,
         ...headers(),
         body,
     })

--- a/webapp/src/octoClient.ts
+++ b/webapp/src/octoClient.ts
@@ -61,7 +61,7 @@ class OctoClient {
     }
 
     async login(username: string, password: string): Promise<boolean> {
-        const path = '/api/v1/login'
+        const path = '/api/v2/login'
         const body = JSON.stringify({username, password, type: 'normal'})
         const response = await fetch(this.getBaseURL() + path, {
             method: 'POST',
@@ -81,7 +81,7 @@ class OctoClient {
     }
 
     async logout(): Promise<boolean> {
-        const path = '/api/v1/logout'
+        const path = '/api/v2/logout'
         const response = await fetch(this.getBaseURL() + path, {
             method: 'POST',
             headers: this.headers(),
@@ -95,7 +95,7 @@ class OctoClient {
     }
 
     async getClientConfig(): Promise<ClientConfig | null> {
-        const path = '/api/v1/clientConfig'
+        const path = '/api/v2/clientConfig'
         const response = await fetch(this.getBaseURL() + path, {
             method: 'GET',
             headers: this.headers(),
@@ -109,7 +109,7 @@ class OctoClient {
     }
 
     async register(email: string, username: string, password: string, token?: string): Promise<{code: number, json: {error?: string}}> {
-        const path = '/api/v1/register'
+        const path = '/api/v2/register'
         const body = JSON.stringify({email, username, password, token})
         const response = await fetch(this.getBaseURL() + path, {
             method: 'POST',
@@ -121,7 +121,7 @@ class OctoClient {
     }
 
     async changePassword(userId: string, oldPassword: string, newPassword: string): Promise<{code: number, json: {error?: string}}> {
-        const path = `/api/v1/users/${encodeURIComponent(userId)}/changepassword`
+        const path = `/api/v2/users/${encodeURIComponent(userId)}/changepassword`
         const body = JSON.stringify({oldPassword, newPassword})
         const response = await fetch(this.getBaseURL() + path, {
             method: 'POST',
@@ -148,15 +148,15 @@ class OctoClient {
             teamIdToUse = this.teamId === Constants.globalTeamId ? UserSettings.lastTeamId || this.teamId : this.teamId
         }
 
-        return `/api/v1/teams/${teamIdToUse}`
+        return `/api/v2/teams/${teamIdToUse}`
     }
 
     private teamsPath(): string {
-        return '/api/v1/teams'
+        return '/api/v2/teams'
     }
 
     async getMe(): Promise<IUser | undefined> {
-        const path = '/api/v1/users/me'
+        const path = '/api/v2/users/me'
         const response = await fetch(this.getBaseURL() + path, {headers: this.headers()})
         if (response.status !== 200) {
             return undefined
@@ -166,7 +166,7 @@ class OctoClient {
     }
 
     async getMyBoardMemberships(): Promise<BoardMember[]> {
-        const path = '/api/v1/users/me/memberships'
+        const path = '/api/v2/users/me/memberships'
         const response = await fetch(this.getBaseURL() + path, {headers: this.headers()})
         if (response.status !== 200) {
             return []
@@ -176,7 +176,7 @@ class OctoClient {
     }
 
     async getUser(userId: string): Promise<IUser | undefined> {
-        const path = `/api/v1/users/${encodeURIComponent(userId)}`
+        const path = `/api/v2/users/${encodeURIComponent(userId)}`
         const response = await fetch(this.getBaseURL() + path, {headers: this.headers()})
         if (response.status !== 200) {
             return undefined
@@ -186,7 +186,7 @@ class OctoClient {
     }
 
     async patchUserConfig(userID: string, patch: UserConfigPatch): Promise<Record<string, string> | undefined> {
-        const path = `/api/v1/users/${encodeURIComponent(userID)}/config`
+        const path = `/api/v2/users/${encodeURIComponent(userID)}/config`
         const body = JSON.stringify(patch)
         const response = await fetch(this.getBaseURL() + path, {
             headers: this.headers(),
@@ -202,12 +202,12 @@ class OctoClient {
     }
 
     async exportBoardArchive(boardID: string): Promise<Response> {
-        const path = `/api/v1/boards/${boardID}/archive/export`
+        const path = `/api/v2/boards/${boardID}/archive/export`
         return fetch(this.getBaseURL() + path, {headers: this.headers()})
     }
 
     async exportFullArchive(teamID: string): Promise<Response> {
-        const path = `/api/v1/teams/${teamID}/archive/export`
+        const path = `/api/v2/teams/${teamID}/archive/export`
         return fetch(this.getBaseURL() + path, {headers: this.headers()})
     }
 
@@ -243,7 +243,7 @@ class OctoClient {
     }
 
     async getBlocksWithBlockID(blockID: string, boardID: string, optionalReadToken?: string): Promise<Block[]> {
-        let path = `/api/v1/boards/${boardID}/blocks?block_id=${blockID}`
+        let path = `/api/v2/boards/${boardID}/blocks?block_id=${blockID}`
         const readToken = optionalReadToken || Utils.getReadToken()
         if (readToken) {
             path += `&read_token=${readToken}`
@@ -252,7 +252,7 @@ class OctoClient {
     }
 
     async getAllBlocks(boardID: string): Promise<Block[]> {
-        let path = `/api/v1/boards/${boardID}/blocks?all=true`
+        let path = `/api/v2/boards/${boardID}/blocks?all=true`
         const readToken = Utils.getReadToken()
         if (readToken) {
             path += `&read_token=${readToken}`
@@ -301,7 +301,7 @@ class OctoClient {
     async patchBlock(boardId: string, blockId: string, blockPatch: BlockPatch): Promise<Response> {
         Utils.log(`patchBlock: ${blockId} block`)
         const body = JSON.stringify(blockPatch)
-        return fetch(`${this.getBaseURL()}/api/v1/boards/${boardId}/blocks/${blockId}`, {
+        return fetch(`${this.getBaseURL()}/api/v2/boards/${boardId}/blocks/${blockId}`, {
             method: 'PATCH',
             headers: this.headers(),
             body,
@@ -324,7 +324,7 @@ class OctoClient {
 
     async deleteBlock(boardId: string, blockId: string): Promise<Response> {
         Utils.log(`deleteBlock: ${blockId} on board ${boardId}`)
-        return fetch(`${this.getBaseURL()}/api/v1/boards/${boardId}/blocks/${encodeURIComponent(blockId)}`, {
+        return fetch(`${this.getBaseURL()}/api/v2/boards/${boardId}/blocks/${encodeURIComponent(blockId)}`, {
             method: 'DELETE',
             headers: this.headers(),
         })
@@ -332,7 +332,7 @@ class OctoClient {
 
     async undeleteBlock(boardId: string, blockId: string): Promise<Response> {
         Utils.log(`undeleteBlock: ${blockId}`)
-        return fetch(`${this.getBaseURL()}/api/v1/boards/${encodeURIComponent(boardId)}/blocks/${encodeURIComponent(blockId)}/undelete`, {
+        return fetch(`${this.getBaseURL()}/api/v2/boards/${encodeURIComponent(boardId)}/blocks/${encodeURIComponent(blockId)}/undelete`, {
             method: 'POST',
             headers: this.headers(),
         })
@@ -340,7 +340,7 @@ class OctoClient {
 
     async undeleteBoard(boardId: string): Promise<Response> {
         Utils.log(`undeleteBoard: ${boardId}`)
-        return fetch(`${this.getBaseURL()}/api/v1/boards/${boardId}/undelete`, {
+        return fetch(`${this.getBaseURL()}/api/v2/boards/${boardId}/undelete`, {
             method: 'POST',
             headers: this.headers(),
         })
@@ -354,7 +354,7 @@ class OctoClient {
             subscriberId: userId,
         }
 
-        return fetch(this.getBaseURL() + '/api/v1/subscriptions', {
+        return fetch(this.getBaseURL() + '/api/v2/subscriptions', {
             method: 'POST',
             headers: this.headers(),
             body: JSON.stringify(body),
@@ -362,7 +362,7 @@ class OctoClient {
     }
 
     async unfollowBlock(blockId: string, blockType: string, userId: string): Promise<Response> {
-        return fetch(this.getBaseURL() + `/api/v1/subscriptions/${blockId}/${userId}`, {
+        return fetch(this.getBaseURL() + `/api/v2/subscriptions/${blockId}/${userId}`, {
             method: 'DELETE',
             headers: this.headers(),
         })
@@ -378,7 +378,7 @@ class OctoClient {
             Utils.log(`\t ${block.type}, ${block.id}, ${block.title?.substr(0, 50) || ''}`)
         })
         const body = JSON.stringify(blocks)
-        return fetch(`${this.getBaseURL()}/api/v1/boards/${boardId}/blocks` + (sourceBoardID ? `?sourceBoardID=${encodeURIComponent(sourceBoardID)}` : ''), {
+        return fetch(`${this.getBaseURL()}/api/v2/boards/${boardId}/blocks` + (sourceBoardID ? `?sourceBoardID=${encodeURIComponent(sourceBoardID)}` : ''), {
             method: 'POST',
             headers: this.headers(),
             body,
@@ -395,7 +395,7 @@ class OctoClient {
         })
 
         const body = JSON.stringify(bab)
-        return fetch(this.getBaseURL() + '/api/v1/boards-and-blocks', {
+        return fetch(this.getBaseURL() + '/api/v2/boards-and-blocks', {
             method: 'POST',
             headers: this.headers(),
             body,
@@ -408,7 +408,7 @@ class OctoClient {
         Utils.log(`\t Blocks ${blockIds.join(', ')}`)
 
         const body = JSON.stringify({boards: boardIds, blocks: blockIds})
-        return fetch(this.getBaseURL() + '/api/v1/boards-and-blocks', {
+        return fetch(this.getBaseURL() + '/api/v2/boards-and-blocks', {
             method: 'DELETE',
             headers: this.headers(),
             body,
@@ -420,7 +420,7 @@ class OctoClient {
         Utils.log(`createBoardMember: user ${member.userId} and board ${member.boardId}`)
 
         const body = JSON.stringify(member)
-        const response = await fetch(this.getBaseURL() + `/api/v1/boards/${member.boardId}/members`, {
+        const response = await fetch(this.getBaseURL() + `/api/v2/boards/${member.boardId}/members`, {
             method: 'POST',
             headers: this.headers(),
             body,
@@ -436,7 +436,7 @@ class OctoClient {
     async joinBoard(boardId: string): Promise<BoardMember|undefined> {
         Utils.log(`joinBoard: board ${boardId}`)
 
-        const response = await fetch(this.getBaseURL() + `/api/v1/boards/${boardId}/join`, {
+        const response = await fetch(this.getBaseURL() + `/api/v2/boards/${boardId}/join`, {
             method: 'POST',
             headers: this.headers()
         })
@@ -452,7 +452,7 @@ class OctoClient {
         Utils.log(`udpateBoardMember: user ${member.userId} and board ${member.boardId}`)
 
         const body = JSON.stringify(member)
-        return fetch(this.getBaseURL() + `/api/v1/boards/${member.boardId}/members/${member.userId}`, {
+        return fetch(this.getBaseURL() + `/api/v2/boards/${member.boardId}/members/${member.userId}`, {
             method: 'PUT',
             headers: this.headers(),
             body,
@@ -462,7 +462,7 @@ class OctoClient {
     async deleteBoardMember(member: BoardMember): Promise<Response> {
         Utils.log(`deleteBoardMember: user ${member.userId} and board ${member.boardId}`)
 
-        return fetch(this.getBaseURL() + `/api/v1/boards/${member.boardId}/members/${member.userId}`, {
+        return fetch(this.getBaseURL() + `/api/v2/boards/${member.boardId}/members/${member.userId}`, {
             method: 'DELETE',
             headers: this.headers(),
         })
@@ -474,7 +474,7 @@ class OctoClient {
         Utils.log(`\t Blocks ${babp.blockIDs.join(', ')}`)
 
         const body = JSON.stringify(babp)
-        return fetch(this.getBaseURL() + '/api/v1/boards-and-blocks', {
+        return fetch(this.getBaseURL() + '/api/v2/boards-and-blocks', {
             method: 'PATCH',
             headers: this.headers(),
             body,
@@ -483,7 +483,7 @@ class OctoClient {
 
     // Sharing
     async getSharing(boardID: string): Promise<ISharing | undefined> {
-        const path = `/api/v1/boards/${boardID}/sharing`
+        const path = `/api/v2/boards/${boardID}/sharing`
         const response = await fetch(this.getBaseURL() + path, {headers: this.headers()})
         if (response.status !== 200) {
             return undefined
@@ -492,7 +492,7 @@ class OctoClient {
     }
 
     async setSharing(boardID: string, sharing: ISharing): Promise<boolean> {
-        const path = `/api/v1/boards/${boardID}/sharing`
+        const path = `/api/v2/boards/${boardID}/sharing`
         const body = JSON.stringify(sharing)
         const response = await fetch(
             this.getBaseURL() + path,
@@ -557,7 +557,7 @@ class OctoClient {
     }
 
     async getFileAsDataUrl(boardId: string, fileId: string): Promise<string> {
-        let path = '/api/v1/files/teams/' + this.teamId + '/' + boardId + '/' + fileId
+        let path = '/api/v2/files/teams/' + this.teamId + '/' + boardId + '/' + fileId
         const readToken = Utils.getReadToken()
         if (readToken) {
             path += `?read_token=${readToken}`
@@ -627,7 +627,7 @@ class OctoClient {
     }
 
     async getBoard(boardID: string): Promise<Board | undefined> {
-        let path = `/api/v1/boards/${boardID}`
+        let path = `/api/v2/boards/${boardID}`
         const readToken = Utils.getReadToken()
         if (readToken) {
             path += `?read_token=${readToken}`
@@ -653,7 +653,7 @@ class OctoClient {
             query += `&toTeam=${encodeURIComponent(toTeam)}`
         }
 
-        const path = `/api/v1/boards/${boardID}/duplicate${query}`
+        const path = `/api/v2/boards/${boardID}/duplicate${query}`
         const response = await fetch(this.getBaseURL() + path, {
             method: 'POST',
             headers: this.headers(),
@@ -671,7 +671,7 @@ class OctoClient {
         if (asTemplate) {
             query = '?asTemplate=true'
         }
-        const path = `/api/v1/boards/${boardID}/blocks/${blockID}/duplicate${query}`
+        const path = `/api/v2/boards/${boardID}/blocks/${blockID}/duplicate${query}`
         const response = await fetch(this.getBaseURL() + path, {
             method: 'POST',
             headers: this.headers(),
@@ -690,7 +690,7 @@ class OctoClient {
     }
 
     async getBoardMembers(teamId: string, boardId: string): Promise<BoardMember[]> {
-        const path = `/api/v1/boards/${boardId}/members`
+        const path = `/api/v2/boards/${boardId}/members`
         return this.getBoardMembersWithPath(path)
     }
 
@@ -706,7 +706,7 @@ class OctoClient {
     async patchBoard(boardId: string, boardPatch: BoardPatch): Promise<Response> {
         Utils.log(`patchBoard: ${boardId} board`)
         const body = JSON.stringify(boardPatch)
-        return fetch(`${this.getBaseURL()}/api/v1/boards/${boardId}`, {
+        return fetch(`${this.getBaseURL()}/api/v2/boards/${boardId}`, {
             method: 'PATCH',
             headers: this.headers(),
             body,
@@ -715,14 +715,14 @@ class OctoClient {
 
     async deleteBoard(boardId: string): Promise<Response> {
         Utils.log(`deleteBoard: ${boardId}`)
-        return fetch(`${this.getBaseURL()}/api/v1/boards/${boardId}`, {
+        return fetch(`${this.getBaseURL()}/api/v2/boards/${boardId}`, {
             method: 'DELETE',
             headers: this.headers(),
         })
     }
 
     async getSidebarCategories(teamID: string): Promise<Array<CategoryBlocks>> {
-        const path = `/api/v1/teams/${teamID}/categories`
+        const path = `/api/v2/teams/${teamID}/categories`
         const response = await fetch(this.getBaseURL() + path, {headers: this.headers()})
         if (response.status !== 200) {
             return []
@@ -732,7 +732,7 @@ class OctoClient {
     }
 
     async createSidebarCategory(category: Category): Promise<Response> {
-        const path = `/api/v1/teams/${category.teamID}/categories`
+        const path = `/api/v2/teams/${category.teamID}/categories`
         const body = JSON.stringify(category)
         return fetch(this.getBaseURL() + path, {
             method: 'POST',
@@ -742,7 +742,7 @@ class OctoClient {
     }
 
     async deleteSidebarCategory(teamID: string, categoryID: string): Promise<Response> {
-        const url = `/api/v1/teams/${teamID}/categories/${categoryID}`
+        const url = `/api/v2/teams/${teamID}/categories/${categoryID}`
         return fetch(this.getBaseURL() + url, {
             method: 'DELETE',
             headers: this.headers(),
@@ -750,7 +750,7 @@ class OctoClient {
     }
 
     async updateSidebarCategory(category: Category): Promise<Response> {
-        const path = `/api/v1/teams/${category.teamID}/categories/${category.id}`
+        const path = `/api/v2/teams/${category.teamID}/categories/${category.id}`
         const body = JSON.stringify(category)
         return fetch(this.getBaseURL() + path, {
             method: 'PUT',
@@ -760,7 +760,7 @@ class OctoClient {
     }
 
     async moveBlockToCategory(teamID: string, blockID: string, toCategoryID: string, fromCategoryID: string): Promise<Response> {
-        const url = `/api/v1/teams/${teamID}/categories/${toCategoryID || '0'}/blocks/${blockID}`
+        const url = `/api/v2/teams/${teamID}/categories/${toCategoryID || '0'}/blocks/${blockID}`
         const payload = {
             fromCategoryID,
         }
@@ -788,7 +788,7 @@ class OctoClient {
     }
 
     async getUserBlockSubscriptions(userId: string): Promise<Array<Subscription>> {
-        const path = `/api/v1/subscriptions/${userId}`
+        const path = `/api/v2/subscriptions/${userId}`
         const response = await fetch(this.getBaseURL() + path, {headers: this.headers()})
         if (response.status !== 200) {
             return []
@@ -799,7 +799,7 @@ class OctoClient {
 
     // onboarding
     async prepareOnboarding(teamId: string): Promise<PrepareOnboardingResponse | undefined> {
-        const path = `/api/v1/teams/${teamId}/onboard`
+        const path = `/api/v2/teams/${teamId}/onboard`
         const response = await fetch(this.getBaseURL() + path, {
             headers: this.headers(),
             method: 'POST',

--- a/website/site/content/guide/admin/_index.md
+++ b/website/site/content/guide/admin/_index.md
@@ -15,7 +15,7 @@ Personal server settings are stored in `config.json` and are read when the serve
 | port          | Server port                   | 8000
 | dbtype        | Type of database. `sqlite3`, `postgres`, or `mysql` | sqlite3
 | dbconfig      | Database connection string    | `postgres://user:pass@localhost/boards?sslmode=disable&connect_timeout=10`
-| useSSL        | Enable or disable SSL         | false 
+| useSSL        | Enable or disable SSL         | false
 | webpath       | Path to web files             | `./webapp/pack`
 | filespath     | Path to uploaded files folder | `./files`
 | telemetry     | Enable health diagnostics telemetry | `true`
@@ -40,7 +40,7 @@ if [[ $# < 2 ]] ; then
     exit 1
 fi
 
-curl --unix-socket /var/tmp/focalboard_local.socket http://localhost/api/v1/admin/users/$1/password -X POST -H 'Content-Type: application/json' -d '{ "password": "'$2'" }'
+curl --unix-socket /var/tmp/focalboard_local.socket http://localhost/api/v2/admin/users/$1/password -X POST -H 'Content-Type: application/json' -d '{ "password": "'$2'" }'
 ```
 
 After resetting a user's password (e.g. if they forgot it), direct them to change it from the user menu, by clicking on their username at the top of the sidebar.


### PR DESCRIPTION
#### Summary
Migrates all api endpoints from the `v1` to the `v2` namespace. The PR updates the swagger comments as well, as we were generating bad URLs from them, having them prefixed with `/api/v1` (see [doc.go](https://github.com/mattermost/focalboard/blob/5afa8699e1780c5a79c359b4588a291b0234018d/server/main/doc.go#L7)) and then the comment on each endpoint would be prefixed as well, generating URLs and examples in the resulting docs starting with `/api/v2/api/v2/...`.

#### Ticket Link
Closes https://github.com/mattermost/focalboard/issues/2754

