### PR TITLE
GH- 2987 - Add "copy" to board title when duplicated

### DIFF
--- a/server/services/store/sqlstore/boards_and_blocks.go
+++ b/server/services/store/sqlstore/boards_and_blocks.go
@@ -141,6 +141,16 @@ func (s *SQLStore) duplicateBoard(db sq.BaseRunner, boardID string, userID strin
 	if err != nil {
 		return nil, nil, err
 	}
+
+	// todo: server localization
+	if asTemplate == board.IsTemplate {
+		// board -> board or template -> template
+		board.Title += " copy"
+	} else if asTemplate {
+		// template from board
+		board.Title = "New board template"
+	}
+
 	// make new board private
 	board.Type = "P"
 	board.IsTemplate = asTemplate


### PR DESCRIPTION
#### Summary

When duplicating a board, a "copy" suffix should be added. Followed the same logic as is v0.15.  So when a template is created from a board the title is changed to "New board template".

As we do not have server localization yet. These are unlocalized.  However, they were in the release-0.15 code as well.
https://github.com/mattermost/focalboard/blob/release-0.15/webapp/src/mutator.ts#L793

#### Ticket Link

  Fixes https://github.com/mattermost/focalboard/issues/2978
