### PR TITLE
Handle jsonb fields on postgres with binary_parameters set

### DIFF
--- a/server/services/store/sqlstore/board.go
+++ b/server/services/store/sqlstore/board.go
@@ -269,7 +269,7 @@ func (s *SQLStore) getBoardsForUserAndTeam(db sq.BaseRunner, userID, teamID stri
 }
 
 func (s *SQLStore) insertBoard(db sq.BaseRunner, board *model.Board, userID string) (*model.Board, error) {
-	propertiesBytes, err := json.Marshal(board.Properties)
+	propertiesBytes, err := s.MarshalJSONB(board.Properties)
 	if err != nil {
 		s.logger.Error(
 			"failed to marshal board.Properties",
@@ -280,7 +280,7 @@ func (s *SQLStore) insertBoard(db sq.BaseRunner, board *model.Board, userID stri
 		return nil, err
 	}
 
-	cardPropertiesBytes, err := json.Marshal(board.CardProperties)
+	cardPropertiesBytes, err := s.MarshalJSONB(board.CardProperties)
 	if err != nil {
 		s.logger.Error(
 			"failed to marshal board.CardProperties",
@@ -383,11 +383,11 @@ func (s *SQLStore) deleteBoard(db sq.BaseRunner, boardID, userID string) error {
 		return err
 	}
 
-	propertiesBytes, err := json.Marshal(board.Properties)
+	propertiesBytes, err := s.MarshalJSONB(board.Properties)
 	if err != nil {
 		return err
 	}
-	cardPropertiesBytes, err := json.Marshal(board.CardProperties)
+	cardPropertiesBytes, err := s.MarshalJSONB(board.CardProperties)
 	if err != nil {
 		return err
 	}
@@ -693,12 +693,12 @@ func (s *SQLStore) undeleteBoard(db sq.BaseRunner, boardID string, modifiedBy st
 		return nil // undeleting not deleted board is not considered an error (for now)
 	}
 
-	propertiesJSON, err := json.Marshal(board.Properties)
+	propertiesJSON, err := s.MarshalJSONB(board.Properties)
 	if err != nil {
 		return err
 	}
 
-	cardPropertiesJSON, err := json.Marshal(board.CardProperties)
+	cardPropertiesJSON, err := s.MarshalJSONB(board.CardProperties)
 	if err != nil {
 		return err
 	}

--- a/server/services/store/sqlstore/sqlstore.go
+++ b/server/services/store/sqlstore/sqlstore.go
@@ -2,6 +2,7 @@ package sqlstore
 
 import (
 	"database/sql"
+	"net/url"
 
 	"github.com/mattermost/mattermost-server/v6/plugin"
 
@@ -24,6 +25,7 @@ type SQLStore struct {
 	logger           *mlog.Logger
 	NewMutexFn       MutexFactory
 	pluginAPI        *plugin.API
+	isBinaryParam    bool
 }
 
 // MutexFactory is used by the store in plugin mode to generate
@@ -49,13 +51,34 @@ func New(params Params) (*SQLStore, error) {
 		pluginAPI:        params.PluginAPI,
 	}
 
-	err := store.Migrate()
+	var err error
+	store.isBinaryParam, err = store.computeBinaryParam()
+	if err != nil {
+		params.Logger.Error(`Cannot compute binary parameter`, mlog.Err(err))
+		return nil, err
+	}
+
+	err = store.Migrate()
 	if err != nil {
 		params.Logger.Error(`Table creation / migration failed`, mlog.Err(err))
 
 		return nil, err
 	}
 	return store, nil
+}
+
+// computeBinaryParam returns whether the data source uses binary_parameters
+// when using Postgres
+func (s *SQLStore) computeBinaryParam() (bool, error) {
+	if s.dbType != model.PostgresDBType {
+		return false, nil
+	}
+
+	url, err := url.Parse(s.connectionString)
+	if err != nil {
+		return false, err
+	}
+	return url.Query().Get("binary_parameters") == "yes", nil
 }
 
 // Shutdown close the connection with the store.

--- a/server/services/store/sqlstore/sqlstore.go
+++ b/server/services/store/sqlstore/sqlstore.go
@@ -68,7 +68,7 @@ func New(params Params) (*SQLStore, error) {
 }
 
 // computeBinaryParam returns whether the data source uses binary_parameters
-// when using Postgres
+// when using Postgres.
 func (s *SQLStore) computeBinaryParam() (bool, error) {
 	if s.dbType != model.PostgresDBType {
 		return false, nil

--- a/server/services/store/sqlstore/util.go
+++ b/server/services/store/sqlstore/util.go
@@ -2,6 +2,7 @@ package sqlstore
 
 import (
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -22,6 +23,19 @@ func (s *SQLStore) CloseRows(rows *sql.Rows) {
 
 func (s *SQLStore) IsErrNotFound(err error) bool {
 	return store.IsErrNotFound(err)
+}
+
+func (s *SQLStore) MarshalJSONB(data interface{}) ([]byte, error) {
+	b, err := json.Marshal(data)
+	if err != nil {
+		return nil, err
+	}
+
+	if s.isBinaryParam {
+		b = append([]byte{0x01}, b...)
+	}
+
+	return b, nil
 }
 
 func PrepareNewTestDatabase() (dbType string, connectionString string, err error) {


### PR DESCRIPTION
#### Summary
This PR sets a flag on the store marking if it has the `binary_parameters` set and creates a utility function that should be used to marshal the contents of the `jsonb` fields and will append the `0x01` byte to them if required as per the spec.

As a follow up, I will abstract these methods in the server code and import them directly to avoid code repetition.

#### Ticket Link
Fixes https://github.com/mattermost/focalboard/issues/2850
