### PR TITLE
Fixed a bug preventing any navigation in Mattermost desktop with subpath

### DIFF
--- a/mattermost-plugin/webapp/src/index.tsx
+++ b/mattermost-plugin/webapp/src/index.tsx
@@ -87,12 +87,12 @@ function customHistory() {
             }
 
             const pathName = event.data.message?.pathName
-            if (!pathName || !pathName.startsWith(windowAny.frontendBaseURL)) {
+            if (!pathName || !pathName.startsWith('/boards')) {
                 return
             }
 
             Utils.log(`Navigating Boards to ${pathName}`)
-            history.replace(pathName.replace(windowAny.frontendBaseURL, ''))
+            history.replace(pathName.replace('/boards', ''))
         })
     }
     return {


### PR DESCRIPTION
Fixes #2027

On the Mattermost desktop app, navigation in boards doesn't work if you are on a subpath. This PR, along with fixes in the latest unreleased desktop app fixes this issue.

To test this, you need to install the desktop app from the `master` branch, or download the latest nightly from [Desktop Builds](https://community-daily.mattermost.com/core/channels/desktop-builds) channel.

Thanks a ton, @devinbinnie for looking into this 🙌