### PR TITLE
ci: test & lint `mattermost-plugin`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,10 +40,14 @@ jobs:
       uses: actions/checkout@v3
 
     - name: npm ci
-      run: cd webapp; npm ci
+      run: |
+        cd webapp && npm ci && cd -
+        cd mattermost-plugin/webapp && npm ci
 
     - name: ESLint
-      run: cd webapp; npm run check
+      run: |
+        cd webapp && npm run check && cd -
+        cd mattermost-plugin/webapp && npm run lint
 
     - name: Set up Go
       uses: actions/setup-go@v3
@@ -67,11 +71,13 @@ jobs:
         name: focalboard-server-linux-amd64.tar.gz
         path: ${{ github.workspace }}/dist/focalboard-server-linux-amd64.tar.gz
 
-    - name: "Test webapp: Jest"
-      run: cd webapp; npm run test
+    - name: "Test webapp + plugin: Jest"
+      run: |
+        cd webapp && npm run test && cd -
+        cd mattermost-plugin/webapp && npm run test
 
     - name: "Test webapp: Cypress"
-      run: "cd webapp; npm run cypress:ci"
+      run: "cd webapp && npm run cypress:ci"
 
   ci-windows-server:
     runs-on: windows-2022

--- a/mattermost-plugin/webapp/tests/setup.tsx
+++ b/mattermost-plugin/webapp/tests/setup.tsx
@@ -1,4 +1,8 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import 'mattermost-webapp/tests/setup'
+// This won't exist locally when running in CI
+// eslint-disable-next-line no-process-env
+if (!process.env.CI) {
+    require('mattermost-webapp/tests/setup')
+}


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

In #3071 tests were added to `BoardsUnfurl` along with an addition to the `make ci` step to simulate a CI run locally. At the time, I didn't realize that `make ci` wasn't explicitly ran in CI so this PR updates `ci.yml` to lint + test `mattermost-plugin/webapp` in addition to the normal `webapp`.

I initially created this PR in https://github.com/mattermost/focalboard/tree/plugin-ci which was branched off `release-7.0`. You can view a successful run here: https://github.com/mattermost/focalboard/runs/6616768660?check_suite_focus=true

If it's desired, I can create another PR to target `release-7.0` as well. This is blocked by #3126 as it includes the aforementioned changes + tests that are actually _ran_.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

N/A

