### PR TITLE
Updated update category-board mapping method to not rely on DB returning affected rows

### DIFF
--- a/webapp/src/components/sidebar/sidebarBoardItem.tsx
+++ b/webapp/src/components/sidebar/sidebarBoardItem.tsx
@@ -75,7 +75,9 @@ const SidebarBoardItem = (props: Props) => {
                 icon={category.id === props.categoryBoards.id ? <Check/> : <Folder/>}
                 onClick={async (toCategoryID) => {
                     const fromCategoryID = props.categoryBoards.id
-                    await mutator.moveBoardToCategory(teamID, boardID, toCategoryID, fromCategoryID)
+                    if (fromCategoryID !== toCategoryID) {
+                        await mutator.moveBoardToCategory(teamID, boardID, toCategoryID, fromCategoryID)
+                    }
                 }}
             />
         ))


### PR DESCRIPTION
Fixes #2799

I'm not sure why the duplicate user-category-board rows got introduced in the database but I suspect it has to do with replying to the database returning the correct number of rows affected in an update operation. This is known to be inconsistent across databases and drivers.

In this PR I've removed the dependency on affected rows being rec=turned by DB in the update operation.