### PR TITLE
Git attributes for linguist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+website/** linguist-documentation
+server/swagger/** linguist-generated


### PR DESCRIPTION
#### Summary
Git attributes for ignoring `website` and `swagger docs` in linguist added.

Currently this repo page shows this distribution of the languages:
<img width="315" alt="image" src="https://user-images.githubusercontent.com/5587620/171685651-292384c2-86b0-4eee-a052-c8e709393029.png">
which is a bit misleading because of auto generated documentation.

With the proposed changes it looks like this:
<img width="322" alt="image" src="https://user-images.githubusercontent.com/5587620/171685819-28dbaa14-f747-43fd-ba4f-97158880bbbb.png">


