### PR TITLE
Avoids join on the getAllBlocks query

### DIFF
--- a/server/services/store/sqlstore/blocks.go
+++ b/server/services/store/sqlstore/blocks.go
@@ -122,8 +122,11 @@ func (s *SQLStore) getBlocksByIDs(db sq.BaseRunner, c store.Container, ids []str
 		return nil, err
 	}
 
+	// if we've found less blocks than we expected, we return the
+	// result and an explicit bug, so the caller can decide how the
+	// partial result should be handled
 	if len(blocks) != len(ids) {
-		return nil, store.NewErrNotAllFound(ids)
+		return blocks, store.NewErrNotAllFound(ids)
 	}
 
 	return blocks, nil
@@ -254,26 +257,9 @@ func (s *SQLStore) getSubTree3(db sq.BaseRunner, c store.Container, blockID stri
 
 func (s *SQLStore) getAllBlocks(db sq.BaseRunner, c store.Container) ([]model.Block, error) {
 	query := s.getQueryBuilder(db).
-		Select(
-			"b.id",
-			"b.parent_id",
-			"b.root_id",
-			"b.created_by",
-			"b.modified_by",
-			"b."+s.escapeField("schema"),
-			"b.type",
-			"b.title",
-			"b.fields",
-			s.timestampToCharField("b.insert_at", "insertAt"),
-			"b.create_at",
-			"b.update_at",
-			"b.delete_at",
-			"COALESCE(b.workspace_id, '0')",
-		).
-		From(s.tablePrefix + "blocks as b").
-		Join(s.tablePrefix + "blocks as pb on b.root_id = pb.id").
-		Where(sq.Eq{"coalesce(b.workspace_id, '0')": c.WorkspaceID}).
-		Where(sq.Eq{"pb.delete_at": 0})
+		Select(s.blockFields()...).
+		From(s.tablePrefix + "blocks").
+		Where(sq.Eq{"coalesce(workspace_id, '0')": c.WorkspaceID})
 
 	rows, err := query.Query()
 	if err != nil {

--- a/server/services/store/storetests/blocks.go
+++ b/server/services/store/storetests/blocks.go
@@ -838,6 +838,8 @@ func testGetBlocks(t *testing.T, storeInstance store.Store, container store.Cont
 		blocks, err = storeInstance.GetBlocksByIDs(container, []string{"not-exists", "block3"})
 		require.Error(t, err)
 		require.True(t, store.IsErrNotAllFound(err))
+		require.Len(t, blocks, 1)
+		require.Equal(t, "block3", blocks[0].ID)
 	})
 
 	t.Run("not existing type", func(t *testing.T) {
@@ -924,14 +926,14 @@ func testGetAllBlocks(t *testing.T, store store.Store, container store.Container
 			require.Len(t, blocks, 6)
 		})
 
-		t.Run("after deleting a board, should only return the other one", func(t *testing.T) {
+		t.Run("after deleting a board, should still return its blocks", func(t *testing.T) {
 			require.NoError(t, store.DeleteBlock(container, "board1", "user-id"))
 
 			blocks, err := store.GetAllBlocks(container)
 			require.NoError(t, err)
-			require.Len(t, blocks, 3)
+			require.Len(t, blocks, 5)
 
-			expectedIDs := []string{"board2", "card2", "text2"}
+			expectedIDs := []string{"card1", "text1", "board2", "card2", "text2"}
 
 			blockIDs := []string{}
 			for _, block := range blocks {


### PR DESCRIPTION
#### Summary
This PR avoids making a join when getting all blocks to check which ones belong to a deleted board, as such join has proven to be quite demanding on instances with a lot of information.

The app layer level methods are modified as well to take into account that the store may return blocks that belong to a deleted board, and the cloud limits are applied without checking the template property of the board if it's deleted.

