### PR TITLE
GH-2895  Call notification engine when duplicating boards

### DIFF
--- a/server/app/app.go
+++ b/server/app/app.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	blockChangeNotifierQueueSize       = 100
+	blockChangeNotifierQueueSize       = 1000
 	blockChangeNotifierPoolSize        = 10
 	blockChangeNotifierShutdownTimeout = time.Second * 10
 )


### PR DESCRIPTION
#### Summary
This PR fixes an issue where authors are not auto-subscribed to cards when duplicating boards (from template or regular board).

This PR also ensures that boards app APIs use the same notifications thread pool as blocks.

#### Ticket Link
fixes https://github.com/mattermost/focalboard/issues/2895