### PR TITLE
allow duplicating cards/baords if filecopy fails

### DIFF
--- a/server/app/blocks.go
+++ b/server/app/blocks.go
@@ -233,14 +233,12 @@ func (a *App) CopyCardFiles(sourceBoardID string, copiedBlocks []model.Block) er
 		)
 
 		if err := a.filesBackend.CopyFile(sourceFilePath, destinationFilePath); err != nil {
-			a.logger.Error(
+			a.logger.Warn(
 				"CopyCardFiles failed to copy file",
 				mlog.String("sourceFilePath", sourceFilePath),
 				mlog.String("destinationFilePath", destinationFilePath),
 				mlog.Err(err),
 			)
-
-			return err
 		}
 		block.Fields["fileId"] = destFilename
 	}

--- a/server/app/boards.go
+++ b/server/app/boards.go
@@ -150,11 +150,7 @@ func (a *App) DuplicateBoard(boardID, userID, toTeam string, asTemplate bool) (*
 
 	// copy any file attachments from the duplicated blocks.
 	if err = a.CopyCardFiles(boardID, bab.Blocks); err != nil {
-		dbab := model.NewDeleteBoardsAndBlocksFromBabs(bab)
-		if err = a.store.DeleteBoardsAndBlocks(dbab, userID); err != nil {
-			a.logger.Error("Cannot delete board after duplication error when copying block's files", mlog.String("boardID", bab.Boards[0].ID), mlog.Err(err))
-		}
-		return nil, nil, fmt.Errorf("could not copy files while duplicating board %s: %w", boardID, err)
+		a.logger.Warn("Could not copy files while duplicating board", mlog.String("BoardID", boardID), mlog.Err(err))
 	}
 
 	// bab.Blocks now has updated file ids for any blocks containing files.  We need to store them.


### PR DESCRIPTION
#### Summary
Don't throw errors when copy files fails. Log a warning and allow duplication to complete.

#### Ticket Link

  Fixes https://github.com/mattermost/focalboard/issues/2979

