### PR TITLE
Initialise the store with a single user flag and pass it to the migrations

### DIFF
--- a/linux/main.go
+++ b/linux/main.go
@@ -61,7 +61,8 @@ func runServer(port int) (*server.Server, error) {
 		AuthMode:                "native",
 	}
 
-	db, err := server.NewStore(config, logger)
+	singleUser := len(sessionToken) > 0
+	db, err := server.NewStore(config, singleUser, logger)
 	if err != nil {
 		fmt.Println("ERROR INITIALIZING THE SERVER STORE", err)
 		return nil, err

--- a/server/integrationtests/clienttestlib.go
+++ b/server/integrationtests/clienttestlib.go
@@ -135,7 +135,8 @@ func newTestServerWithLicense(singleUserToken string, licenseType LicenseType) *
 	if err = logger.Configure("", cfg.LoggingCfgJSON, nil); err != nil {
 		panic(err)
 	}
-	innerStore, err := server.NewStore(cfg, logger)
+	singleUser := len(singleUserToken) > 0
+	innerStore, err := server.NewStore(cfg, singleUser, logger)
 	if err != nil {
 		panic(err)
 	}
@@ -183,7 +184,7 @@ func NewTestServerPluginMode() *server.Server {
 	if err = logger.Configure("", cfg.LoggingCfgJSON, nil); err != nil {
 		panic(err)
 	}
-	innerStore, err := server.NewStore(cfg, logger)
+	innerStore, err := server.NewStore(cfg, false, logger)
 	if err != nil {
 		panic(err)
 	}
@@ -219,7 +220,7 @@ func newTestServerLocalMode() *server.Server {
 		panic(err)
 	}
 
-	db, err := server.NewStore(cfg, logger)
+	db, err := server.NewStore(cfg, false, logger)
 	if err != nil {
 		panic(err)
 	}

--- a/server/main/main.go
+++ b/server/main/main.go
@@ -141,7 +141,7 @@ func main() {
 		config.Port = *pPort
 	}
 
-	db, err := server.NewStore(config, logger)
+	db, err := server.NewStore(config, singleUser, logger)
 	if err != nil {
 		logger.Fatal("server.NewStore ERROR", mlog.Err(err))
 	}
@@ -232,7 +232,8 @@ func startServer(webPath string, filesPath string, port int, singleUserToken, db
 		config.DBConfigString = dbConfigString
 	}
 
-	db, err := server.NewStore(config, logger)
+	singleUser := len(singleUserToken) > 0
+	db, err := server.NewStore(config, singleUser, logger)
 	if err != nil {
 		logger.Fatal("server.NewStore ERROR", mlog.Err(err))
 	}

--- a/server/server/server.go
+++ b/server/server/server.go
@@ -207,7 +207,7 @@ func New(params Params) (*Server, error) {
 	return &server, nil
 }
 
-func NewStore(config *config.Configuration, logger *mlog.Logger) (store.Store, error) {
+func NewStore(config *config.Configuration, isSingleUser bool, logger *mlog.Logger) (store.Store, error) {
 	sqlDB, err := sql.Open(config.DBType, config.DBConfigString)
 	if err != nil {
 		logger.Error("connectDatabase failed", mlog.Err(err))
@@ -227,6 +227,7 @@ func NewStore(config *config.Configuration, logger *mlog.Logger) (store.Store, e
 		Logger:           logger,
 		DB:               sqlDB,
 		IsPlugin:         false,
+		IsSingleUser:     isSingleUser,
 	}
 
 	var db store.Store

--- a/server/services/store/sqlstore/migrate.go
+++ b/server/services/store/sqlstore/migrate.go
@@ -136,11 +136,12 @@ func (s *SQLStore) Migrate() error {
 	}
 
 	params := map[string]interface{}{
-		"prefix":   s.tablePrefix,
-		"postgres": s.dbType == model.PostgresDBType,
-		"sqlite":   s.dbType == model.SqliteDBType,
-		"mysql":    s.dbType == model.MysqlDBType,
-		"plugin":   s.isPlugin,
+		"prefix":     s.tablePrefix,
+		"postgres":   s.dbType == model.PostgresDBType,
+		"sqlite":     s.dbType == model.SqliteDBType,
+		"mysql":      s.dbType == model.MysqlDBType,
+		"plugin":     s.isPlugin,
+		"singleUser": s.isSingleUser,
 	}
 
 	migrationAssets := &embedded.AssetSource{

--- a/server/services/store/sqlstore/params.go
+++ b/server/services/store/sqlstore/params.go
@@ -16,6 +16,7 @@ type Params struct {
 	Logger           *mlog.Logger
 	DB               *sql.DB
 	IsPlugin         bool
+	IsSingleUser     bool
 	NewMutexFn       MutexFactory
 	PluginAPI        *plugin.API
 }

--- a/server/services/store/sqlstore/sqlstore.go
+++ b/server/services/store/sqlstore/sqlstore.go
@@ -21,6 +21,7 @@ type SQLStore struct {
 	tablePrefix      string
 	connectionString string
 	isPlugin         bool
+	isSingleUser     bool
 	logger           *mlog.Logger
 	NewMutexFn       MutexFactory
 	pluginAPI        *plugin.API
@@ -45,6 +46,7 @@ func New(params Params) (*SQLStore, error) {
 		connectionString: params.ConnectionString,
 		logger:           params.Logger,
 		isPlugin:         params.IsPlugin,
+		isSingleUser:     params.IsSingleUser,
 		NewMutexFn:       params.NewMutexFn,
 		pluginAPI:        params.PluginAPI,
 	}


### PR DESCRIPTION
#### Summary
This PR initialises the store with a `singleUser` parameter that is in the end passed to the migrations. It also modifies the board members initial migration to operate differently if running in single user mode.

#### Ticket Link
Fixes https://github.com/mattermost/focalboard/issues/2876

