### PR TITLE
fix(webapp): template from global is modifiable

### DIFF
--- a/webapp/cypress/integration/createBoard.ts
+++ b/webapp/cypress/integration/createBoard.ts
@@ -173,7 +173,7 @@ describe('Create and delete board / card', () => {
         // eslint-disable-next-line cypress/no-unnecessary-waiting
         cy.get('.Kanban').
             trigger('dragover', {clientX: 400, clientY: Cypress.config().viewportHeight / 2}).
-            wait(3500).
+            wait(4500).
             trigger('dragend')
 
         cy.get('.Kanban').invoke('scrollLeft').should('equal', 0)

--- a/webapp/src/mutator.ts
+++ b/webapp/src/mutator.ts
@@ -795,6 +795,7 @@ class Mutator {
         } else if (asTemplate) {
             // Template from board
             newBoard.title = 'New board template'
+            newBoard.fields.templateVer = 0 // default it to display edit/delete actions
         } else {
             // Board from template
         }
@@ -831,6 +832,7 @@ class Mutator {
         } else if (asTemplate) {
             // Template from board
             newBoard.title = 'New board template'
+            newBoard.fields.templateVer = 0 // default it to display edit/delete actions
         } else {
             // Board from template
         }


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

Custom templates created from global templates are now able to be edited/deleted in the UI.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

Fixes #3061 

#### Screencap

https://user-images.githubusercontent.com/6335792/170309728-685a5b18-a137-4386-9751-efafdd318835.mov