### PR TITLE
Fixed incorrect navigation bug

### DIFF
--- a/mattermost-plugin/server/manifest.go
+++ b/mattermost-plugin/server/manifest.go
@@ -21,7 +21,7 @@ const manifestStr = `
   "release_notes_url": "https://github.com/mattermost/focalboard/releases",
   "icon_path": "assets/starter-template-icon.svg",
   "version": "0.17.0",
-  "min_server_version": "6.7.0",
+  "min_server_version": "6.0.0",
   "server": {
     "executables": {
       "darwin-amd64": "server/dist/plugin-darwin-amd64",


### PR DESCRIPTION
Fixes #2945

1. The issue wasn't just with other users but with your own use as well once you start switching between teams.
2. The issue occurs when you delete the last viewed board of a team, or the first board in the first category (in order of appearance in the sidebar).