### PR TITLE
GH-2815 fix for following button on card

### DIFF
--- a/mattermost-plugin/webapp/src/index.tsx
+++ b/mattermost-plugin/webapp/src/index.tsx
@@ -187,13 +187,13 @@ export default class Plugin {
             // This handles the user selecting a team from the team sidebar.
             const currentTeamID = mmStore.getState().entities.teams.currentTeamId
             if (currentTeamID && currentTeamID !== prevTeamID) {
-                prevTeamID = currentTeamID
-                store.dispatch(setTeam(currentTeamID))
-                if (window.location.pathname.startsWith(windowAny.frontendBaseURL || '')) {
+                if (prevTeamID && window.location.pathname.startsWith(windowAny.frontendBaseURL || '')) {
                     console.log("REDIRECTING HERE")
                     browserHistory.push(`/team/${currentTeamID}`)
                     wsClient.subscribeToTeam(currentTeamID)
                 }
+                prevTeamID = currentTeamID
+                store.dispatch(setTeam(currentTeamID))
             }
         })
 

--- a/webapp/src/pages/boardPage/boardPage.tsx
+++ b/webapp/src/pages/boardPage/boardPage.tsx
@@ -61,7 +61,7 @@ const BoardPage = (props: Props): JSX.Element => {
             }
 
             dispatch(fetchUserBlockSubscriptions(me!.id))
-        }, [teamId])
+        }, [me?.id])
     }
 
     // TODO: Make this less brittle. This only works because this is the root render function


### PR DESCRIPTION
#### Summary
Fixes setting the following button on a card. Currently if going directly to a card via a URL the following information is not loaded.

In addition in order to duplicate the issue, I had to provide a fix where if going directly to the card via a URL, you were automatically redirected to the team.

#### Ticket Link
  Fixes https://github.com/mattermost/focalboard/issues/2815
  Fixes https://github.com/mattermost/focalboard/issues/2783
