### PR TITLE
GH-1919 fix unexpected dialog close

### DIFF
--- a/webapp/src/components/__snapshots__/cardDialog.test.tsx.snap
+++ b/webapp/src/components/__snapshots__/cardDialog.test.tsx.snap
@@ -6,6 +6,9 @@ exports[`components/cardDialog already following card 1`] = `
     class="Dialog dialog-back cardDialog"
   >
     <div
+      class="backdrop"
+    />
+    <div
       class="wrapper"
     >
       <div
@@ -282,6 +285,9 @@ exports[`components/cardDialog return a cardDialog readonly 1`] = `
     class="Dialog dialog-back cardDialog"
   >
     <div
+      class="backdrop"
+    />
+    <div
       class="wrapper"
     >
       <div
@@ -386,6 +392,9 @@ exports[`components/cardDialog return cardDialog menu content 1`] = `
   <div
     class="Dialog dialog-back cardDialog"
   >
+    <div
+      class="backdrop"
+    />
     <div
       class="wrapper"
     >
@@ -772,6 +781,9 @@ exports[`components/cardDialog return cardDialog menu content and cancel delete 
     class="Dialog dialog-back cardDialog"
   >
     <div
+      class="backdrop"
+    />
+    <div
       class="wrapper"
     >
       <div
@@ -1048,6 +1060,9 @@ exports[`components/cardDialog should match snapshot 1`] = `
     class="Dialog dialog-back cardDialog"
   >
     <div
+      class="backdrop"
+    />
+    <div
       class="wrapper"
     >
       <div
@@ -1323,6 +1338,9 @@ exports[`components/cardDialog should match snapshot without permissions 1`] = `
   <div
     class="Dialog dialog-back cardDialog"
   >
+    <div
+      class="backdrop"
+    />
     <div
       class="wrapper"
     >

--- a/webapp/src/components/__snapshots__/confirmationDialogBox.test.tsx.snap
+++ b/webapp/src/components/__snapshots__/confirmationDialogBox.test.tsx.snap
@@ -6,6 +6,9 @@ exports[`/components/confirmationDialogBox confirmDialog should match snapshot 1
     class="Dialog dialog-back confirmation-dialog-box"
   >
     <div
+      class="backdrop"
+    />
+    <div
       class="wrapper"
     >
       <div
@@ -74,6 +77,9 @@ exports[`/components/confirmationDialogBox confirmDialog with Confirm Button Tex
   <div
     class="Dialog dialog-back confirmation-dialog-box"
   >
+    <div
+      class="backdrop"
+    />
     <div
       class="wrapper"
     >

--- a/webapp/src/components/__snapshots__/dialog.test.tsx.snap
+++ b/webapp/src/components/__snapshots__/dialog.test.tsx.snap
@@ -6,6 +6,9 @@ exports[`components/dialog should match snapshot 1`] = `
     class="Dialog dialog-back undefined"
   >
     <div
+      class="backdrop"
+    />
+    <div
       class="wrapper"
     >
       <div
@@ -40,6 +43,9 @@ exports[`components/dialog should return dialog and click on cancel button 1`] =
   <div
     class="Dialog dialog-back undefined"
   >
+    <div
+      class="backdrop"
+    />
     <div
       class="wrapper"
     >

--- a/webapp/src/components/boardTemplateSelector/__snapshots__/boardTemplateSelectorItem.test.tsx.snap
+++ b/webapp/src/components/boardTemplateSelector/__snapshots__/boardTemplateSelectorItem.test.tsx.snap
@@ -146,6 +146,9 @@ exports[`components/boardTemplateSelector/boardTemplateSelectorItem should trigg
       class="Dialog dialog-back DeleteBoardDialog"
     >
       <div
+        class="backdrop"
+      />
+      <div
         class="wrapper"
       >
         <div

--- a/webapp/src/components/dialog.scss
+++ b/webapp/src/components/dialog.scss
@@ -8,11 +8,17 @@
         z-index: 200;
     }
 
-    .wrapper {
-        position: absolute;
+    .backdrop {
+        position: fixed;
+        z-index: -1;
         width: 100%;
         height: 100%;
         background-color: rgba(var(--center-channel-color-rgb), 0.5);
+    }
+
+    .wrapper {
+        width: 100%;
+        height: 100%;
         display: flex;
         align-items: center;
         justify-content: center;

--- a/webapp/src/components/dialog.tsx
+++ b/webapp/src/components/dialog.tsx
@@ -1,6 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
-import React from 'react'
+import React, {useRef} from 'react'
 import {useIntl} from 'react-intl'
 import {useHotkeys} from 'react-hotkeys-hook'
 
@@ -31,14 +31,25 @@ const Dialog = (props: Props) => {
 
     useHotkeys('esc', () => props.onClose())
 
+    const isBackdropClickedRef = useRef(false)
+
     return (
         <div className={`Dialog dialog-back ${props.className}`}>
+            <div className='backdrop'/>
             <div
                 className='wrapper'
                 onClick={(e) => {
                     e.stopPropagation()
-                    if (e.target === e.currentTarget) {
-                        props.onClose()
+                    if(!isBackdropClickedRef.current){
+                        return
+                    }
+                    isBackdropClickedRef.current = false
+                    props.onClose()
+        
+                }}
+                onMouseDown={(e) => {
+                    if(e.target === e.currentTarget){
+                        isBackdropClickedRef.current = true
                     }
                 }}
             >

--- a/webapp/src/components/shareBoard/__snapshots__/shareBoard.test.tsx.snap
+++ b/webapp/src/components/shareBoard/__snapshots__/shareBoard.test.tsx.snap
@@ -6,6 +6,9 @@ exports[`src/components/shareBoard/shareBoard return shareBoard and click Copy l
     class="Dialog dialog-back ShareBoardDialog"
   >
     <div
+      class="backdrop"
+    />
+    <div
       class="wrapper"
     >
       <div
@@ -228,6 +231,9 @@ exports[`src/components/shareBoard/shareBoard return shareBoard and click Copy l
     class="Dialog dialog-back ShareBoardDialog"
   >
     <div
+      class="backdrop"
+    />
+    <div
       class="wrapper"
     >
       <div
@@ -449,6 +455,9 @@ exports[`src/components/shareBoard/shareBoard return shareBoard and click Regene
   <div
     class="Dialog dialog-back ShareBoardDialog"
   >
+    <div
+      class="backdrop"
+    />
     <div
       class="wrapper"
     >
@@ -695,6 +704,9 @@ exports[`src/components/shareBoard/shareBoard return shareBoard, and click switc
     class="Dialog dialog-back ShareBoardDialog"
   >
     <div
+      class="backdrop"
+    />
+    <div
       class="wrapper"
     >
       <div
@@ -939,6 +951,9 @@ exports[`src/components/shareBoard/shareBoard return shareBoardComponent and cli
   <div
     class="Dialog dialog-back ShareBoardDialog"
   >
+    <div
+      class="backdrop"
+    />
     <div
       class="wrapper"
     >
@@ -1185,6 +1200,9 @@ exports[`src/components/shareBoard/shareBoard should match snapshot 1`] = `
     class="Dialog dialog-back ShareBoardDialog"
   >
     <div
+      class="backdrop"
+    />
+    <div
       class="wrapper"
     >
       <div
@@ -1406,6 +1424,9 @@ exports[`src/components/shareBoard/shareBoard should match snapshot with sharing
   <div
     class="Dialog dialog-back ShareBoardDialog"
   >
+    <div
+      class="backdrop"
+    />
     <div
       class="wrapper"
     >
@@ -1629,6 +1650,9 @@ exports[`src/components/shareBoard/shareBoard should match snapshot with sharing
     class="Dialog dialog-back ShareBoardDialog"
   >
     <div
+      class="backdrop"
+    />
+    <div
       class="wrapper"
     >
       <div
@@ -1850,6 +1874,9 @@ exports[`src/components/shareBoard/shareBoard should match snapshot with sharing
   <div
     class="Dialog dialog-back ShareBoardDialog"
   >
+    <div
+      class="backdrop"
+    />
     <div
       class="wrapper"
     >


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

If I drag a component in `Dialog` and release the mouse outside of `Dialog`, `Dialog` closes.
It's because the logic that checks `e.target` and `e.currentTarget` is executed when `mouse up` is triggered. ('click' event includes `mouse down` and `mouse up`).

I added `onMouseDown` event, so `isBackdropClicked` is decided when we `mouse down` .
 When we `click`(`mouse up`),  `prop.onClose` is executed if `isBackdropClickedRef.current` is true.

#### Before

https://user-images.githubusercontent.com/59413880/163673465-fcf29b8a-4c13-42ef-9514-4577392023d5.mov

#### After


https://user-images.githubusercontent.com/59413880/163673518-4fc2d648-bd20-4cee-9769-0a7643e3b784.mov


#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Fixes #1919 

