### PR TITLE
GH-2808: fix some logging issues with share board.

### DIFF
--- a/server/api/api.go
+++ b/server/api/api.go
@@ -1545,7 +1545,7 @@ func (a *API) handleGetSharing(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if sharing == nil {
-		a.errorResponse(w, r.URL.Path, http.StatusNotFound, "", nil)
+		jsonStringResponse(w, http.StatusOK, "{}")
 		return
 	}
 

--- a/server/integrationtests/sharing_test.go
+++ b/server/integrationtests/sharing_test.go
@@ -44,7 +44,9 @@ func TestSharing(t *testing.T) {
 
 		sharing, resp := th.Client.GetSharing(boardID)
 		require.NoError(t, resp.Error)
-		require.Nil(t, sharing)
+		require.NotNil(t, sharing)
+		require.False(t, sharing.Enabled)
+		require.Empty(t, sharing.ID)
 	})
 
 	t.Run("POST sharing, config = false", func(t *testing.T) {

--- a/server/integrationtests/sharing_test.go
+++ b/server/integrationtests/sharing_test.go
@@ -1,7 +1,6 @@
 package integrationtests
 
 import (
-	"net/http"
 	"testing"
 
 	"github.com/mattermost/focalboard/server/model"
@@ -64,10 +63,12 @@ func TestSharing(t *testing.T) {
 
 		t.Run("GET sharing", func(t *testing.T) {
 			sharing, resp := th.Client.GetSharing(boardID)
-			// Expect not found error
-			require.Error(t, resp.Error)
-			require.Equal(t, resp.StatusCode, http.StatusNotFound)
-			require.Nil(t, sharing)
+			// Expect empty sharing object
+			require.NoError(t, resp.Error)
+			require.NotNil(t, sharing)
+			require.False(t, sharing.Enabled)
+			require.Empty(t, sharing.ID)
+			require.Empty(t, sharing.Token)
 		})
 	})
 

--- a/server/integrationtests/sharing_test.go
+++ b/server/integrationtests/sharing_test.go
@@ -43,7 +43,7 @@ func TestSharing(t *testing.T) {
 		require.Nil(t, s)
 
 		sharing, resp := th.Client.GetSharing(boardID)
-		th.CheckNotFound(resp)
+		require.NoError(t, resp.Error)
 		require.Nil(t, sharing)
 	})
 

--- a/webapp/src/components/shareBoard/shareBoard.test.tsx
+++ b/webapp/src/components/shareBoard/shareBoard.test.tsx
@@ -180,7 +180,12 @@ describe('src/components/shareBoard/shareBoard', () => {
     })
 
     test('should match snapshot', async () => {
-        mockedOctoClient.getSharing.mockResolvedValue(undefined)
+        const sharing:ISharing = {
+            id: '',
+            enabled: false,
+            token: '',
+        }
+        mockedOctoClient.getSharing.mockResolvedValue(sharing)
         let container
         await act(async () => {
             const result = render(
@@ -356,7 +361,12 @@ describe('src/components/shareBoard/shareBoard', () => {
         expect(container).toMatchSnapshot()
     })
     test('return shareBoardComponent and click Switch without sharing', async () => {
-        mockedOctoClient.getSharing.mockResolvedValue(undefined)
+        const sharing:ISharing = {
+            id: '',
+            enabled: false,
+            token: '',
+        }
+        mockedOctoClient.getSharing.mockResolvedValue(sharing)
         mockedUtils.createGuid.mockReturnValue('aToken')
         let container: Element | undefined
         await act(async () => {

--- a/webapp/src/components/shareBoard/shareBoard.tsx
+++ b/webapp/src/components/shareBoard/shareBoard.tsx
@@ -36,6 +36,8 @@ import SearchIcon from '../../widgets/icons/search'
 
 import BoardPermissionGate from '../permissions/boardPermissionGate'
 
+import {useHasPermissions} from '../../hooks/permissions'
+
 import TeamPermissionsRow from './teamPermissionsRow'
 import UserPermissionsRow from './userPermissionsRow'
 
@@ -105,10 +107,14 @@ export default function ShareBoardDialog(props: Props): JSX.Element {
     const intl = useIntl()
     const match = useRouteMatch<{teamId?: string, boardId: string, viewId: string}>()
 
+    const hasSharePermissions = useHasPermissions(board.teamId, boardId, [Permission.ShareBoard])
+
     const loadData = async () => {
-        const newSharing = await client.getSharing(boardId)
-        setSharing(newSharing)
-        setWasCopiedPublic(false)
+        if( hasSharePermissions ){
+            const newSharing = await client.getSharing(boardId)
+            setSharing(newSharing)
+            setWasCopiedPublic(false)
+        }
     }
 
     const createSharingInfo = () => {


### PR DESCRIPTION
#### Summary
When displaying shared board menu, check if user has permissions before calling API. Otherwise, API logs error and return error unnecessarily. 

If "sharing" is not found. That is an expected case and no reason to log error.

#### Ticket Link
https://github.com/mattermost/focalboard/issues/2808
