### PR TITLE
Added the toggle feature on sidebar hearder

### DIFF
--- a/webapp/src/components/__snapshots__/workspace.test.tsx.snap
+++ b/webapp/src/components/__snapshots__/workspace.test.tsx.snap
@@ -117,17 +117,13 @@ exports[`src/components/workspace return workspace and showcard 1`] = `
           <div
             class="octo-sidebar-item category ' expanded active"
           >
-            <button
-              type="button"
-            >
-              <i
-                class="CompassIcon icon-chevron-down ChevronDownIcon"
-              />
-            </button>
             <div
               class="octo-sidebar-title category-title"
               title="Category 1"
             >
+              <i
+                class="CompassIcon icon-chevron-down ChevronDownIcon"
+              />
               Category 1
             </div>
             <div
@@ -208,17 +204,13 @@ exports[`src/components/workspace return workspace and showcard 1`] = `
           <div
             class="octo-sidebar-item category ' expanded "
           >
-            <button
-              type="button"
-            >
-              <i
-                class="CompassIcon icon-chevron-down ChevronDownIcon"
-              />
-            </button>
             <div
               class="octo-sidebar-title category-title"
               title="Boards"
             >
+              <i
+                class="CompassIcon icon-chevron-down ChevronDownIcon"
+              />
               Boards
             </div>
             <div
@@ -1334,17 +1326,13 @@ exports[`src/components/workspace should match snapshot 1`] = `
           <div
             class="octo-sidebar-item category ' expanded active"
           >
-            <button
-              type="button"
-            >
-              <i
-                class="CompassIcon icon-chevron-down ChevronDownIcon"
-              />
-            </button>
             <div
               class="octo-sidebar-title category-title"
               title="Category 1"
             >
+              <i
+                class="CompassIcon icon-chevron-down ChevronDownIcon"
+              />
               Category 1
             </div>
             <div
@@ -1425,17 +1413,13 @@ exports[`src/components/workspace should match snapshot 1`] = `
           <div
             class="octo-sidebar-item category ' expanded "
           >
-            <button
-              type="button"
-            >
-              <i
-                class="CompassIcon icon-chevron-down ChevronDownIcon"
-              />
-            </button>
             <div
               class="octo-sidebar-title category-title"
               title="Boards"
             >
+              <i
+                class="CompassIcon icon-chevron-down ChevronDownIcon"
+              />
               Boards
             </div>
             <div

--- a/webapp/src/components/sidebar/__snapshots__/sidebar.test.tsx.snap
+++ b/webapp/src/components/sidebar/__snapshots__/sidebar.test.tsx.snap
@@ -173,18 +173,13 @@ exports[`components/sidebarSidebar sidebar hidden 1`] = `
         <div
           class="octo-sidebar-item category ' expanded "
         >
-          <button
-            class="IconButton"
-            type="button"
-          >
-            <i
-              class="CompassIcon icon-chevron-down ChevronDownIcon"
-            />
-          </button>
           <div
             class="octo-sidebar-title category-title"
             title="Category 1"
           >
+            <i
+              class="CompassIcon icon-chevron-down ChevronDownIcon"
+            />
             Category 1
           </div>
           <div
@@ -238,18 +233,13 @@ exports[`components/sidebarSidebar sidebar hidden 1`] = `
         <div
           class="octo-sidebar-item category ' expanded "
         >
-          <button
-            class="IconButton"
-            type="button"
-          >
-            <i
-              class="CompassIcon icon-chevron-down ChevronDownIcon"
-            />
-          </button>
           <div
             class="octo-sidebar-title category-title"
             title="Boards"
           >
+            <i
+              class="CompassIcon icon-chevron-down ChevronDownIcon"
+            />
             Boards
           </div>
           <div

--- a/webapp/src/components/sidebar/__snapshots__/sidebarCategory.test.tsx.snap
+++ b/webapp/src/components/sidebar/__snapshots__/sidebarCategory.test.tsx.snap
@@ -8,18 +8,13 @@ exports[`components/sidebarCategory sidebar call hideSidebar 1`] = `
     <div
       class="octo-sidebar-item category ' expanded "
     >
-      <button
-        class="IconButton"
-        type="button"
-      >
-        <i
-          class="CompassIcon icon-chevron-down ChevronDownIcon"
-        />
-      </button>
       <div
         class="octo-sidebar-title category-title"
         title="Category 1"
       >
+        <i
+          class="CompassIcon icon-chevron-down ChevronDownIcon"
+        />
         Category 1
       </div>
       <div
@@ -105,25 +100,78 @@ exports[`components/sidebarCategory sidebar call hideSidebar 2`] = `
     class="SidebarCategory"
   >
     <div
-      class="octo-sidebar-item category ' collapsed "
+      class="octo-sidebar-item category ' expanded "
     >
-      <button
-        class="IconButton"
-        type="button"
-      >
-        <i
-          class="CompassIcon icon-chevron-right ChevronRightIcon"
-        />
-      </button>
       <div
         class="octo-sidebar-title category-title"
         title="Category 1"
       >
+        <i
+          class="CompassIcon icon-chevron-down ChevronDownIcon"
+        />
         Category 1
       </div>
       <div
         aria-label="menuwrapper"
         class="MenuWrapper"
+        role="button"
+      >
+        <button
+          class="IconButton"
+          type="button"
+        >
+          <i
+            class="CompassIcon icon-dots-horizontal OptionsIcon"
+          />
+        </button>
+      </div>
+    </div>
+    <div
+      class="SidebarBoardItem subitem "
+    >
+      <div
+        class="octo-sidebar-icon"
+      >
+        i
+      </div>
+      <div
+        class="octo-sidebar-title"
+        title="board title"
+      >
+        board title
+      </div>
+      <div
+        aria-label="menuwrapper"
+        class="MenuWrapper x"
+        role="button"
+      >
+        <button
+          class="IconButton"
+          type="button"
+        >
+          <i
+            class="CompassIcon icon-dots-horizontal OptionsIcon"
+          />
+        </button>
+      </div>
+    </div>
+    <div
+      class="SidebarBoardItem subitem "
+    >
+      <div
+        class="octo-sidebar-icon"
+      >
+        i
+      </div>
+      <div
+        class="octo-sidebar-title"
+        title="board title"
+      >
+        board title
+      </div>
+      <div
+        aria-label="menuwrapper"
+        class="MenuWrapper x"
         role="button"
       >
         <button

--- a/webapp/src/components/sidebar/sidebarCategory.test.tsx
+++ b/webapp/src/components/sidebar/sidebarCategory.test.tsx
@@ -89,7 +89,7 @@ describe('components/sidebarCategory', () => {
         expect(container).toMatchSnapshot()
 
         // testing collapsed state of category
-        const subItems = container.querySelectorAll('.category > .IconButton')
+        const subItems = container.querySelectorAll('.category')
         expect(subItems).toBeDefined()
         userEvent.click(subItems[0] as Element)
         expect(container).toMatchSnapshot()

--- a/webapp/src/components/sidebar/sidebarCategory.tsx
+++ b/webapp/src/components/sidebar/sidebarCategory.tsx
@@ -142,15 +142,12 @@ const SidebarCategory = (props: Props) => {
             <div
                 className={`octo-sidebar-item category ' ${collapsed ? 'collapsed' : 'expanded'} ${props.categoryBoards.id === props.activeCategoryId ? 'active' : ''}`}
             >
-                <IconButton
-                    icon={collapsed ? <ChevronRight/> : <ChevronDown/>}
-                    onClick={() => setCollapsed(!collapsed)}
-                />
                 <div
                     className='octo-sidebar-title category-title'
                     title={props.categoryBoards.name}
                     onClick={() => setCollapsed(!collapsed)}
                 >
+                    {collapsed ? <ChevronRight/> : <ChevronDown/>}
                     {props.categoryBoards.name}
                 </div>
                 <MenuWrapper

--- a/webapp/src/components/sidebar/sidebarCategory.tsx
+++ b/webapp/src/components/sidebar/sidebarCategory.tsx
@@ -149,6 +149,7 @@ const SidebarCategory = (props: Props) => {
                 <div
                     className='octo-sidebar-title category-title'
                     title={props.categoryBoards.name}
+                    onClick={() => setCollapsed(!collapsed)}
                 >
                     {props.categoryBoards.name}
                 </div>


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
This PR adds the feature to toggle and collapse by clicking on the board category on the sidebar as it is in channels. 
<!--
A description of what this pull request does.
-->

#### Ticket Link
Fixes https://github.com/mattermost/focalboard/issues/2955
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

