### PR TITLE
GH 3116 Check cloud limits when duplicating view

### DIFF
--- a/webapp/src/components/viewMenu.test.tsx
+++ b/webapp/src/components/viewMenu.test.tsx
@@ -2,6 +2,8 @@
 // See LICENSE.txt for license information.
 import '@testing-library/jest-dom'
 import {render} from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
 import 'isomorphic-fetch'
 
 import React from 'react'
@@ -102,5 +104,33 @@ describe('/components/viewMenu', () => {
 
         const container = render(component)
         expect(container).toMatchSnapshot()
+    })
+
+    it('should check view limits', () => {
+        const mockStore = configureStore([])
+        const store = mockStore(state)
+
+        const mockedallowCreateView = jest.fn()
+        mockedallowCreateView.mockReturnValue(false)
+
+        const component = wrapDNDIntl(
+            <ReduxProvider store={store}>
+                <Router history={history}>
+                    <ViewMenu
+                        board={board}
+                        activeView={activeView}
+                        views={views}
+                        readonly={false}
+                        allowCreateView={mockedallowCreateView}
+                    />
+                </Router>
+            </ReduxProvider>,
+        )
+
+        const container = render(component)
+
+        const buttonElement = container.getByRole('button', {name: 'Duplicate view'})
+        userEvent.click(buttonElement)
+        expect(mockedallowCreateView).toBeCalledTimes(1)
     })
 })

--- a/webapp/src/components/viewMenu.tsx
+++ b/webapp/src/components/viewMenu.tsx
@@ -44,6 +44,11 @@ const ViewMenu = (props: Props) => {
     const handleDuplicateView = useCallback(() => {
         const {board, activeView} = props
         Utils.log('duplicateView')
+
+        if (!props.allowCreateView()) {
+            return
+        }
+
         TelemetryClient.trackEvent(TelemetryCategory, TelemetryActions.DuplicateBoardView, {board: board.id, view: activeView.id})
         const currentViewId = activeView.id
         const newView = createBoardView(activeView)


### PR DESCRIPTION
#### Summary
When duplicating a view, the cloud limits should be checked. Just as when adding a view.

#### Ticket Link
  Fixes https://github.com/mattermost/focalboard/issues/3116

