### PR TITLE
revert ServerRoot path change

### DIFF
--- a/mattermost-plugin/server/plugin.go
+++ b/mattermost-plugin/server/plugin.go
@@ -211,7 +211,7 @@ func (p *Plugin) createBoardsConfig(mmconfig mmModel.Config, baseURL string, ser
 	featureFlags := parseFeatureFlags(mmconfig.FeatureFlags.ToMap())
 
 	return &config.Configuration{
-		ServerRoot:               baseURL,
+		ServerRoot:               baseURL + "/plugins/focalboard",
 		Port:                     -1,
 		DBType:                   *mmconfig.SqlSettings.DriverName,
 		DBConfigString:           *mmconfig.SqlSettings.DataSource,


### PR DESCRIPTION
#### Summary
A previous [PR](https://github.com/mattermost/focalboard/pull/2758) changed the Plugin config field `ServerRoot` to drop the `/plugins/focalboard` path.  This broke public shared board links.  This PR reverts that change.

#### Ticket Link
fixes https://github.com/mattermost/focalboard/issues/2789