### PR TITLE
GH-2798 - make board private when created from template

### DIFF
--- a/server/services/store/sqlstore/boards_and_blocks.go
+++ b/server/services/store/sqlstore/boards_and_blocks.go
@@ -141,6 +141,11 @@ func (s *SQLStore) duplicateBoard(db sq.BaseRunner, boardID string, userID strin
 	if err != nil {
 		return nil, nil, err
 	}
+	// if original board is template
+	// make new board private
+	if board.IsTemplate {
+		board.Type = "P"
+	}
 	board.IsTemplate = asTemplate
 	board.CreatedBy = userID
 


### PR DESCRIPTION
#### Summary
Currently all boards created from public templates are public (because the templates are public). This PR updates the duplication logic to set boards created from a template to private boards.

#### Ticket Link
  Fixes https://github.com/mattermost/focalboard/issues/2798

