### PR TITLE
GH-1871 fix background for today

### DIFF
--- a/server/services/store/sqlstore/boards_and_blocks.go
+++ b/server/services/store/sqlstore/boards_and_blocks.go
@@ -141,11 +141,8 @@ func (s *SQLStore) duplicateBoard(db sq.BaseRunner, boardID string, userID strin
 	if err != nil {
 		return nil, nil, err
 	}
-	// if original board is template
 	// make new board private
-	if board.IsTemplate {
-		board.Type = "P"
-	}
+	board.Type = "P"
 	board.IsTemplate = asTemplate
 	board.CreatedBy = userID
 

--- a/webapp/src/components/calendar/fullcalendar.scss
+++ b/webapp/src/components/calendar/fullcalendar.scss
@@ -229,7 +229,7 @@
     }
 
     .fc-day-today {
-        background: transparent;
+        background-color: rgb(var(--center-channel-bg-rgb));
 
         .fc-daygrid-day-number {
             .dateDisplay {

--- a/webapp/src/components/calendar/fullcalendar.scss
+++ b/webapp/src/components/calendar/fullcalendar.scss
@@ -228,8 +228,8 @@
         text-align: center;
     }
 
-    .fc-day-today {
-        background-color: rgb(var(--center-channel-bg-rgb));
+    .fc-daygrid-day.fc-day-today {
+        background-color: unset;
 
         .fc-daygrid-day-number {
             .dateDisplay {


### PR DESCRIPTION
#### Summary
The `+ more` button when displayed on "today" was displaying as transparent, because `fs-today` was taking presidence over `fs-popup`.

Rather than setting as transparent, unset the background for the grid component today. Leaving `fs-popup fs-today` unchanged.

#### Ticket Link

  Fixes https://github.com/mattermost/focalboard/issues/1871

