### PR TITLE
product: proof of concept

### DIFF
--- a/mattermost-plugin/product/adapters.go
+++ b/mattermost-plugin/product/adapters.go
@@ -1,0 +1,210 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package product
+
+import (
+	"github.com/mattermost/mattermost-server/v6/app"
+	"github.com/mattermost/mattermost-server/v6/app/request"
+	mmModel "github.com/mattermost/mattermost-server/v6/model"
+	"github.com/mattermost/mattermost-server/v6/product"
+)
+
+type mattermostauthlayerPluginAPIImpl struct {
+	userService     product.UserService
+	licenseService  product.LicenseService
+	channelsService product.ChannelService
+}
+
+func newMattermostAuthLayerPluginAPIImpl(services map[app.ServiceKey]interface{}) *mattermostauthlayerPluginAPIImpl {
+	us := services[app.UserKey].(product.UserService)
+	ls := services[app.LicenseKey].(product.LicenseService)
+	cs := services[app.ChannelKey].(product.ChannelService)
+	return &mattermostauthlayerPluginAPIImpl{
+		userService:     us,
+		licenseService:  ls,
+		channelsService: cs,
+	}
+}
+
+func (impl *mattermostauthlayerPluginAPIImpl) GetDirectChannel(userID1, userID2 string) (*mmModel.Channel, *mmModel.AppError) {
+	return impl.channelsService.GetDirectChannel(userID1, userID2)
+}
+
+func (impl *mattermostauthlayerPluginAPIImpl) GetUser(userID string) (*mmModel.User, *mmModel.AppError) {
+	return impl.userService.GetUser(userID)
+}
+
+func (impl *mattermostauthlayerPluginAPIImpl) UpdateUser(user *mmModel.User) (*mmModel.User, *mmModel.AppError) {
+	return impl.userService.UpdateUser(user, true)
+}
+
+func (impl *mattermostauthlayerPluginAPIImpl) GetUserByEmail(email string) (*mmModel.User, *mmModel.AppError) {
+	return impl.userService.GetUserByEmail(email)
+}
+
+func (impl *mattermostauthlayerPluginAPIImpl) GetUserByUsername(username string) (*mmModel.User, *mmModel.AppError) {
+	return impl.userService.GetUserByUsername(username)
+}
+
+func (impl *mattermostauthlayerPluginAPIImpl) GetLicense() *mmModel.License {
+	return impl.licenseService.GetLicense()
+}
+
+type storePluginAPIImpl struct {
+	channelsService product.ChannelService
+}
+
+func newStorePluginAPIImpl(services map[app.ServiceKey]interface{}) *storePluginAPIImpl {
+	cs := services[app.ChannelKey].(product.ChannelService)
+	return &storePluginAPIImpl{
+		channelsService: cs,
+	}
+}
+
+func (impl *storePluginAPIImpl) GetChannel(id string) (*mmModel.Channel, *mmModel.AppError) {
+	return impl.channelsService.GetChannelByID(id)
+}
+
+type mutexAPIImpl struct {
+	clusterService product.ClusterService
+	logService     product.LogService
+}
+
+func newMutexAPIImpl(services map[app.ServiceKey]interface{}) *mutexAPIImpl {
+	cs := services[app.ClusterKey].(product.ClusterService)
+	ls := services[app.LogKey].(product.LogService)
+	return &mutexAPIImpl{
+		clusterService: cs,
+		logService:     ls,
+	}
+}
+
+func (impl *mutexAPIImpl) KVSetWithOptions(key string, value []byte, options mmModel.PluginKVSetOptions) (bool, *mmModel.AppError) {
+	return impl.clusterService.SetPluginKeyWithOptions("focalboard", key, value, options)
+}
+
+func (impl *mutexAPIImpl) LogError(msg string, keyValuePairs ...interface{}) {
+	impl.logService.LogError("focalboard", msg, keyValuePairs...)
+}
+
+type pluginDeliveriyAPIImpl struct {
+	userService     product.UserService
+	licenseService  product.LicenseService
+	channelsService product.ChannelService
+	postService     product.PostService
+	teamService     product.TeamService
+	botService      product.BotService
+	context         *request.Context
+}
+
+func newPluginDeliveryAPIImpl(ctx *request.Context, services map[app.ServiceKey]interface{}) *pluginDeliveriyAPIImpl {
+	us := services[app.UserKey].(product.UserService)
+	ls := services[app.LicenseKey].(product.LicenseService)
+	cs := services[app.ChannelKey].(product.ChannelService)
+	ps := services[app.PostKey].(product.PostService)
+	ts := services[app.TeamKey].(product.TeamService)
+	bs := services[app.BotKey].(product.BotService)
+	return &pluginDeliveriyAPIImpl{
+		userService:     us,
+		licenseService:  ls,
+		channelsService: cs,
+		postService:     ps,
+		teamService:     ts,
+		botService:      bs,
+		context:         ctx,
+	}
+}
+
+func (impl *pluginDeliveriyAPIImpl) GetDirectChannel(userID1, userID2 string) (*mmModel.Channel, error) {
+	return impl.channelsService.GetDirectChannel(userID1, userID2)
+}
+
+func (impl *pluginDeliveriyAPIImpl) CreatePost(post *mmModel.Post) error {
+	_, err := impl.postService.CreatePost(impl.context, post)
+	return err
+}
+
+func (impl *pluginDeliveriyAPIImpl) GetUserByID(userID string) (*mmModel.User, error) {
+	return impl.userService.GetUser(userID)
+}
+
+func (impl *pluginDeliveriyAPIImpl) GetUserByUsername(name string) (*mmModel.User, error) {
+	return impl.userService.GetUserByUsername(name)
+}
+
+func (impl *pluginDeliveriyAPIImpl) GetTeamMember(teamID string, userID string) (*mmModel.TeamMember, error) {
+	return impl.teamService.GetMember(teamID, userID)
+}
+
+func (impl *pluginDeliveriyAPIImpl) GetChannelByID(channelID string) (*mmModel.Channel, error) {
+	return impl.channelsService.GetChannelByID(channelID)
+}
+
+func (impl *pluginDeliveriyAPIImpl) GetChannelMember(channelID string, userID string) (*mmModel.ChannelMember, error) {
+	return impl.channelsService.GetChannelMember(channelID, userID)
+}
+
+func (impl *pluginDeliveriyAPIImpl) CreateMember(teamID string, userID string) (*mmModel.TeamMember, error) {
+	return impl.teamService.CreateMember(impl.context, teamID, userID)
+}
+
+func (impl *pluginDeliveriyAPIImpl) EnsureBot(bot *mmModel.Bot) (string, error) {
+	return impl.botService.EnsureBot(impl.context, "focalboard", bot)
+}
+
+type wsPluginAPIImpl struct {
+	clusterService product.ClusterService
+	logService     product.LogService
+}
+
+func newWSPluginAPIImpl(services map[app.ServiceKey]interface{}) *wsPluginAPIImpl {
+	cs := services[app.ClusterKey].(product.ClusterService)
+	ls := services[app.LogKey].(product.LogService)
+	return &wsPluginAPIImpl{
+		clusterService: cs,
+		logService:     ls,
+	}
+}
+
+func (impl *wsPluginAPIImpl) PublishWebSocketEvent(event string, payload map[string]interface{}, broadcast *mmModel.WebsocketBroadcast) {
+	impl.clusterService.PublishWebSocketEvent("focalboard", event, payload, broadcast)
+}
+
+func (impl *wsPluginAPIImpl) LogError(msg string, keyValuePairs ...interface{}) {
+	impl.logService.LogError("focalboard", msg, keyValuePairs...)
+}
+
+func (impl *wsPluginAPIImpl) LogWarn(msg string, keyValuePairs ...interface{}) {
+	impl.logService.LogWarn("focalboard", msg, keyValuePairs...)
+}
+
+func (impl *wsPluginAPIImpl) LogDebug(msg string, keyValuePairs ...interface{}) {
+	impl.logService.LogDebug("focalboard", msg, keyValuePairs...)
+}
+
+func (impl *wsPluginAPIImpl) PublishPluginClusterEvent(ev mmModel.PluginClusterEvent, opts mmModel.PluginClusterEventSendOptions) error {
+	return impl.clusterService.PublishPluginClusterEvent("focalboard", ev, opts)
+}
+
+type permissionsPluginAPIImpl struct {
+	permissionService product.PermissionService
+	logService        product.LogService
+}
+
+func newPermissionsPluginAPIImpl(services map[app.ServiceKey]interface{}) *permissionsPluginAPIImpl {
+	ps := services[app.PermissionsKey].(product.PermissionService)
+	ls := services[app.LogKey].(product.LogService)
+	return &permissionsPluginAPIImpl{
+		permissionService: ps,
+		logService:        ls,
+	}
+}
+
+func (impl *permissionsPluginAPIImpl) HasPermissionToTeam(userID, teamID string, permission *mmModel.Permission) bool {
+	return impl.permissionService.HasPermissionToTeam(userID, teamID, permission)
+}
+
+func (impl *permissionsPluginAPIImpl) LogError(msg string, keyValuePairs ...interface{}) {
+	impl.logService.LogError("focalboard", msg, keyValuePairs...)
+}

--- a/mattermost-plugin/product/notifications.go
+++ b/mattermost-plugin/product/notifications.go
@@ -1,0 +1,90 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package product
+
+import (
+	"fmt"
+
+	"github.com/mattermost/focalboard/server/services/config"
+	"github.com/mattermost/focalboard/server/services/notify/notifymentions"
+	"github.com/mattermost/focalboard/server/services/notify/notifysubscriptions"
+	"github.com/mattermost/focalboard/server/services/notify/plugindelivery"
+	"github.com/mattermost/focalboard/server/services/permissions"
+	"github.com/mattermost/focalboard/server/services/store"
+	"github.com/mattermost/focalboard/server/ws"
+
+	"github.com/mattermost/mattermost-server/v6/model"
+
+	"github.com/mattermost/mattermost-server/v6/shared/mlog"
+)
+
+const (
+	botUsername    = "boards"
+	botDisplayname = "Boards"
+	botDescription = "Created by Boards plugin."
+)
+
+type notifyBackendParams struct {
+	cfg         *config.Configuration
+	pluginAPI   *pluginDeliveriyAPIImpl
+	permissions permissions.PermissionsService
+	store       store.Store
+	wsAdapter   ws.Adapter
+	serverRoot  string
+	logger      *mlog.Logger
+}
+
+func createMentionsNotifyBackend(params notifyBackendParams) (*notifymentions.Backend, error) {
+	delivery, err := createDelivery(params.pluginAPI, params.serverRoot)
+	if err != nil {
+		return nil, err
+	}
+
+	backendParams := notifymentions.BackendParams{
+		Store:       params.store,
+		Permissions: params.permissions,
+		Delivery:    delivery,
+		WSAdapter:   params.wsAdapter,
+		Logger:      params.logger,
+	}
+
+	backend := notifymentions.New(backendParams)
+
+	return backend, nil
+}
+
+func createSubscriptionsNotifyBackend(params notifyBackendParams) (*notifysubscriptions.Backend, error) {
+	delivery, err := createDelivery(params.pluginAPI, params.serverRoot)
+	if err != nil {
+		return nil, err
+	}
+
+	backendParams := notifysubscriptions.BackendParams{
+		ServerRoot:             params.serverRoot,
+		Store:                  params.store,
+		Permissions:            params.permissions,
+		Delivery:               delivery,
+		WSAdapter:              params.wsAdapter,
+		Logger:                 params.logger,
+		NotifyFreqCardSeconds:  params.cfg.NotifyFreqCardSeconds,
+		NotifyFreqBoardSeconds: params.cfg.NotifyFreqBoardSeconds,
+	}
+	backend := notifysubscriptions.New(backendParams)
+
+	return backend, nil
+}
+
+func createDelivery(pd *pluginDeliveriyAPIImpl, serverRoot string) (*plugindelivery.PluginDelivery, error) {
+	bot := &model.Bot{
+		Username:    botUsername,
+		DisplayName: botDisplayname,
+		Description: botDescription,
+	}
+	botID, err := pd.EnsureBot(bot)
+	if err != nil {
+		return nil, fmt.Errorf("failed to ensure %s bot: %w", botDisplayname, err)
+	}
+
+	return plugindelivery.New(botID, serverRoot, pd), nil
+}

--- a/mattermost-plugin/product/product.go
+++ b/mattermost-plugin/product/product.go
@@ -1,0 +1,37 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package product
+
+import (
+	"fmt"
+
+	"github.com/mattermost/mattermost-server/v6/app"
+)
+
+func init() {
+	app.RegisterProduct("boards", app.ProductManifest{
+		Initializer:  NewBoards,
+		Dependencies: map[app.ServiceKey]struct{}{},
+	})
+}
+
+type Boards struct {
+}
+
+func NewBoards(mmServer *app.Server, services map[app.ServiceKey]interface{}) (app.Product, error) {
+	for _, service := range services {
+		fmt.Printf("Services available: %T\n", service)
+	}
+	return &Boards{}, nil
+}
+
+func (b *Boards) Start() error {
+	fmt.Printf("\n\n -------- STARTING BOARDS -------- \n\n\n")
+	return nil
+}
+
+func (b *Boards) Stop() error {
+	fmt.Printf("\n\n -------- STOPPING BOARDS -------- \n\n\n")
+	return nil
+}

--- a/mattermost-plugin/product/product.go
+++ b/mattermost-plugin/product/product.go
@@ -4,34 +4,320 @@
 package product
 
 import (
+	"encoding/json"
 	"fmt"
+	"net/url"
+	"reflect"
+	"strings"
+	"sync"
+
+	"github.com/mattermost/focalboard/server/auth"
+	"github.com/mattermost/focalboard/server/server"
+	"github.com/mattermost/focalboard/server/services/notify"
+	"github.com/mattermost/focalboard/server/services/permissions/mmpermissions"
+	"github.com/mattermost/focalboard/server/services/store"
+	"github.com/mattermost/focalboard/server/services/store/mattermostauthlayer"
+	"github.com/mattermost/focalboard/server/services/store/sqlstore"
+	"github.com/mattermost/focalboard/server/ws"
+	"github.com/mattermost/mattermost-plugin-api/cluster"
 
 	"github.com/mattermost/mattermost-server/v6/app"
+	"github.com/mattermost/mattermost-server/v6/app/request"
+	mmModel "github.com/mattermost/mattermost-server/v6/model"
+	"github.com/mattermost/mattermost-server/v6/plugin"
+	"github.com/mattermost/mattermost-server/v6/product"
 )
 
 func init() {
 	app.RegisterProduct("boards", app.ProductManifest{
-		Initializer:  NewBoards,
-		Dependencies: map[app.ServiceKey]struct{}{},
+		Initializer: NewBoards,
+		Dependencies: map[app.ServiceKey]struct{}{
+			app.PostKey:        {},
+			app.PermissionsKey: {},
+			app.UserKey:        {},
+			app.LicenseKey:     {},
+			app.ChannelKey:     {},
+			app.HooksKey:       {},
+			app.RouterKey:      {},
+		},
 	})
 }
 
 type Boards struct {
+	configurationLock sync.RWMutex
+	configuration     *configuration
+	server            *server.Server
+	ws                *ws.PluginAdapter
+	mmConfig          func() *mmModel.Config
+	hooksService      product.HooksService
 }
 
+// NewBoards creates the focalboard product ready to be started. The app.Server and Service map provides
+// or should provied all the necessary interfaces adn functionalities to initialize the focalboard server
 func NewBoards(mmServer *app.Server, services map[app.ServiceKey]interface{}) (app.Product, error) {
-	for _, service := range services {
-		fmt.Printf("Services available: %T\n", service)
+	// Get config
+	mmConfig := mmServer.Config()
+
+	sqlDB := mmServer.Store.GetInternalMasterDB()
+
+	// init logger and configure
+	logger := mmServer.Log
+
+	baseURL := ""
+	if mmConfig.ServiceSettings.SiteURL != nil {
+		baseURL = *mmConfig.ServiceSettings.SiteURL
 	}
-	return &Boards{}, nil
+
+	// TODO: add system service
+	serverID := "test_diagnostic_id" //client.System.GetDiagnosticID()
+	cfg := createBoardsConfig(*mmConfig, baseURL, serverID)
+
+	// create boards store
+	storeParams := sqlstore.Params{
+		DBType:           cfg.DBType,
+		ConnectionString: cfg.DBConfigString,
+		TablePrefix:      cfg.DBTablePrefix,
+		Logger:           logger,
+		DB:               sqlDB,
+		IsPlugin:         true,
+		NewMutexFn: func(name string) (*cluster.Mutex, error) {
+			return cluster.NewMutex(newMutexAPIImpl(services), name) // use services
+		},
+		PluginAPI: newStorePluginAPIImpl(services),
+	}
+
+	var db store.Store
+	var err error
+	db, err = sqlstore.New(storeParams)
+	if err != nil {
+		return nil, fmt.Errorf("error initializing the DB: %w", err)
+	}
+	if cfg.AuthMode == server.MattermostAuthMod {
+		layeredStore, err2 := mattermostauthlayer.New(cfg.DBType, sqlDB, db, logger, newMattermostAuthLayerPluginAPIImpl(services))
+		if err2 != nil {
+			return nil, fmt.Errorf("error initializing the DB: %w", err2)
+		}
+		db = layeredStore
+	}
+
+	psAPI := newPermissionsPluginAPIImpl(services)
+	permissionsService := mmpermissions.New(db, psAPI)
+	wsAPI := newWSPluginAPIImpl(services)
+
+	wsPluginAdapter := ws.NewPluginAdapter(wsAPI, auth.New(cfg, db, permissionsService), db, logger)
+
+	// TODO: create actual request.Context()
+	notifypluginAdapter := newPluginDeliveryAPIImpl(request.EmptyContext(), services)
+
+	backendParams := notifyBackendParams{
+		cfg:         cfg,
+		pluginAPI:   notifypluginAdapter,
+		store:       db,
+		permissions: permissionsService,
+		wsAdapter:   wsPluginAdapter,
+		serverRoot:  baseURL + "/boards",
+		logger:      logger,
+	}
+
+	var notifyBackends []notify.Backend
+
+	// TODO: add utility function or import
+	mentionsBackend, err := createMentionsNotifyBackend(backendParams)
+	if err != nil {
+		return nil, fmt.Errorf("error creating mention notifications backend: %w", err)
+	}
+	notifyBackends = append(notifyBackends, mentionsBackend)
+
+	// TODO: add utility function or import
+	subscriptionsBackend, err2 := createSubscriptionsNotifyBackend(backendParams)
+	if err2 != nil {
+		return nil, fmt.Errorf("error creating subscription notifications backend: %w", err2)
+	}
+	notifyBackends = append(notifyBackends, subscriptionsBackend)
+	mentionsBackend.AddListener(subscriptionsBackend)
+
+	params := server.Params{
+		Cfg:                cfg,
+		SingleUserToken:    "",
+		DBStore:            db,
+		Logger:             logger,
+		ServerID:           serverID,
+		WSAdapter:          wsPluginAdapter,
+		NotifyBackends:     notifyBackends,
+		PermissionsService: permissionsService,
+	}
+
+	server, err := server.New(params)
+	if err != nil {
+		fmt.Println("ERROR INITIALIZING THE SERVER", err)
+		return nil, err
+	}
+
+	routerService := services[app.RouterKey].(product.RouterService)
+	routerService.RegisterRouter("focalboard", server.GetRootRouter())
+	hooksService := services[app.HooksKey].(product.HooksService)
+
+	b := &Boards{
+		server:       server,
+		ws:           wsPluginAdapter,
+		mmConfig:     mmServer.Config,
+		hooksService: hooksService,
+	}
+
+	return b, nil
 }
 
 func (b *Boards) Start() error {
 	fmt.Printf("\n\n -------- STARTING BOARDS -------- \n\n\n")
-	return nil
+	// We need to register hooks after start, because the plugin environment
+	// starts after the channels product starts. And the boards product itself
+	// implements product.Hooks interface, it can be replaced by any other struct
+	// as this is just for demonstration purposes.
+	if err := b.hooksService.RegisterHooks("focalboard", b); err != nil {
+		return err
+	}
+	return b.server.Start()
 }
 
 func (b *Boards) Stop() error {
 	fmt.Printf("\n\n -------- STOPPING BOARDS -------- \n\n\n")
+	return b.server.Shutdown()
+}
+
+func (b *Boards) MessageWillBePosted(_ *plugin.Context, post *mmModel.Post) (*mmModel.Post, string) {
+	fmt.Println("hook called")
+	return postWithBoardsEmbed(post), ""
+}
+
+func (b *Boards) MessageWillBeUpdated(_ *plugin.Context, newPost, _ *mmModel.Post) (*mmModel.Post, string) {
+	return postWithBoardsEmbed(newPost), ""
+}
+
+func (b *Boards) OnWebSocketConnect(webConnID, userID string) {
+	b.ws.OnWebSocketConnect(webConnID, userID)
+}
+
+func (b *Boards) OnWebSocketDisconnect(webConnID, userID string) {
+	b.ws.OnWebSocketDisconnect(webConnID, userID)
+}
+
+func (b *Boards) WebSocketMessageHasBeenPosted(webConnID, userID string, req *mmModel.WebSocketRequest) {
+	b.ws.WebSocketMessageHasBeenPosted(webConnID, userID, req)
+}
+
+func (b *Boards) OnPluginClusterEvent(_ *plugin.Context, ev mmModel.PluginClusterEvent) {
+	b.ws.HandleClusterEvent(ev)
+}
+
+func (b *Boards) OnConfigurationChange() error { //nolint
+	// Have we been setup by OnActivate?
+	if b.ws == nil {
+		return nil
+	}
+	mmconfig := b.mmConfig()
+
+	// handle plugin configuration settings
+	enableShareBoards := false
+	if mmconfig.PluginSettings.Plugins[pluginName][sharedBoardsName] == true {
+		enableShareBoards = true
+	}
+	configuration := &configuration{
+		EnablePublicSharedBoards: enableShareBoards,
+	}
+	b.setConfiguration(configuration)
+	b.server.Config().EnablePublicSharedBoards = enableShareBoards
+
+	// handle feature flags
+	b.server.Config().FeatureFlags = parseFeatureFlags(mmconfig.FeatureFlags.ToMap())
+
+	// handle Data Retention settings
+	enableBoardsDeletion := false
+	if mmconfig.DataRetentionSettings.EnableBoardsDeletion != nil {
+		enableBoardsDeletion = true
+	}
+	b.server.Config().EnableDataRetention = enableBoardsDeletion
+	b.server.Config().DataRetentionDays = *mmconfig.DataRetentionSettings.BoardsRetentionDays
+
+	b.server.UpdateAppConfig()
+	b.ws.BroadcastConfigChange(*b.server.App().GetClientConfig())
 	return nil
+}
+
+type configuration struct {
+	EnablePublicSharedBoards bool
+}
+
+func (b *Boards) setConfiguration(configuration *configuration) {
+	b.configurationLock.Lock()
+	defer b.configurationLock.Unlock()
+
+	if configuration != nil && b.configuration == configuration {
+		// Ignore assignment if the configuration struct is empty. Go will optimize the
+		// allocation for same to point at the same memory address, breaking the check
+		// above.
+		if reflect.ValueOf(*configuration).NumField() == 0 {
+			return
+		}
+
+		panic("setConfiguration called with the existing configuration")
+	}
+
+	b.configuration = configuration
+}
+
+func postWithBoardsEmbed(post *mmModel.Post) *mmModel.Post {
+	if _, ok := post.GetProps()["boards"]; ok {
+		post.AddProp("boards", nil)
+	}
+
+	firstLink, newPostMessage := getFirstLinkAndShortenAllBoardsLink(post.Message)
+	post.Message = newPostMessage
+
+	if firstLink == "" {
+		return post
+	}
+
+	u, err := url.Parse(firstLink)
+
+	if err != nil {
+		return post
+	}
+
+	// Trim away the first / because otherwise after we split the string, the first element in the array is a empty element
+	urlPath := u.Path
+	urlPath = strings.TrimPrefix(urlPath, "/")
+	urlPath = strings.TrimSuffix(urlPath, "/")
+	pathSplit := strings.Split(strings.ToLower(urlPath), "/")
+	queryParams := u.Query()
+
+	if len(pathSplit) == 0 {
+		return post
+	}
+
+	teamID, boardID, viewID, cardID := returnBoardsParams(pathSplit)
+
+	if teamID != "" && boardID != "" && viewID != "" && cardID != "" {
+		b, _ := json.Marshal(BoardsEmbed{
+			TeamID:       teamID,
+			BoardID:      boardID,
+			ViewID:       viewID,
+			CardID:       cardID,
+			ReadToken:    queryParams.Get("r"),
+			OriginalPath: u.RequestURI(),
+		})
+
+		BoardsPostEmbed := &mmModel.PostEmbed{
+			Type: mmModel.PostEmbedBoards,
+			Data: string(b),
+		}
+
+		if post.Metadata == nil {
+			post.Metadata = &mmModel.PostMetadata{}
+		}
+
+		post.Metadata.Embeds = []*mmModel.PostEmbed{BoardsPostEmbed}
+		post.AddProp("boards", string(b))
+	}
+
+	return post
 }

--- a/server/services/store/mattermostauthlayer/mattermostauthlayer.go
+++ b/server/services/store/mattermostauthlayer/mattermostauthlayer.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 
 	mmModel "github.com/mattermost/mattermost-server/v6/model"
-	"github.com/mattermost/mattermost-server/v6/plugin"
 
 	sq "github.com/Masterminds/squirrel"
 
@@ -24,17 +23,28 @@ func (pe NotSupportedError) Error() string {
 	return pe.msg
 }
 
+// PluginAPI is the interface required my the MattermostAuthLayer to interact with
+// the mattermost-server. You can use plugin-api or product-api adapter implementations.
+type PluginAPI interface {
+	GetDirectChannel(userID1, userID2 string) (*mmModel.Channel, *mmModel.AppError)
+	GetUser(userID string) (*mmModel.User, *mmModel.AppError)
+	UpdateUser(user *mmModel.User) (*mmModel.User, *mmModel.AppError)
+	GetUserByEmail(email string) (*mmModel.User, *mmModel.AppError)
+	GetUserByUsername(username string) (*mmModel.User, *mmModel.AppError)
+	GetLicense() *mmModel.License
+}
+
 // Store represents the abstraction of the data storage.
 type MattermostAuthLayer struct {
 	store.Store
 	dbType    string
 	mmDB      *sql.DB
 	logger    *mlog.Logger
-	pluginAPI plugin.API
+	pluginAPI PluginAPI
 }
 
 // New creates a new SQL implementation of the store.
-func New(dbType string, db *sql.DB, store store.Store, logger *mlog.Logger, pluginAPI plugin.API) (*MattermostAuthLayer, error) {
+func New(dbType string, db *sql.DB, store store.Store, logger *mlog.Logger, pluginAPI PluginAPI) (*MattermostAuthLayer, error) {
 	layer := &MattermostAuthLayer{
 		Store:     store,
 		dbType:    dbType,

--- a/server/services/store/sqlstore/data_migrations.go
+++ b/server/services/store/sqlstore/data_migrations.go
@@ -420,7 +420,7 @@ func (s *SQLStore) getBestTeamForBoard(tx sq.BaseRunner, board *model.Board) (st
 		// no common teams found. Let's try finding the best suitable team
 		if board.Type == "D" {
 			// get DM's creator and pick one of their team
-			channel, appErr := (*s.pluginAPI).GetChannel(board.ChannelID)
+			channel, appErr := (s.pluginAPI).GetChannel(board.ChannelID)
 			if appErr != nil {
 				s.logger.Error("failed to fetch DM channel for board", mlog.String("board_id", board.ID), mlog.String("channel_id", board.ChannelID), mlog.Err(appErr))
 				return "", appErr

--- a/server/services/store/sqlstore/params.go
+++ b/server/services/store/sqlstore/params.go
@@ -4,8 +4,7 @@ import (
 	"database/sql"
 	"fmt"
 
-	"github.com/mattermost/mattermost-server/v6/plugin"
-
+	mmModel "github.com/mattermost/mattermost-server/v6/model"
 	"github.com/mattermost/mattermost-server/v6/shared/mlog"
 )
 
@@ -18,7 +17,13 @@ type Params struct {
 	IsPlugin         bool
 	IsSingleUser     bool
 	NewMutexFn       MutexFactory
-	PluginAPI        *plugin.API
+	PluginAPI        PluginAPI
+}
+
+// PluginAPI is the interface required my the Params to interact with the mattermost-server.
+// You can use plugin-api or product-api adapter implementations.
+type PluginAPI interface {
+	GetChannel(string) (*mmModel.Channel, *mmModel.AppError)
 }
 
 func (p Params) CheckValid() error {

--- a/server/services/store/sqlstore/sqlstore.go
+++ b/server/services/store/sqlstore/sqlstore.go
@@ -4,8 +4,6 @@ import (
 	"database/sql"
 	"net/url"
 
-	"github.com/mattermost/mattermost-server/v6/plugin"
-
 	sq "github.com/Masterminds/squirrel"
 
 	"github.com/mattermost/focalboard/server/model"
@@ -25,7 +23,7 @@ type SQLStore struct {
 	isSingleUser     bool
 	logger           *mlog.Logger
 	NewMutexFn       MutexFactory
-	pluginAPI        *plugin.API
+	pluginAPI        PluginAPI
 	isBinaryParam    bool
 }
 

--- a/server/ws/plugin_adapter.go
+++ b/server/ws/plugin_adapter.go
@@ -13,7 +13,6 @@ import (
 	"github.com/mattermost/focalboard/server/utils"
 
 	mmModel "github.com/mattermost/mattermost-server/v6/model"
-	"github.com/mattermost/mattermost-server/v6/plugin"
 	"github.com/mattermost/mattermost-server/v6/shared/mlog"
 )
 
@@ -33,8 +32,18 @@ type PluginAdapterInterface interface {
 	HandleClusterEvent(ev mmModel.PluginClusterEvent)
 }
 
+// PluginAPI is the interface required my the PluginAdapter to interact with
+// the mattermost-server. You can use plugin-api or product-api adapter implementations.
+type PluginAPI interface {
+	PublishWebSocketEvent(event string, payload map[string]interface{}, broadcast *mmModel.WebsocketBroadcast)
+	LogError(msg string, keyValuePairs ...interface{})
+	LogWarn(msg string, keyValuePairs ...interface{})
+	LogDebug(msg string, keyValuePairs ...interface{})
+	PublishPluginClusterEvent(ev mmModel.PluginClusterEvent, opts mmModel.PluginClusterEventSendOptions) error
+}
+
 type PluginAdapter struct {
-	api            plugin.API
+	api            PluginAPI
 	auth           auth.AuthInterface
 	staleThreshold time.Duration
 	store          Store
@@ -49,7 +58,7 @@ type PluginAdapter struct {
 	listenersByBlock map[string][]*PluginAdapterClient
 }
 
-func NewPluginAdapter(api plugin.API, auth auth.AuthInterface, store Store, logger *mlog.Logger) *PluginAdapter {
+func NewPluginAdapter(api PluginAPI, auth auth.AuthInterface, store Store, logger *mlog.Logger) *PluginAdapter {
 	return &PluginAdapter{
 		api:               api,
 		auth:              auth,


### PR DESCRIPTION
#### Summary
Add skeleton for `app.Product` interface.

To make this work you will need to add a `go.work` file in the mattermost-server project as:

```
go 1.18

use ./

use ../focalboard/mattermost-plugin/ #considering that focalboard project is next to mattermost-server project directory
```

Then do an empty import `mattermost-server/cmd/mattermost/main.go`

```Go
import(
	...
	// Focalboard
	_ "github.com/mattermost/focalboard/mattermost-plugin/product"
)
```


