### PR TITLE
fix: personal server invite link omitted base URL

### DIFF
--- a/webapp/src/components/sidebar/__snapshots__/registrationLink.test.tsx.snap
+++ b/webapp/src/components/sidebar/__snapshots__/registrationLink.test.tsx.snap
@@ -1,0 +1,65 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`components/sidebar/RegistrationLink renders with signupToken in URL query param 1`] = `
+<div>
+  <div
+    class="Modal bottom-right"
+  >
+    <div
+      class="toolbar hideOnWidescreen"
+    >
+      <button
+        aria-label="Close"
+        class="IconButton"
+        title="Close"
+        type="button"
+      >
+        <i
+          class="CompassIcon icon-close CloseIcon"
+        />
+      </button>
+    </div>
+    <div
+      class="RegistrationLink"
+    >
+      <div
+        class="row"
+      >
+        Share this link for others to create accounts:
+      </div>
+      <div
+        class="row"
+      >
+        <a
+          class="shareUrl"
+          href="http://localhost/register?t=abc123"
+          rel="noreferrer"
+          target="_blank"
+        >
+          http://localhost/register?t=abc123
+        </a>
+        <button
+          class="Button filled size--small"
+          type="button"
+        >
+          <span>
+            Copy link
+          </span>
+        </button>
+      </div>
+      <div
+        class="row"
+      >
+        <button
+          class="Button emphasis--secondary size--small"
+          type="button"
+        >
+          <span>
+            Regenerate token
+          </span>
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/webapp/src/components/sidebar/registrationLink.test.tsx
+++ b/webapp/src/components/sidebar/registrationLink.test.tsx
@@ -1,0 +1,73 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react'
+import configureStore from 'redux-mock-store'
+
+import {Provider as ReduxProvider} from 'react-redux'
+
+import {render} from '@testing-library/react'
+
+import {wrapIntl} from '../../testUtils'
+
+import {TestBlockFactory} from '../../test/testBlockFactory'
+
+import RegistrationLink from './registrationLink'
+
+describe('components/sidebar/RegistrationLink', () => {
+    const mockStore = configureStore([])
+
+    const board = TestBlockFactory.createBoard()
+    board.id = 'board1'
+
+    const categoryAttribute1 = TestBlockFactory.createCategoryBoards()
+    categoryAttribute1.name = 'Category 1'
+    categoryAttribute1.boardIDs = [board.id]
+
+    const state = {
+        teams: {
+            current: {
+                id: 'team-id',
+                signupToken: 'abc123'
+            },
+        },
+        boards: {
+            current: board.id,
+            boards: {
+                [board.id]: board,
+            },
+            myBoardMemberships: {
+                [board.id]: board,
+            },
+        },
+        views: {
+            views: [],
+        },
+        users: {
+            me: {},
+        },
+        sidebar: {
+            categoryAttributes: [
+                categoryAttribute1,
+            ],
+        },
+    }
+
+    test('renders with signupToken in URL query param', () => {
+        const store = mockStore(state)
+
+        const component = wrapIntl(
+            <ReduxProvider store={store}>
+                <RegistrationLink
+                    onClose={() => {}}
+                />
+            </ReduxProvider>,
+        )
+        const {container} = render(component)
+        expect(container).toMatchSnapshot()
+
+        const anchor = container.querySelector('.shareUrl')
+        const url = new URL(anchor?.getAttribute('href') as string)
+        expect(url.searchParams.get('t')).toStrictEqual(state.teams.current.signupToken)
+    })
+})

--- a/webapp/src/components/sidebar/registrationLink.test.tsx
+++ b/webapp/src/components/sidebar/registrationLink.test.tsx
@@ -10,46 +10,16 @@ import {render} from '@testing-library/react'
 
 import {wrapIntl} from '../../testUtils'
 
-import {TestBlockFactory} from '../../test/testBlockFactory'
-
 import RegistrationLink from './registrationLink'
 
 describe('components/sidebar/RegistrationLink', () => {
     const mockStore = configureStore([])
-
-    const board = TestBlockFactory.createBoard()
-    board.id = 'board1'
-
-    const categoryAttribute1 = TestBlockFactory.createCategoryBoards()
-    categoryAttribute1.name = 'Category 1'
-    categoryAttribute1.boardIDs = [board.id]
-
     const state = {
         teams: {
             current: {
                 id: 'team-id',
                 signupToken: 'abc123'
             },
-        },
-        boards: {
-            current: board.id,
-            boards: {
-                [board.id]: board,
-            },
-            myBoardMemberships: {
-                [board.id]: board,
-            },
-        },
-        views: {
-            views: [],
-        },
-        users: {
-            me: {},
-        },
-        sidebar: {
-            categoryAttributes: [
-                categoryAttribute1,
-            ],
         },
     }
 

--- a/webapp/src/components/sidebar/registrationLink.tsx
+++ b/webapp/src/components/sidebar/registrationLink.tsx
@@ -44,7 +44,7 @@ const RegistrationLink = (props: Props) => {
         }
     }
 
-    const registrationUrl = new URL(Utils.buildURL('/register?t=' + signupToken), window.location.toString()).toString()
+    const registrationUrl = `${Utils.getBaseURL(true).replace(/\/$/, '')}/register?t=${signupToken}`
 
     return (
         <Modal

--- a/webapp/src/components/sidebar/registrationLink.tsx
+++ b/webapp/src/components/sidebar/registrationLink.tsx
@@ -44,7 +44,7 @@ const RegistrationLink = (props: Props) => {
         }
     }
 
-    const registrationUrl = Utils.buildURL('/register?t=' + signupToken, true)
+    const registrationUrl = new URL(Utils.buildURL('/register?t=' + signupToken), window.location.toString()).toString()
 
     return (
         <Modal


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

The Personal Server 'invite users' URL wasn't showing the base URL, just the `/register?t=xxx`. It looks like there was a change during the permissions branch that updated the behavior of `Utils.buildURL` to return _only_ the `path` argument if it's _not_ a plugin instance, even if the `absolute` arg is present. I followed the existing conventions to use the builtin `URL` type + constructor to create a properly formatted URL string.

![image](https://user-images.githubusercontent.com/6335792/164557129-90fd766c-1740-4453-a95c-9ec532df9f40.png)


#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

closes #2898 
