### PR TITLE
Include plugin unit tests in CI via makefile; fix unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,6 +134,7 @@ server-test-mysql: templates-archive ## Run server tests using mysql
 	docker-compose -f ./docker-testing/docker-compose-mysql.yml down -v --remove-orphans
 	docker-compose -f ./docker-testing/docker-compose-mysql.yml run start_dependencies
 	cd server; go test -tags '$(BUILD_TAGS)' -race -v -count=1 -timeout=30m ./...
+	cd mattermost-plugin/server; go test -tags '$(BUILD_TAGS)' -race -v -count=1 -timeout=30m ./...
 	docker-compose -f ./docker-testing/docker-compose-mysql.yml down -v --remove-orphans
 
 server-test-postgres: export FB_UNIT_TESTING=1
@@ -145,6 +146,7 @@ server-test-postgres: templates-archive ## Run server tests using postgres
 	docker-compose -f ./docker-testing/docker-compose-postgres.yml down -v --remove-orphans
 	docker-compose -f ./docker-testing/docker-compose-postgres.yml run start_dependencies
 	cd server; go test -tags '$(BUILD_TAGS)' -race -v -count=1 -timeout=30m ./...
+	cd mattermost-plugin/server; go test -tags '$(BUILD_TAGS)' -race -v -count=1 -timeout=30m ./...
 	docker-compose -f ./docker-testing/docker-compose-postgres.yml down -v --remove-orphans
 
 webapp: ## Build webapp.

--- a/mattermost-plugin/server/plugin_test.go
+++ b/mattermost-plugin/server/plugin_test.go
@@ -6,13 +6,19 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/mattermost/mattermost-server/v6/model"
 )
 
 func TestServeHTTP(t *testing.T) {
+	th, tearDown := SetupTestHelper(t)
+	defer tearDown()
+
 	assert := assert.New(t)
-	plugin := Plugin{}
+	plugin := Plugin{
+		server: th.Server,
+	}
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest(http.MethodGet, "/", nil)
 
@@ -25,11 +31,18 @@ func TestServeHTTP(t *testing.T) {
 	assert.Nil(err)
 	bodyString := string(bodyBytes)
 
-	assert.Equal("Hello, world!", bodyString)
+	// TODO: fix this; where is `Hello World` text generated?
+	// assert.Equal("Hello, world!", bodyString)
+	assert.Equal("", bodyString)
 }
 
 func TestSetConfiguration(t *testing.T) {
-	plugin := Plugin{}
+	th, tearDown := SetupTestHelper(t)
+	defer tearDown()
+
+	plugin := Plugin{
+		server: th.Server,
+	}
 	boolTrue := true
 	stringRef := ""
 
@@ -46,8 +59,9 @@ func TestSetConfiguration(t *testing.T) {
 
 	directory := "testDirectory"
 	baseFileSettings := &model.FileSettings{
-		DriverName: &driverName,
-		Directory:  &directory,
+		DriverName:  &driverName,
+		Directory:   &directory,
+		MaxFileSize: model.NewInt64(1024 * 1024),
 	}
 
 	baseConfig := &model.Config{

--- a/mattermost-plugin/server/plugin_test.go
+++ b/mattermost-plugin/server/plugin_test.go
@@ -20,7 +20,7 @@ func TestServeHTTP(t *testing.T) {
 		server: th.Server,
 	}
 	w := httptest.NewRecorder()
-	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r := httptest.NewRequest(http.MethodGet, "/hello", nil)
 
 	plugin.ServeHTTP(nil, w, r)
 
@@ -31,9 +31,7 @@ func TestServeHTTP(t *testing.T) {
 	assert.Nil(err)
 	bodyString := string(bodyBytes)
 
-	// TODO: fix this; where is `Hello World` text generated?
-	// assert.Equal("Hello, world!", bodyString)
-	assert.Equal("", bodyString)
+	assert.Equal("Hello", bodyString)
 }
 
 func TestSetConfiguration(t *testing.T) {

--- a/server/api/api.go
+++ b/server/api/api.go
@@ -141,17 +141,20 @@ func (a *API) RegisterRoutes(r *mux.Router) {
 	// Get Files API
 	apiv2.HandleFunc("/files/teams/{teamID}/{boardID}/{filename}", a.attachSession(a.handleServeFile, false)).Methods("GET")
 
-	// Subscriptions
+	// Subscription APIs
 	apiv2.HandleFunc("/subscriptions", a.sessionRequired(a.handleCreateSubscription)).Methods("POST")
 	apiv2.HandleFunc("/subscriptions/{blockID}/{subscriberID}", a.sessionRequired(a.handleDeleteSubscription)).Methods("DELETE")
 	apiv2.HandleFunc("/subscriptions/{subscriberID}", a.sessionRequired(a.handleGetSubscriptions)).Methods("GET")
 
-	// onboarding tour endpoints
+	// Onboarding tour endpoints APIs
 	apiv2.HandleFunc("/teams/{teamID}/onboard", a.sessionRequired(a.handleOnboard)).Methods(http.MethodPost)
 
-	// archives
+	// Archive APIs
 	apiv2.HandleFunc("/boards/{boardID}/archive/export", a.sessionRequired(a.handleArchiveExportBoard)).Methods("GET")
 	apiv2.HandleFunc("/teams/{teamID}/archive/import", a.sessionRequired(a.handleArchiveImport)).Methods("POST")
+
+	// System APIs
+	r.HandleFunc("/hello", a.handleHello).Methods("GET")
 }
 
 func (a *API) RegisterAdminRoutes(r *mux.Router) {
@@ -4111,6 +4114,20 @@ func (a *API) handleDeleteBoardsAndBlocks(w http.ResponseWriter, r *http.Request
 	auditRec.Success()
 }
 
+func (a *API) handleHello(w http.ResponseWriter, r *http.Request) {
+	// swagger:operation GET /hello hello
+	//
+	// Responds with `Hello` if the web service is running.
+	//
+	// ---
+	// produces:
+	// - text/plain
+	// responses:
+	//   '200':
+	//     description: success
+	stringResponse(w, "Hello")
+}
+
 // Response helpers
 
 func (a *API) errorResponse(w http.ResponseWriter, api string, code int, message string, sourceError error) {
@@ -4137,6 +4154,11 @@ func (a *API) errorResponse(w http.ResponseWriter, api string, code int, message
 	}
 	w.WriteHeader(code)
 	_, _ = w.Write(data)
+}
+
+func stringResponse(w http.ResponseWriter, message string) {
+	w.Header().Set("Content-Type", "text/plain")
+	_, _ = fmt.Fprint(w, message)
 }
 
 func jsonStringResponse(w http.ResponseWriter, code int, message string) { //nolint:unparam

--- a/server/integrationtests/clienttestlib.go
+++ b/server/integrationtests/clienttestlib.go
@@ -171,7 +171,7 @@ func newTestServerWithLicense(singleUserToken string, licenseType LicenseType) *
 	return srv
 }
 
-func newTestServerPluginMode() *server.Server {
+func NewTestServerPluginMode() *server.Server {
 	cfg, err := getTestConfig()
 	if err != nil {
 		panic(err)
@@ -259,7 +259,7 @@ func SetupTestHelper(t *testing.T) *TestHelper {
 
 func SetupTestHelperPluginMode(t *testing.T) *TestHelper {
 	th := &TestHelper{T: t}
-	th.Server = newTestServerPluginMode()
+	th.Server = NewTestServerPluginMode()
 	th.Start()
 	return th
 }


### PR DESCRIPTION
#### Summary
This PR enables unit testing for plugin when running locally via `make server-test` or CI.  Also fixes broken unit tests.

#### Ticket Link
NONE