### PR TITLE
GH-2894- Fix missing readonly token

### DIFF
--- a/server/api/api.go
+++ b/server/api/api.go
@@ -1548,7 +1548,7 @@ func (a *API) handleGetSharing(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if sharing == nil {
-		jsonStringResponse(w, http.StatusOK, "{}")
+		jsonStringResponse(w, http.StatusOK, "")
 		return
 	}
 


### PR DESCRIPTION

#### Summary
An update was made to reduce logging, so when a Sharing object isn't found, an empty object is returned rather than an error. However, the code that creates the token is dependent on the Sharing object being `undefined`, not an empty object.

This PR updates the return to return nothing, instead of an empty object, so the Sharing object is `undefined`.

#### Ticket Link

  Fixes https://github.com/mattermost/focalboard/issues/2894
