### PR TITLE
GH-3135 ReadOnly banner fix

### DIFF
--- a/webapp/src/components/messages/cloudMessage.tsx
+++ b/webapp/src/components/messages/cloudMessage.tsx
@@ -48,7 +48,7 @@ const CloudMessage = React.memo(() => {
         }
     }
 
-    if (Utils.isFocalboardPlugin() || cloudMessageCanceled || !me) {
+    if (Utils.isFocalboardPlugin() || Utils.isFocalboardLegacy() || cloudMessageCanceled || !me) {
         return null
     }
 


### PR DESCRIPTION
#### Summary
If accessing a read-only board with a logged in user, the cloud message appears. Needed to add a check for `isFocalboardLegacy()` path. Since the user may be logged in and read-only boards don't return as plugins. 

#### Ticket Link

  Fixes https://github.com/mattermost/focalboard/issues/3135
