### PR TITLE
update min version in Plugin and build

### DIFF
--- a/mattermost-plugin/plugin.json
+++ b/mattermost-plugin/plugin.json
@@ -7,7 +7,7 @@
     "release_notes_url": "https://github.com/mattermost/focalboard/releases",
     "icon_path": "assets/starter-template-icon.svg",
     "version": "0.17.0",
-    "min_server_version": "6.0.0",
+    "min_server_version": "6.7.0",
     "server": {
         "executables": {
             "linux-amd64": "server/dist/plugin-linux-amd64",

--- a/mattermost-plugin/server/manifest.go
+++ b/mattermost-plugin/server/manifest.go
@@ -21,7 +21,7 @@ const manifestStr = `
   "release_notes_url": "https://github.com/mattermost/focalboard/releases",
   "icon_path": "assets/starter-template-icon.svg",
   "version": "0.17.0",
-  "min_server_version": "6.0.0",
+  "min_server_version": "6.7.0",
   "server": {
     "executables": {
       "darwin-amd64": "server/dist/plugin-darwin-amd64",


### PR DESCRIPTION
#### Summary
Update plugin.json to have updated `min_server-version`. Then ran build to ensure manifest.go got updated.

