### PR TITLE
Removed teamID from search API

### DIFF
--- a/server/api/api.go
+++ b/server/api/api.go
@@ -3173,7 +3173,7 @@ func (a *API) handleSearchBoards(w http.ResponseWriter, r *http.Request) {
 	auditRec.AddMeta("teamID", teamID)
 
 	// retrieve boards list
-	boards, err := a.app.SearchBoardsForUser(term, userID, teamID)
+	boards, err := a.app.SearchBoardsForUser(term, userID)
 	if err != nil {
 		a.errorResponse(w, r.URL.Path, http.StatusInternalServerError, "", err)
 		return

--- a/server/app/boards.go
+++ b/server/app/boards.go
@@ -369,8 +369,8 @@ func (a *App) DeleteBoardMember(boardID, userID string) error {
 	return nil
 }
 
-func (a *App) SearchBoardsForUser(term, userID, teamID string) ([]*model.Board, error) {
-	return a.store.SearchBoardsForUser(term, userID, teamID)
+func (a *App) SearchBoardsForUser(term, userID string) ([]*model.Board, error) {
+	return a.store.SearchBoardsForUser(term, userID)
 }
 
 func (a *App) UndeleteBoard(boardID string, modifiedBy string) error {

--- a/server/services/store/mockstore/mockstore.go
+++ b/server/services/store/mockstore/mockstore.go
@@ -1159,18 +1159,18 @@ func (mr *MockStoreMockRecorder) SaveMember(arg0 interface{}) *gomock.Call {
 }
 
 // SearchBoardsForUser mocks base method.
-func (m *MockStore) SearchBoardsForUser(arg0, arg1, arg2 string) ([]*model.Board, error) {
+func (m *MockStore) SearchBoardsForUser(arg0, arg1 string) ([]*model.Board, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SearchBoardsForUser", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "SearchBoardsForUser", arg0, arg1)
 	ret0, _ := ret[0].([]*model.Board)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // SearchBoardsForUser indicates an expected call of SearchBoardsForUser.
-func (mr *MockStoreMockRecorder) SearchBoardsForUser(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockStoreMockRecorder) SearchBoardsForUser(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SearchBoardsForUser", reflect.TypeOf((*MockStore)(nil).SearchBoardsForUser), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SearchBoardsForUser", reflect.TypeOf((*MockStore)(nil).SearchBoardsForUser), arg0, arg1)
 }
 
 // SearchUsersByTeam mocks base method.

--- a/server/services/store/sqlstore/public_methods.go
+++ b/server/services/store/sqlstore/public_methods.go
@@ -677,7 +677,7 @@ func (s *SQLStore) SaveMember(bm *model.BoardMember) (*model.BoardMember, error)
 
 }
 
-func (s *SQLStore) SearchBoardsForUser(term string, userID string, teamID string) ([]*model.Board, error) {
+func (s *SQLStore) SearchBoardsForUser(term string, userID string) ([]*model.Board, error) {
 	return s.searchBoardsForUser(s.db, term, userID)
 
 }

--- a/server/services/store/store.go
+++ b/server/services/store/store.go
@@ -99,7 +99,7 @@ type Store interface {
 	GetBoardMemberHistory(boardID, userID string, limit uint64) ([]*model.BoardMemberHistoryEntry, error)
 	GetMembersForBoard(boardID string) ([]*model.BoardMember, error)
 	GetMembersForUser(userID string) ([]*model.BoardMember, error)
-	SearchBoardsForUser(term, userID, teamID string) ([]*model.Board, error)
+	SearchBoardsForUser(term, userID string) ([]*model.Board, error)
 
 	// @withTransaction
 	CreateBoardsAndBlocksWithAdmin(bab *model.BoardsAndBlocks, userID string) (*model.BoardsAndBlocks, []*model.BoardMember, error)

--- a/server/services/store/storetests/boards.go
+++ b/server/services/store/storetests/boards.go
@@ -689,7 +689,7 @@ func testSearchBoardsForUser(t *testing.T, store store.Store) {
 	userID := "user-id-1"
 
 	t.Run("should return empty if user is not a member of any board and there are no public boards on the team", func(t *testing.T) {
-		boards, err := store.SearchBoardsForUser("", userID, teamID1)
+		boards, err := store.SearchBoardsForUser("", userID)
 		require.NoError(t, err)
 		require.Empty(t, boards)
 	})
@@ -785,7 +785,7 @@ func testSearchBoardsForUser(t *testing.T, store store.Store) {
 
 	for _, tc := range testCases {
 		t.Run(tc.Name, func(t *testing.T) {
-			boards, err := store.SearchBoardsForUser(tc.Term, tc.UserID, tc.TeamID)
+			boards, err := store.SearchBoardsForUser(tc.Term, tc.UserID)
 			require.NoError(t, err)
 
 			boardIDs := []string{}


### PR DESCRIPTION
Fixed some instances of search board method being called with extra params