### PR TITLE
GH-2896 - Error on invalid token

### DIFF
--- a/webapp/src/errors.ts
+++ b/webapp/src/errors.ts
@@ -84,7 +84,9 @@ function errorDefFromId(id: ErrorId | null): ErrorDef {
         errDef.title = intl.formatMessage({id: 'error.invalid-read-only-board', defaultMessage: 'You don\’t have access to this board. Log in to access Boards.'})
         errDef.button1Enabled = true
         errDef.button1Text = intl.formatMessage({id: 'error.go-login', defaultMessage: 'Login'})
-        errDef.button1Redirect = window.location.origin + '/login'
+        errDef.button1Redirect = (): string => {
+            return window.location.origin
+        }
         errDef.button1Fill = true
         break
     }

--- a/webapp/src/errors.ts
+++ b/webapp/src/errors.ts
@@ -81,7 +81,7 @@ function errorDefFromId(id: ErrorId | null): ErrorDef {
         break
     }
     case ErrorId.InvalidReadOnlyBoard: {
-        errDef.title = intl.formatMessage({id: 'error.invalid-read-only-board', defaultMessage: 'You don’t have access to this board. Log in to access Boards.'})
+        errDef.title = intl.formatMessage({id: 'error.invalid-read-only-board', defaultMessage: 'You don\’t have access to this board. Log in to access Boards.'})
         errDef.button1Enabled = true
         errDef.button1Text = intl.formatMessage({id: 'error.go-login', defaultMessage: 'Login'})
         errDef.button1Redirect = window.location.origin + '/login'

--- a/webapp/src/errors.ts
+++ b/webapp/src/errors.ts
@@ -8,6 +8,7 @@ import {UserSettings} from './userSettings'
 enum ErrorId {
     TeamUndefined = 'team-undefined',
     NotLoggedIn = 'not-logged-in',
+    InvalidReadToken = 'invalid-read-token',
     BoardNotFound = 'board-not-found',
 }
 
@@ -76,6 +77,14 @@ function errorDefFromId(id: ErrorId | null): ErrorDef {
             }
             return '/login'
         }
+        errDef.button1Fill = true
+        break
+    }
+    case ErrorId.InvalidReadToken: {
+        errDef.title = intl.formatMessage({id: 'error.invalid-read-token', defaultMessage: 'Sorry, you don’t have access to this board. Log in to access Boards.'})
+        errDef.button1Enabled = true
+        errDef.button1Text = intl.formatMessage({id: 'error.go-login', defaultMessage: 'Login'})
+        errDef.button1Redirect = window.location.origin + '/login'
         errDef.button1Fill = true
         break
     }

--- a/webapp/src/errors.ts
+++ b/webapp/src/errors.ts
@@ -8,7 +8,7 @@ import {UserSettings} from './userSettings'
 enum ErrorId {
     TeamUndefined = 'team-undefined',
     NotLoggedIn = 'not-logged-in',
-    InvalidReadToken = 'invalid-read-token',
+    InvalidReadOnlyBoard = 'invalid-read-only-board',
     BoardNotFound = 'board-not-found',
 }
 
@@ -80,8 +80,8 @@ function errorDefFromId(id: ErrorId | null): ErrorDef {
         errDef.button1Fill = true
         break
     }
-    case ErrorId.InvalidReadToken: {
-        errDef.title = intl.formatMessage({id: 'error.invalid-read-token', defaultMessage: 'Sorry, you don’t have access to this board. Log in to access Boards.'})
+    case ErrorId.InvalidReadOnlyBoard: {
+        errDef.title = intl.formatMessage({id: 'error.invalid-read-only-board', defaultMessage: 'You don’t have access to this board. Log in to access Boards.'})
         errDef.button1Enabled = true
         errDef.button1Text = intl.formatMessage({id: 'error.go-login', defaultMessage: 'Login'})
         errDef.button1Redirect = window.location.origin + '/login'

--- a/webapp/src/store/initialLoad.ts
+++ b/webapp/src/store/initialLoad.ts
@@ -48,6 +48,11 @@ export const initialReadOnlyLoad = createAsyncThunk(
             client.getAllBlocks(boardId),
         ])
 
+        // if no board, read_token invalid
+        if (!board) {
+            throw new Error(ErrorId.InvalidReadToken)
+        }
+        
         return {board, blocks}
     },
 )

--- a/webapp/src/store/initialLoad.ts
+++ b/webapp/src/store/initialLoad.ts
@@ -50,7 +50,7 @@ export const initialReadOnlyLoad = createAsyncThunk(
 
         // if no board, read_token invalid
         if (!board) {
-            throw new Error(ErrorId.InvalidReadToken)
+            throw new Error(ErrorId.InvalidReadOnlyBoard)
         }
         
         return {board, blocks}


### PR DESCRIPTION
#### Summary
If a read-only token is invalid, an unauthorized user is left on the "Create Board" screen. This PR creates and handles an error when a read-only board is not returned. (ie. an invalid read-only token). 

#### Ticket Link

  Fixes https://github.com/mattermost/focalboard/issues/2896

#### ScreenShot
<img width="1063" alt="Screen Shot 2022-04-22 at 10 31 22 AM" src="https://user-images.githubusercontent.com/12704875/164756450-83f741a8-e187-48db-ab66-ac182614fbb7.png">
