### PR TITLE
Add cypress:debug script to webapp/package.json

### DIFF
--- a/webapp/package.json
+++ b/webapp/package.json
@@ -15,6 +15,7 @@
 		"i18n-extract": "formatjs extract ../mattermost-plugin/webapp/src/*/*/*.ts? src/*.ts? src/*/*.ts? src/*/*/*.ts? src/*/*/*/*.ts? --out-file i18n/tmp.json; formatjs compile i18n/tmp.json --out-file i18n/en.json; rm i18n/tmp.json",
 		"runserver-test": "cd cypress && \"../../bin/focalboard-server\"",
 		"cypress:ci": "start-server-and-test runserver-test http://localhost:8088 cypress:run",
+		"cypress:debug": "start-server-and-test runserver-test http://localhost:8088 cypress:open",
 		"cypress:run": "cypress run",
 		"cypress:run:chrome": "cypress run --browser chrome",
 		"cypress:run:firefox": "cypress run --browser firefox",


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Adds a script to the `webapp/package.json` file to simplify the process of starting up the server and opening Cypress in interactive mode for debugging purposes.

If a developer wants to run a Cypress test in interactive mode, they can just execute the following command:
`cd webapp && npm run cypress:debug`

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

