### PR TITLE
Added board link in bot message when notifying any changes in card

### DIFF
--- a/server/services/notify/plugindelivery/mention_deliver.go
+++ b/server/services/notify/plugindelivery/mention_deliver.go
@@ -50,11 +50,12 @@ func (pd *PluginDelivery) MentionDeliver(mentionUsername string, extract string,
 		return "", fmt.Errorf("cannot get direct channel: %w", err)
 	}
 	link := utils.MakeCardLink(pd.serverRoot, evt.Workspace, evt.Board.ID, evt.Card.ID)
+	boardLink := utils.MakeBoardLink(pd.serverRoot, evt.Workspace, evt.Board.ID)
 
 	post := &model.Post{
 		UserId:    pd.botID,
 		ChannelId: channel.Id,
-		Message:   formatMessage(author.Username, extract, evt.Card.Title, link, evt.BlockChanged),
+		Message:   formatMessage(author.Username, extract, evt.Card.Title, link, evt.BlockChanged, boardLink, evt.Board.Title),
 	}
 	return member.UserId, pd.api.CreatePost(post)
 }

--- a/server/services/notify/plugindelivery/message.go
+++ b/server/services/notify/plugindelivery/message.go
@@ -11,14 +11,14 @@ import (
 
 const (
 	// TODO: localize these when i18n is available.
-	defCommentTemplate     = "@%s mentioned you in a comment on the card [%s](%s)\n> %s"
-	defDescriptionTemplate = "@%s mentioned you in the card [%s](%s)\n> %s"
+	defCommentTemplate     = "@%s mentioned you in a comment on the card [%s](%s) in board [%s](%s)\n> %s"
+	defDescriptionTemplate = "@%s mentioned you in the card [%s](%s) in board [%s](%s)\n> %s"
 )
 
-func formatMessage(author string, extract string, card string, link string, block *model.Block) string {
+func formatMessage(author string, extract string, card string, link string, block *model.Block, boardLink string, board string) string {
 	template := defDescriptionTemplate
 	if block.Type == model.TypeComment {
 		template = defCommentTemplate
 	}
-	return fmt.Sprintf(template, author, card, link, extract)
+	return fmt.Sprintf(template, author, card, link, board, boardLink, extract)
 }

--- a/server/utils/links.go
+++ b/server/utils/links.go
@@ -9,3 +9,7 @@ import "fmt"
 func MakeCardLink(serverRoot string, workspace string, board string, card string) string {
 	return fmt.Sprintf("%s/workspace/%s/%s/0/%s/", serverRoot, workspace, board, card)
 }
+
+func MakeBoardLink(serverRoot string, workspace string, board string) string {
+	return fmt.Sprintf("%s/workspace/%s/%s", serverRoot, workspace, board)
+}


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
This PR adds a board link to board messages in channels when notifying any changes in card.

#### Ticket Link
Fixes https://github.com/mattermost/focalboard/issues/2543
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

