### PR TITLE
Standardize env variable naming

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,20 +115,20 @@ watch-server-test: modd-precheck ## Run server tests watching for changes
 
 server-test: server-test-sqlite server-test-mysql server-test-postgres ## Run server tests
 
-server-test-sqlite: export FB_UNIT_TESTING=1
+server-test-sqlite: export FOCALBOARD_UNIT_TESTING=1
 
 server-test-sqlite: templates-archive ## Run server tests using sqlite
 	cd server; go test -tags '$(BUILD_TAGS)' -race -v -coverpkg=./... -coverprofile=server-sqlite-profile.coverage -count=1 -timeout=30m ./...
 	cd server; go tool cover -func server-sqlite-profile.coverage
 
-server-test-mini-sqlite: export FB_UNIT_TESTING=1
+server-test-mini-sqlite: export FOCALBOARD_UNIT_TESTING=1
 
 server-test-mini-sqlite: templates-archive ## Run server tests using sqlite
 	cd server/integrationtests; go test -tags '$(BUILD_TAGS)' -race -v -count=1 -timeout=30m ./...
 
-server-test-mysql: export FB_UNIT_TESTING=1
-server-test-mysql: export FB_STORE_TEST_DB_TYPE=mysql
-server-test-mysql: export FB_STORE_TEST_DOCKER_PORT=44445
+server-test-mysql: export FOCALBOARD_UNIT_TESTING=1
+server-test-mysql: export FOCALBOARD_STORE_TEST_DB_TYPE=mysql
+server-test-mysql: export FOCALBOARD_STORE_TEST_DOCKER_PORT=44445
 
 server-test-mysql: templates-archive ## Run server tests using mysql
 	@echo Starting docker container for mysql
@@ -140,9 +140,9 @@ server-test-mysql: templates-archive ## Run server tests using mysql
 	cd mattermost-plugin/server; go tool cover -func plugin-mysql-profile.coverage
 	docker-compose -f ./docker-testing/docker-compose-mysql.yml down -v --remove-orphans
 
-server-test-postgres: export FB_UNIT_TESTING=1
-server-test-postgres: export FB_STORE_TEST_DB_TYPE=postgres
-server-test-postgres: export FB_STORE_TEST_DOCKER_PORT=44446
+server-test-postgres: export FOCALBOARD_UNIT_TESTING=1
+server-test-postgres: export FOCALBOARD_STORE_TEST_DB_TYPE=postgres
+server-test-postgres: export FOCALBOARD_STORE_TEST_DOCKER_PORT=44446
 
 server-test-postgres: templates-archive ## Run server tests using postgres
 	@echo Starting docker container for postgres

--- a/mattermost-plugin/Makefile
+++ b/mattermost-plugin/Makefile
@@ -214,7 +214,7 @@ detach: setup-attach
 
 ## Runs any lints and unit tests defined for the server and webapp, if they exist.
 .PHONY: test
-test: export FB_UNIT_TESTING=1
+test: export FOCALBOARD_UNIT_TESTING=1
 test: webapp/node_modules
 ifneq ($(HAS_SERVER),)
 	$(GO) test -v $(GO_TEST_FLAGS) ./server/...

--- a/server/services/store/sqlstore/util.go
+++ b/server/services/store/sqlstore/util.go
@@ -38,7 +38,7 @@ func (s *SQLStore) MarshalJSONB(data interface{}) ([]byte, error) {
 }
 
 func PrepareNewTestDatabase() (dbType string, connectionString string, err error) {
-	dbType = strings.TrimSpace(os.Getenv("FB_STORE_TEST_DB_TYPE"))
+	dbType = strings.TrimSpace(os.Getenv("FOCALBOARD_STORE_TEST_DB_TYPE"))
 	if dbType == "" {
 		dbType = model.SqliteDBType
 	}
@@ -53,7 +53,7 @@ func PrepareNewTestDatabase() (dbType string, connectionString string, err error
 		}
 		connectionString = file.Name() + "?_busy_timeout=5000"
 		_ = file.Close()
-	} else if port := strings.TrimSpace(os.Getenv("FB_STORE_TEST_DOCKER_PORT")); port != "" {
+	} else if port := strings.TrimSpace(os.Getenv("FOCALBOARD_STORE_TEST_DOCKER_PORT")); port != "" {
 		// docker unit tests take priority over any DSN env vars
 		var template string
 		switch dbType {
@@ -97,7 +97,7 @@ func PrepareNewTestDatabase() (dbType string, connectionString string, err error
 		connectionString = fmt.Sprintf(template, "mmuser", port, dbName)
 	} else {
 		// mysql or postgres need a DSN (connection string)
-		connectionString = strings.TrimSpace(os.Getenv("FB_STORE_TEST_CONN_STRING"))
+		connectionString = strings.TrimSpace(os.Getenv("FOCALBOARD_STORE_TEST_CONN_STRING"))
 	}
 
 	return dbType, connectionString, nil

--- a/server/utils/debug.go
+++ b/server/utils/debug.go
@@ -7,7 +7,7 @@ import (
 
 // IsRunningUnitTests returns true if this instance of FocalBoard is running unit or integration tests.
 func IsRunningUnitTests() bool {
-	testing := os.Getenv("FB_UNIT_TESTING")
+	testing := os.Getenv("FOCALBOARD_UNIT_TESTING")
 	if testing == "" {
 		return false
 	}

--- a/server/web/webserver.go
+++ b/server/web/webserver.go
@@ -140,7 +140,7 @@ func fileExists(path string) bool {
 
 // errorOrWarn returns a `warn` level if this server instance is running unit tests, otherwise `error`.
 func errorOrWarn() mlog.Level {
-	unitTesting := strings.ToLower(strings.TrimSpace(os.Getenv("FB_UNIT_TESTING")))
+	unitTesting := strings.ToLower(strings.TrimSpace(os.Getenv("FOCALBOARD_UNIT_TESTING")))
 	if unitTesting == "1" || unitTesting == "y" || unitTesting == "t" {
 		return mlog.LvlWarn
 	}


### PR DESCRIPTION
#### Summary
This PR standardizes the environment variables so they are always prefixed with `FOCALBOARD_`.

This PR does **not** extract the env vars into a const file since all but two vars are via Viper's config file overrides or are simply defined and used by the makefile.

#### Ticket Link
https://community.mattermost.com/boards/workspace/qgsck6cts3fwpqwyjiupjm5cde/b4ctmm917q3rzdfi451qtuxjzcw/150d1464-6d59-4c39-810f-ee201439dbaf/c8erwyx3h37bxxkh31bozt1iyfc