### PR TITLE
GH-2995- Fix for following

### DIFF
--- a/webapp/src/pages/boardPage/websocketConnection.tsx
+++ b/webapp/src/pages/boardPage/websocketConnection.tsx
@@ -131,7 +131,7 @@ const WebsocketConnection = (props: Props) => {
             wsClient.removeOnReconnect(() => dispatch(props.loadAction(props.boardId)))
             wsClient.removeOnStateChange(updateWebsocketState)
         }
-    }, [props.teamId, props.readonly, props.boardId, props.loadAction])
+    }, [me?.id, props.teamId, props.readonly, props.boardId, props.loadAction])
 
     if (websocketClosed) {
         return (


### PR DESCRIPTION
#### Summary
When following/unfollowing card, the subscriber id is compared to me?id. However, we weren't rebuilding that function after me.id gets set.

#### Ticket Link

  Fixes https://github.com/mattermost/focalboard/issues/2995

