### PR TITLE
fix: filter bots in person property select

### DIFF
--- a/webapp/src/components/properties/user/user.tsx
+++ b/webapp/src/components/properties/user/user.tsx
@@ -48,7 +48,7 @@ const formatOptionLabel = (user: any) => {
 }
 
 const UserProperty = (props: Props): JSX.Element => {
-    const workspaceUsers = useAppSelector<IUser[]>(getWorkspaceUsersList)
+    const workspaceUsers = useAppSelector<IUser[]>(getWorkspaceUsersList).filter((user) => !user.is_bot)
     const workspaceUsersById = useAppSelector<{[key:string]: IUser}>(getWorkspaceUsers)
 
     if (props.readonly) {


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

Filters out bots for displaying the enumerable `options` in the `Person` property value selector.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

Fixes #3144 

![image](https://user-images.githubusercontent.com/6335792/170781060-d599011a-f986-4016-92fe-5f27f52d5c1b.png)


