### PR TITLE
Checks if the cards property on the limits payload is nil before dere…

### DIFF
--- a/server/app/cloud.go
+++ b/server/app/cloud.go
@@ -44,8 +44,12 @@ func (a *App) GetBoardsCloudLimits() (*model.BoardsCloudLimits, error) {
 		CardLimitTimestamp: cardLimitTimestamp,
 	}
 	if productLimits != nil && productLimits.Boards != nil {
-		boardsCloudLimits.Cards = *productLimits.Boards.Cards
-		boardsCloudLimits.Views = *productLimits.Boards.Views
+		if productLimits.Boards.Cards != nil {
+			boardsCloudLimits.Cards = *productLimits.Boards.Cards
+		}
+		if productLimits.Boards.Views != nil {
+			boardsCloudLimits.Views = *productLimits.Boards.Views
+		}
 	}
 
 	return boardsCloudLimits, nil
@@ -70,7 +74,7 @@ func (a *App) SetCloudLimits(limits *mmModel.ProductLimits) error {
 	// if the limit object doesn't come complete, we assume limits are
 	// being disabled
 	cardLimit := 0
-	if limits != nil && limits.Boards != nil {
+	if limits != nil && limits.Boards != nil && limits.Boards.Cards != nil {
 		cardLimit = *limits.Boards.Cards
 	}
 

--- a/server/app/cloud_test.go
+++ b/server/app/cloud_test.go
@@ -109,6 +109,20 @@ func TestSetCloudLimits(t *testing.T) {
 			require.NoError(t, th.App.SetCloudLimits(limits))
 			require.Zero(t, th.App.CardLimit())
 		})
+
+		t.Run("limits not empty but board limits values empty", func(t *testing.T) {
+			th, tearDown := SetupTestHelper(t)
+			defer tearDown()
+
+			require.Zero(t, th.App.CardLimit())
+
+			limits := &mmModel.ProductLimits{
+				Boards: &mmModel.BoardsLimits{},
+			}
+
+			require.NoError(t, th.App.SetCloudLimits(limits))
+			require.Zero(t, th.App.CardLimit())
+		})
 	})
 
 	t.Run("if the limits are not empty, it should update them and calculate the new timestamp", func(t *testing.T) {


### PR DESCRIPTION
#### Summary
This PR adds checks for the `ProductLimits` payload to avoid dereferencing nil values when limits are set to zero.

#### Ticket Link
Fixes https://github.com/mattermost/focalboard/issues/3166
