### PR TITLE
Forbid updating limited cards

### DIFF
--- a/server/api/api.go
+++ b/server/api/api.go
@@ -841,6 +841,10 @@ func (a *API) handlePatchBlock(w http.ResponseWriter, r *http.Request) {
 	auditRec.AddMeta("blockID", blockID)
 
 	err = a.app.PatchBlock(*container, blockID, patch, userID)
+	if errors.Is(err, app.ErrPatchUpdatesLimitedCards) {
+		a.errorResponse(w, r.URL.Path, http.StatusForbidden, "", err)
+		return
+	}
 	if err != nil {
 		a.errorResponse(w, r.URL.Path, http.StatusInternalServerError, "", err)
 		return
@@ -882,8 +886,6 @@ func (a *API) handlePatchBlocks(w http.ResponseWriter, r *http.Request) {
 	//     schema:
 	//       "$ref": "#/definitions/ErrorResponse"
 
-	// ToDo: prevent updates if cloud limited
-
 	ctx := r.Context()
 	session := ctx.Value(sessionContextKey).(*model.Session)
 	userID := session.UserID
@@ -914,6 +916,10 @@ func (a *API) handlePatchBlocks(w http.ResponseWriter, r *http.Request) {
 	}
 
 	err = a.app.PatchBlocks(*container, patches, userID)
+	if errors.Is(err, app.ErrPatchUpdatesLimitedCards) {
+		a.errorResponse(w, r.URL.Path, http.StatusForbidden, "", err)
+		return
+	}
 	if err != nil {
 		a.errorResponse(w, r.URL.Path, http.StatusInternalServerError, "", err)
 		return

--- a/server/app/app.go
+++ b/server/app/app.go
@@ -1,6 +1,8 @@
 package app
 
 import (
+	"sync"
+
 	"github.com/mattermost/focalboard/server/auth"
 	"github.com/mattermost/focalboard/server/services/config"
 	"github.com/mattermost/focalboard/server/services/metrics"
@@ -38,8 +40,8 @@ type App struct {
 	logger        *mlog.Logger
 	pluginAPI     plugin.API
 
-	// ToDo: do we require a mutex?
-	CardLimit int
+	cardLimitMux sync.Mutex
+	CardLimit    int
 }
 
 func (a *App) SetConfig(config *config.Configuration) {

--- a/server/app/app.go
+++ b/server/app/app.go
@@ -40,8 +40,8 @@ type App struct {
 	logger        *mlog.Logger
 	pluginAPI     plugin.API
 
-	cardLimitMux sync.Mutex
-	CardLimit    int
+	cardLimitMux sync.RWMutex
+	cardLimit    int
 }
 
 func (a *App) SetConfig(config *config.Configuration) {
@@ -62,4 +62,16 @@ func New(config *config.Configuration, wsAdapter ws.Adapter, services Services) 
 	}
 	app.initialize(services.SkipTemplateInit)
 	return app
+}
+
+func (a *App) CardLimit() int {
+	a.cardLimitMux.RLock()
+	defer a.cardLimitMux.RUnlock()
+	return a.cardLimit
+}
+
+func (a *App) SetCardLimit(cardLimit int) {
+	a.cardLimitMux.Lock()
+	defer a.cardLimitMux.Unlock()
+	a.cardLimit = cardLimit
 }

--- a/server/app/blocks_test.go
+++ b/server/app/blocks_test.go
@@ -1,13 +1,16 @@
 package app
 
 import (
+	"database/sql"
 	"testing"
 
-	"github.com/mattermost/focalboard/server/model"
-
 	"github.com/golang/mock/gomock"
-	st "github.com/mattermost/focalboard/server/services/store"
 	"github.com/stretchr/testify/require"
+
+	mmModel "github.com/mattermost/mattermost-server/v6/model"
+
+	"github.com/mattermost/focalboard/server/model"
+	st "github.com/mattermost/focalboard/server/services/store"
 )
 
 type blockError struct {
@@ -71,17 +74,63 @@ func TestPatchBlocks(t *testing.T) {
 		WorkspaceID: "0",
 	}
 	t.Run("patchBlocks success scenerio", func(t *testing.T) {
-		blockPatches := model.BlockPatchBatch{}
+		blockPatches := model.BlockPatchBatch{
+			BlockIDs: []string{"block1"},
+			BlockPatches: []model.BlockPatch{
+				{Title: mmModel.NewString("new title")},
+			},
+		}
+
+		block1 := model.Block{ID: "block1"}
+		th.Store.EXPECT().GetBlocksByIDs(container, []string{"block1"}).Return([]model.Block{block1}, nil)
 		th.Store.EXPECT().PatchBlocks(gomock.Eq(container), gomock.Eq(&blockPatches), gomock.Eq("user-id-1")).Return(nil)
+		th.Store.EXPECT().GetBlock(container, "block1").Return(&block1, nil)
 		err := th.App.PatchBlocks(container, &blockPatches, "user-id-1")
 		require.NoError(t, err)
 	})
 
 	t.Run("patchBlocks error scenerio", func(t *testing.T) {
-		blockPatches := model.BlockPatchBatch{}
-		th.Store.EXPECT().PatchBlocks(gomock.Eq(container), gomock.Eq(&blockPatches), gomock.Eq("user-id-1")).Return(blockError{"error"})
+		blockPatches := model.BlockPatchBatch{BlockIDs: []string{}}
+		th.Store.EXPECT().GetBlocksByIDs(container, []string{}).Return(nil, sql.ErrNoRows)
 		err := th.App.PatchBlocks(container, &blockPatches, "user-id-1")
-		require.Error(t, err, "error")
+		require.ErrorIs(t, err, sql.ErrNoRows)
+	})
+
+	t.Run("cloud limit error scenario", func(t *testing.T) {
+		th.App.CardLimit = 5
+
+		fakeLicense := &mmModel.License{
+			Features: &mmModel.Features{Cloud: mmModel.NewBool(true)},
+		}
+
+		blockPatches := model.BlockPatchBatch{
+			BlockIDs: []string{"block1"},
+			BlockPatches: []model.BlockPatch{
+				{Title: mmModel.NewString("new title")},
+			},
+		}
+
+		block1 := model.Block{
+			ID:       "block1",
+			Type:     model.TypeCard,
+			ParentID: "board1",
+			RootID:   "board1",
+			UpdateAt: 100,
+		}
+
+		board1 := model.Block{
+			ID:       "board1",
+			Type:     model.TypeBoard,
+			ParentID: "board1",
+			RootID:   "board1",
+		}
+
+		th.Store.EXPECT().GetBlocksByIDs(container, []string{"block1"}).Return([]model.Block{block1}, nil)
+		th.Store.EXPECT().GetLicense().Return(fakeLicense)
+		th.Store.EXPECT().GetCardLimitTimestamp().Return(int64(150), nil)
+		th.Store.EXPECT().GetBlocksByIDs(container, []string{"board1"}).Return([]model.Block{board1}, nil)
+		err := th.App.PatchBlocks(container, &blockPatches, "user-id-1")
+		require.ErrorIs(t, err, ErrPatchUpdatesLimitedCards)
 	})
 }
 

--- a/server/app/blocks_test.go
+++ b/server/app/blocks_test.go
@@ -97,7 +97,7 @@ func TestPatchBlocks(t *testing.T) {
 	})
 
 	t.Run("cloud limit error scenario", func(t *testing.T) {
-		th.App.CardLimit = 5
+		th.App.SetCardLimit(5)
 
 		fakeLicense := &mmModel.License{
 			Features: &mmModel.Features{Cloud: mmModel.NewBool(true)},

--- a/server/app/cloud.go
+++ b/server/app/cloud.go
@@ -73,7 +73,9 @@ func (a *App) SetCloudLimits(limits *mmModel.ProductLimits) error {
 	if limits != nil && limits.Boards != nil {
 		cardLimit = *limits.Boards.Cards
 	}
+	a.cardLimitMux.Lock()
 	a.CardLimit = cardLimit
+	a.cardLimitMux.Unlock()
 
 	if oldCardLimit != cardLimit {
 		return a.doUpdateCardLimitTimestamp()
@@ -202,8 +204,7 @@ func (a *App) ApplyCloudLimits(c store.Container, blocks []model.Block) ([]model
 			continue
 		}
 
-		if block.Type == model.TypeCard &&
-			block.UpdateAt < cardLimitTimestamp {
+		if block.ShouldBeLimited(cardLimitTimestamp) {
 			limitedBlocks[i] = block.GetLimited()
 		} else {
 			limitedBlocks[i] = block
@@ -211,6 +212,80 @@ func (a *App) ApplyCloudLimits(c store.Container, blocks []model.Block) ([]model
 	}
 
 	return limitedBlocks, nil
+}
+
+// ContainsLimitedBlocks checks if a list of block IDs contain any
+// block that references a limited card.
+func (a *App) ContainsLimitedBlocks(c store.Container, blocks []model.Block) (bool, error) {
+	cardLimitTimestamp, err := a.store.GetCardLimitTimestamp()
+	if err != nil {
+		return false, err
+	}
+
+	if cardLimitTimestamp == 0 {
+		return false, nil
+	}
+
+	cards := []model.Block{}
+	cardIDMap := map[string]bool{}
+	for _, block := range blocks {
+		switch block.Type {
+		case model.TypeBoard:
+		case model.TypeCard:
+			cards = append(cards, block)
+		default:
+			cardIDMap[block.ParentID] = true
+		}
+	}
+
+	cardIDs := []string{}
+	// if the card is already present on the set, we don't need to
+	// fetch it from the database
+	for cardID := range cardIDMap {
+		alreadyPresent := false
+		for _, card := range cards {
+			if card.ID == cardID {
+				alreadyPresent = true
+				break
+			}
+		}
+
+		if !alreadyPresent {
+			cardIDs = append(cardIDs, cardID)
+		}
+	}
+
+	if len(cardIDs) > 0 {
+		fetchedCards, fErr := a.store.GetBlocksByIDs(c, cardIDs)
+		if fErr != nil {
+			return false, fErr
+		}
+		cards = append(cards, fetchedCards...)
+	}
+
+	templateMap, err := a.getTemplateMapForBlocks(c, blocks)
+	if err != nil {
+		return false, err
+	}
+
+	for _, card := range cards {
+		isTemplate, ok := templateMap[card.RootID]
+		if !ok {
+			return false, newErrBoardNotFoundInTemplateMap(card.RootID)
+		}
+
+		// if the block belongs to a template, it will never be
+		// limited
+		if isTemplate {
+			continue
+		}
+
+		if card.ShouldBeLimited(cardLimitTimestamp) {
+			return true, nil
+		}
+	}
+
+	return false, nil
 }
 
 func (a *App) NotifyPortalAdminsUpgradeRequest(workspaceID string) error {

--- a/server/app/cloud.go
+++ b/server/app/cloud.go
@@ -60,12 +60,12 @@ func (a *App) IsCloud() bool {
 // IsCloudLimited returns true if the server is running in cloud mode
 // and the card limit has been set.
 func (a *App) IsCloudLimited() bool {
-	return a.CardLimit != 0 && a.IsCloud()
+	return a.CardLimit() != 0 && a.IsCloud()
 }
 
 // SetCloudLimits sets the limits of the server.
 func (a *App) SetCloudLimits(limits *mmModel.ProductLimits) error {
-	oldCardLimit := a.CardLimit
+	oldCardLimit := a.CardLimit()
 
 	// if the limit object doesn't come complete, we assume limits are
 	// being disabled
@@ -73,11 +73,9 @@ func (a *App) SetCloudLimits(limits *mmModel.ProductLimits) error {
 	if limits != nil && limits.Boards != nil {
 		cardLimit = *limits.Boards.Cards
 	}
-	a.cardLimitMux.Lock()
-	a.CardLimit = cardLimit
-	a.cardLimitMux.Unlock()
 
 	if oldCardLimit != cardLimit {
+		a.SetCardLimit(cardLimit)
 		return a.doUpdateCardLimitTimestamp()
 	}
 
@@ -87,7 +85,7 @@ func (a *App) SetCloudLimits(limits *mmModel.ProductLimits) error {
 // doUpdateCardLimitTimestamp performs the update without running any
 // checks.
 func (a *App) doUpdateCardLimitTimestamp() error {
-	cardLimitTimestamp, err := a.store.UpdateCardLimitTimestamp(a.CardLimit)
+	cardLimitTimestamp, err := a.store.UpdateCardLimitTimestamp(a.CardLimit())
 	if err != nil {
 		return err
 	}

--- a/server/app/cloud_test.go
+++ b/server/app/cloud_test.go
@@ -68,7 +68,7 @@ func TestIsCloudLimited(t *testing.T) {
 		th, tearDown := SetupTestHelper(t)
 		defer tearDown()
 
-		require.Zero(t, th.App.CardLimit)
+		require.Zero(t, th.App.CardLimit())
 		require.False(t, th.App.IsCloudLimited())
 	})
 
@@ -81,7 +81,7 @@ func TestIsCloudLimited(t *testing.T) {
 		}
 		th.Store.EXPECT().GetLicense().Return(fakeLicense)
 
-		th.App.CardLimit = 5
+		th.App.SetCardLimit(5)
 		require.True(t, th.App.IsCloudLimited())
 	})
 }
@@ -92,22 +92,22 @@ func TestSetCloudLimits(t *testing.T) {
 			th, tearDown := SetupTestHelper(t)
 			defer tearDown()
 
-			require.Zero(t, th.App.CardLimit)
+			require.Zero(t, th.App.CardLimit())
 
 			require.NoError(t, th.App.SetCloudLimits(nil))
-			require.Zero(t, th.App.CardLimit)
+			require.Zero(t, th.App.CardLimit())
 		})
 
 		t.Run("limits not empty but board limits empty", func(t *testing.T) {
 			th, tearDown := SetupTestHelper(t)
 			defer tearDown()
 
-			require.Zero(t, th.App.CardLimit)
+			require.Zero(t, th.App.CardLimit())
 
 			limits := &mmModel.ProductLimits{}
 
 			require.NoError(t, th.App.SetCloudLimits(limits))
-			require.Zero(t, th.App.CardLimit)
+			require.Zero(t, th.App.CardLimit())
 		})
 	})
 
@@ -115,7 +115,7 @@ func TestSetCloudLimits(t *testing.T) {
 		th, tearDown := SetupTestHelper(t)
 		defer tearDown()
 
-		require.Zero(t, th.App.CardLimit)
+		require.Zero(t, th.App.CardLimit())
 
 		newCardLimitTimestamp := int64(27)
 		th.Store.EXPECT().UpdateCardLimitTimestamp(5).Return(newCardLimitTimestamp, nil)
@@ -125,27 +125,27 @@ func TestSetCloudLimits(t *testing.T) {
 		}
 
 		require.NoError(t, th.App.SetCloudLimits(limits))
-		require.Equal(t, 5, th.App.CardLimit)
+		require.Equal(t, 5, th.App.CardLimit())
 	})
 
 	t.Run("if the limits are already set and we unset them, the timestamp will be unset too", func(t *testing.T) {
 		th, tearDown := SetupTestHelper(t)
 		defer tearDown()
 
-		th.App.CardLimit = 20
+		th.App.SetCardLimit(20)
 
 		th.Store.EXPECT().UpdateCardLimitTimestamp(0)
 
 		require.NoError(t, th.App.SetCloudLimits(nil))
 
-		require.Zero(t, th.App.CardLimit)
+		require.Zero(t, th.App.CardLimit())
 	})
 
 	t.Run("if the limits are already set and we try to set the same ones again", func(t *testing.T) {
 		th, tearDown := SetupTestHelper(t)
 		defer tearDown()
 
-		th.App.CardLimit = 20
+		th.App.SetCardLimit(20)
 
 		// the call to update card limit timestamp should not happen
 		// as the limits didn't change
@@ -156,7 +156,7 @@ func TestSetCloudLimits(t *testing.T) {
 		}
 
 		require.NoError(t, th.App.SetCloudLimits(limits))
-		require.Equal(t, 20, th.App.CardLimit)
+		require.Equal(t, 20, th.App.CardLimit())
 	})
 }
 
@@ -169,7 +169,7 @@ func TestUpdateCardLimitTimestamp(t *testing.T) {
 		th, tearDown := SetupTestHelper(t)
 		defer tearDown()
 
-		require.Zero(t, th.App.CardLimit)
+		require.Zero(t, th.App.CardLimit())
 
 		// the license check will not be done as the limit not being
 		// set is enough for the method to return
@@ -185,7 +185,7 @@ func TestUpdateCardLimitTimestamp(t *testing.T) {
 		th, tearDown := SetupTestHelper(t)
 		defer tearDown()
 
-		th.App.CardLimit = 5
+		th.App.SetCardLimit(5)
 
 		th.Store.EXPECT().GetLicense().Return(fakeLicense)
 		// no call to UpdateCardLimitTimestamp should happen as the
@@ -493,7 +493,7 @@ func TestApplyCloudLimits(t *testing.T) {
 		th, tearDown := SetupTestHelper(t)
 		defer tearDown()
 
-		require.Zero(t, th.App.CardLimit)
+		require.Zero(t, th.App.CardLimit())
 
 		newBlocks, err := th.App.ApplyCloudLimits(container, blocks)
 		require.NoError(t, err)
@@ -514,7 +514,7 @@ func TestApplyCloudLimits(t *testing.T) {
 		th, tearDown := SetupTestHelper(t)
 		defer tearDown()
 
-		th.App.CardLimit = 5
+		th.App.SetCardLimit(5)
 
 		th.Store.EXPECT().GetLicense().Return(fakeLicense)
 		th.Store.EXPECT().GetCardLimitTimestamp().Return(int64(150), nil)
@@ -588,7 +588,7 @@ func TestContainsLimitedBlocks(t *testing.T) {
 			RootID:   "board1",
 		}
 
-		th.App.CardLimit = 500
+		th.App.SetCardLimit(500)
 		cardLimitTimestamp := int64(150)
 		th.Store.EXPECT().GetCardLimitTimestamp().Return(cardLimitTimestamp, nil)
 		th.Store.EXPECT().GetBlocksByIDs(container, []string{"board1"}).Return([]model.Block{board1}, nil)
@@ -620,7 +620,7 @@ func TestContainsLimitedBlocks(t *testing.T) {
 			Fields:   map[string]interface{}{"isTemplate": true},
 		}
 
-		th.App.CardLimit = 500
+		th.App.SetCardLimit(500)
 		cardLimitTimestamp := int64(150)
 		th.Store.EXPECT().GetCardLimitTimestamp().Return(cardLimitTimestamp, nil)
 		th.Store.EXPECT().GetBlocksByIDs(container, []string{"board1"}).Return([]model.Block{board1}, nil)
@@ -659,7 +659,7 @@ func TestContainsLimitedBlocks(t *testing.T) {
 			RootID:   "board1",
 		}
 
-		th.App.CardLimit = 500
+		th.App.SetCardLimit(500)
 		cardLimitTimestamp := int64(150)
 		th.Store.EXPECT().GetCardLimitTimestamp().Return(cardLimitTimestamp, nil)
 		th.Store.EXPECT().GetBlocksByIDs(container, []string{"card1"}).Return([]model.Block{card1}, nil)
@@ -699,7 +699,7 @@ func TestContainsLimitedBlocks(t *testing.T) {
 			RootID:   "board1",
 		}
 
-		th.App.CardLimit = 500
+		th.App.SetCardLimit(500)
 		cardLimitTimestamp := int64(150)
 		th.Store.EXPECT().GetCardLimitTimestamp().Return(cardLimitTimestamp, nil)
 		th.Store.EXPECT().GetBlocksByIDs(container, []string{"card1"}).Return([]model.Block{card1}, nil)
@@ -789,7 +789,7 @@ func TestContainsLimitedBlocks(t *testing.T) {
 			RootID:   "board3",
 		}
 
-		th.App.CardLimit = 500
+		th.App.SetCardLimit(500)
 		cardLimitTimestamp := int64(150)
 		th.Store.EXPECT().GetCardLimitTimestamp().Return(cardLimitTimestamp, nil)
 		th.Store.EXPECT().GetBlocksByIDs(container, gomock.InAnyOrder([]string{"card1", "card3"})).Return([]model.Block{card1, card3}, nil)

--- a/server/client/client.go
+++ b/server/client/client.go
@@ -442,3 +442,19 @@ func (c *Client) GetSubscriptions(workspaceID string, subscriberID string) ([]*m
 
 	return subs, BuildResponse(r)
 }
+
+func (c *Client) GetLimits() (*model.BoardsCloudLimits, *Response) {
+	r, err := c.DoAPIGet("/limits", "")
+	if err != nil {
+		return nil, BuildErrorResponse(r, err)
+	}
+	defer closeBody(r)
+
+	var limits *model.BoardsCloudLimits
+	err = json.NewDecoder(r.Body).Decode(&limits)
+	if err != nil {
+		return nil, BuildErrorResponse(r, err)
+	}
+
+	return limits, BuildResponse(r)
+}

--- a/server/model/block.go
+++ b/server/model/block.go
@@ -201,6 +201,11 @@ func StampModificationMetadata(userID string, blocks []Block, auditRec *audit.Re
 	}
 }
 
+func (b Block) ShouldBeLimited(cardLimitTimestamp int64) bool {
+	return b.Type == TypeCard &&
+		b.UpdateAt < cardLimitTimestamp
+}
+
 // Returns a limited version of the block that doesn't contain the
 // contents of the block, only its IDs and type.
 func (b Block) GetLimited() Block {


### PR DESCRIPTION
#### Summary
This PR checks if cloud limits should apply before accepting patch requests, and rejects them if they refer to a card that is limited
