### PR TITLE
GH-2970 - Check for propertyValue not null

### DIFF
--- a/webapp/src/store/cards.ts
+++ b/webapp/src/store/cards.ts
@@ -271,7 +271,7 @@ function searchFilterCards(cards: Card[], board: Board, searchTextRaw: string): 
         for (const [propertyId, propertyValue] of Object.entries(card.fields.properties)) {
             // TODO: Refactor to a shared function that returns the display value of a property
             const propertyTemplate = board.cardProperties.find((o) => o.id === propertyId)
-            if (propertyTemplate) {
+            if (propertyTemplate && propertyValue) {
                 if (propertyTemplate.type === 'select') {
                     // Look up the value of the select option
                     const option = propertyTemplate.options.find((o) => o.id === propertyValue)


### PR DESCRIPTION
#### Summary
Some older cards may have Select property set to null. Newer cards have the property removed rather than its value set to null. Add a check for the propertyValue being null.

#### Ticket Link

  Fixes https://github.com/mattermost/focalboard/issues/2970
