### PR TITLE
Fixed the css issue in emptyCardButton for firefox browser

### DIFF
--- a/webapp/src/components/viewHeader/emptyCardButton.scss
+++ b/webapp/src/components/viewHeader/emptyCardButton.scss
@@ -1,0 +1,24 @@
+@-moz-document url-prefix() {
+    .MenuOption .TextOption .menu-option .bold-menu-text {
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+        position: relative;
+        font-size: 14px;
+        line-height: 24px;
+        font-weight: 400;
+        height: 32px;
+        padding: 4px 20px;
+        cursor: pointer;
+    }
+
+    .bold-menu-text {
+        div:first-child {
+            opacity: 0.56;
+            width: 18px;
+            height: 18px;
+        }
+    }
+
+    
+}

--- a/webapp/src/components/viewHeader/emptyCardButton.tsx
+++ b/webapp/src/components/viewHeader/emptyCardButton.tsx
@@ -17,6 +17,8 @@ import {useAppSelector} from '../../store/hooks'
 import {getCurrentView} from '../../store/views'
 import {getCurrentBoardId} from '../../store/boards'
 
+import './emptyCardButton.scss'
+
 type Props = {
     addCard: () => void
 }


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

CSS fixed in emptyCardButton icon button alignment for FireFox browser.

#### Ticket Link: https://github.com/mattermost/focalboard/issues/2807
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

