### PR TITLE
GH-2992 - Drag drop card to groups doesn't work

### DIFF
--- a/webapp/src/components/table/table.tsx
+++ b/webapp/src/components/table/table.tsx
@@ -117,7 +117,7 @@ const Table = (props: Props): JSX.Element => {
     const onDropToCard = useCallback((srcCard: Card, dstCard: Card) => {
         Utils.log(`onDropToCard: ${dstCard.title}`)
         onDropToGroup(srcCard, dstCard.fields.properties[activeView.fields.groupById!] as string, dstCard.id)
-    }, [activeView.fields.groupById])
+    }, [activeView.fields.groupById, cards])
 
     const onDropToGroup = useCallback((srcCard: Card, groupID: string, dstCardID: string) => {
         Utils.log(`onDropToGroup: ${srcCard.title}`)


### PR DESCRIPTION
#### Summary
Dragging a card from one group to anther and then dragging back to the original group did now work because OnDropToCard did not get updated when cards collection changed. Therefore is was using the old collection and thus had its group to original group. 


#### Ticket Link
  Fixes https://github.com/mattermost/focalboard/issues/2992

