### PR TITLE
Do not check rowCount when updating the card limit

### DIFF
--- a/server/services/store/sqlstore/cloud.go
+++ b/server/services/store/sqlstore/cloud.go
@@ -121,13 +121,8 @@ func (s *SQLStore) updateCardLimitTimestamp(db sq.BaseRunner, cardLimit int) (in
 		return 0, err
 	}
 
-	rowCount, err := result.RowsAffected()
-	if err != nil {
+	if _, err := result.RowsAffected(); err != nil {
 		return 0, err
-	}
-
-	if rowCount < 1 {
-		return 0, store.NewErrNotFound(store.CardLimitTimestampSystemKey)
 	}
 
 	return s.getCardLimitTimestamp(db)

--- a/server/services/store/storetests/cloud.go
+++ b/server/services/store/storetests/cloud.go
@@ -229,6 +229,28 @@ func testUpdateCardLimitTimestamp(t *testing.T, store storeservice.Store, contai
 		require.Equal(t, "0", cardLimitTimestampStr)
 	})
 
+	t.Run("should correctly modify the limit several times in a row", func(t *testing.T) {
+		cardLimitTimestamp, err := store.UpdateCardLimitTimestamp(0)
+		require.NoError(t, err)
+		require.Zero(t, cardLimitTimestamp)
+
+		cardLimitTimestamp, err = store.UpdateCardLimitTimestamp(10)
+		require.NoError(t, err)
+		require.NotZero(t, cardLimitTimestamp)
+
+		cardLimitTimestampStr, err := store.GetSystemSetting(storeservice.CardLimitTimestampSystemKey)
+		require.NoError(t, err)
+		require.NotEqual(t, "0", cardLimitTimestampStr)
+
+		cardLimitTimestamp, err = store.UpdateCardLimitTimestamp(0)
+		require.NoError(t, err)
+		require.Zero(t, cardLimitTimestamp)
+
+		cardLimitTimestampStr, err = store.GetSystemSetting(storeservice.CardLimitTimestampSystemKey)
+		require.NoError(t, err)
+		require.Equal(t, "0", cardLimitTimestampStr)
+	})
+
 	t.Run("should set the correct timestamp", func(t *testing.T) {
 		t.Run("limit 10", func(t *testing.T) {
 			// we fetch the first block


### PR DESCRIPTION
#### Summary
This PR modifies the `updateCardLimitTimestamp` store method not to rely on `rowCount`, as `MySQL` seems not to send back `rowCount` if several updates happen in quick succession
