### PR TITLE
Displayed only board members in autocomplete

### DIFF
--- a/webapp/src/components/cardDialog.tsx
+++ b/webapp/src/components/cardDialog.tsx
@@ -25,7 +25,7 @@ import Button from '../widgets/buttons/button'
 import {getUserBlockSubscriptionList} from '../store/initialLoad'
 
 import {IUser} from '../user'
-import {getBoardUsers, getMe} from '../store/users'
+import {getMe} from '../store/users'
 import {Permission} from '../constants'
 
 import BoardPermissionGate from './permissions/boardPermissionGate'
@@ -178,8 +178,6 @@ const CardDialog = (props: Props): JSX.Element => {
     const followingCards = useAppSelector(getUserBlockSubscriptionList)
     const isFollowingCard = Boolean(followingCards.find((following) => following.blockId === props.cardId))
     const toolbar = followActionButton(isFollowingCard)
-
-    console.log(useAppSelector(getBoardUsers))
 
     return (
         <>

--- a/webapp/src/components/cardDialog.tsx
+++ b/webapp/src/components/cardDialog.tsx
@@ -25,7 +25,7 @@ import Button from '../widgets/buttons/button'
 import {getUserBlockSubscriptionList} from '../store/initialLoad'
 
 import {IUser} from '../user'
-import {getMe} from '../store/users'
+import {getBoardUsers, getMe} from '../store/users'
 import {Permission} from '../constants'
 
 import BoardPermissionGate from './permissions/boardPermissionGate'
@@ -178,6 +178,8 @@ const CardDialog = (props: Props): JSX.Element => {
     const followingCards = useAppSelector(getUserBlockSubscriptionList)
     const isFollowingCard = Boolean(followingCards.find((following) => following.blockId === props.cardId))
     const toolbar = followActionButton(isFollowingCard)
+
+    console.log(useAppSelector(getBoardUsers))
 
     return (
         <>

--- a/webapp/src/store/boards.ts
+++ b/webapp/src/store/boards.ts
@@ -3,7 +3,7 @@
 
 import {createSlice, PayloadAction, createAsyncThunk, createSelector} from '@reduxjs/toolkit'
 
-import octoClient, {default as client} from '../octoClient'
+import {default as client} from '../octoClient'
 import {Board, BoardMember} from '../blocks/board'
 import {IUser} from '../user'
 
@@ -25,9 +25,6 @@ type BoardsState = {
 export const fetchBoardMembers = createAsyncThunk(
     'boardMembers/fetch',
     async ({teamId, boardId}: {teamId: string, boardId: string}, thunkAPI: any) => {
-        const allTeamUsers = await octoClient.getTeamUsers()
-        console.log(allTeamUsers)
-
         const members = await client.getBoardMembers(teamId, boardId)
         const users = [] as IUser[]
 


### PR DESCRIPTION
Fixes #2886

The issue was that we were adding new board members to the store who weren't part of the previous board, but not removing old users, who aren't part of the new board.