### PR TITLE
Personal server fixes for cloud message

### DIFF
--- a/webapp/src/components/centerPanel.tsx
+++ b/webapp/src/components/centerPanel.tsx
@@ -182,6 +182,8 @@ class CenterPanel extends React.Component<Props, State> {
         this.startBoardsTour()
     }
 
+    showShareButton = !this.props.readonly && this.props.me?.id !== 'single-user'
+
     render(): JSX.Element {
         const {groupByProperty, activeView, board, views, cards, hiddenCardsCount} = this.props
         const {visible: visibleGroups, hidden: hiddenGroups} = getVisibleAndHiddenGroups(cards, activeView.fields.visibleOptionIds, activeView.fields.hiddenOptionIds, groupByProperty)
@@ -222,7 +224,7 @@ class CenterPanel extends React.Component<Props, State> {
                             readonly={this.props.readonly}
                         />
                         <div className='shareButtonWrapper'>
-                            {!this.props.readonly &&
+                            {this.showShareButton &&
                              (
                                  <ShareBoardButton
                                      boardId={this.props.board.id}

--- a/webapp/src/components/messages/__snapshots__/cloudMessage.test.tsx.snap
+++ b/webapp/src/components/messages/__snapshots__/cloudMessage.test.tsx.snap
@@ -36,4 +36,38 @@ exports[`components/messages/CloudMessage not plugin mode, show message, close m
 </div>
 `;
 
+exports[`components/messages/CloudMessage not plugin mode, single user, close message 1`] = `
+<div>
+  <div
+    class="CloudMessage"
+  >
+    <div
+      class="banner"
+    >
+      <i
+        class="CompassIcon icon-information-outline CompassIcon"
+      />
+      Get your own free cloud server.
+      <button
+        title="Learn more"
+        type="button"
+      >
+        <span>
+          Learn more
+        </span>
+      </button>
+    </div>
+    <button
+      aria-label="Close dialog"
+      title="Close dialog"
+      type="button"
+    >
+      <i
+        class="CompassIcon icon-close CloseIcon"
+      />
+    </button>
+  </div>
+</div>
+`;
+
 exports[`components/messages/CloudMessage plugin mode, no display 1`] = `<div />`;

--- a/webapp/src/components/messages/cloudMessage.test.tsx
+++ b/webapp/src/components/messages/cloudMessage.test.tsx
@@ -19,6 +19,8 @@ import {wrapIntl} from '../../testUtils'
 
 import client from '../../octoClient'
 
+import {UserSettings} from '../../userSettings'
+
 import CloudMessage from './cloudMessage'
 
 jest.mock('../../utils')
@@ -130,5 +132,43 @@ describe('components/messages/CloudMessage', () => {
                 focalboard_cloudMessageCanceled: 'true',
             },
         })
+    })
+
+    test('not plugin mode, single user, close message', () => {
+        const me: IUser = {
+            id: 'single-user',
+            username: 'single-user',
+            email: 'single-user',
+            props: {},
+            create_at: 0,
+            update_at: Date.now() - (1000 * 60 * 60 * 24), //24 hours,
+            is_bot: false,
+            roles: '',
+        }
+        const state = {
+            users: {
+                me,
+            },
+        }
+        const store = mockStore(state)
+        const hideCloudMessageSpy = jest.spyOn(UserSettings, 'hideCloudMessage', 'set')
+
+        mockedUtils.isFocalboardPlugin.mockReturnValue(false)
+
+        const component = wrapIntl(
+            <ReduxProvider store={store}>
+                <CloudMessage/>
+            </ReduxProvider>,
+        )
+
+        const {container} = render(component)
+        expect(container).toMatchSnapshot()
+
+        const buttonElement = screen.getByRole('button', {name: 'Close dialog'})
+        userEvent.click(buttonElement)
+
+        expect(mockedOctoClient.patchUserConfig).toBeCalledTimes(0)
+        expect(hideCloudMessageSpy).toHaveBeenCalledWith(true)
+        expect(UserSettings.hideCloudMessage).toBe(true)
     })
 })

--- a/webapp/src/components/messages/cloudMessage.tsx
+++ b/webapp/src/components/messages/cloudMessage.tsx
@@ -14,6 +14,7 @@ import {useAppSelector, useAppDispatch} from '../../store/hooks'
 import octoClient from '../../octoClient'
 import {IUser, UserConfigPatch} from '../../user'
 import {getMe, patchProps, getCloudMessageCanceled} from '../../store/users'
+import {UserSettings} from '../../userSettings'
 
 import CompassIcon from '../../widgets/icons/compassIcon'
 import TelemetryClient, {TelemetryCategory, TelemetryActions} from '../../telemetry/telemetryClient'
@@ -35,6 +36,11 @@ const CloudMessage = React.memo(() => {
 
     const onClose = async () => {
         if (me) {
+            if (me.id === 'single-user') {
+                UserSettings.hideCloudMessage = true
+                dispatch(patchProps({focalboard_cloudMessageCanceled: 'true'}))
+                return
+            }
             const patch: UserConfigPatch = {
                 updatedFields: {
                     focalboard_cloudMessageCanceled: 'true',

--- a/webapp/src/store/users.ts
+++ b/webapp/src/store/users.ts
@@ -10,6 +10,8 @@ import {Utils} from '../utils'
 
 import {Subscription} from '../wsclient'
 
+import {UserSettings} from '../userSettings'
+
 import {initialLoad} from './initialLoad'
 
 import {RootState} from './index'
@@ -137,6 +139,9 @@ export const getCloudMessageCanceled = createSelector(
     (me): boolean => {
         if (!me) {
             return false
+        }
+        if (me.id === 'single-user') {
+            return UserSettings.hideCloudMessage
         }
         return Boolean(me.props?.focalboard_cloudMessageCanceled)
     },

--- a/webapp/src/userSettings.ts
+++ b/webapp/src/userSettings.ts
@@ -17,7 +17,8 @@ export enum UserSettingKey {
     RandomIcons = 'randomIcons',
     MobileWarningClosed = 'mobileWarningClosed',
     WelcomePageViewed = 'welcomePageViewed',
-    DashboardShowEmpty = 'dashboardShowEmpty'
+    DashboardShowEmpty = 'dashboardShowEmpty',
+    HideCloudMessage = 'hideCloudMessage'
 }
 
 export class UserSettings {
@@ -112,6 +113,14 @@ export class UserSettings {
 
     static set mobileWarningClosed(newValue: boolean) {
         UserSettings.set(UserSettingKey.MobileWarningClosed, String(newValue))
+    }
+
+    static get hideCloudMessage(): boolean {
+        return localStorage.getItem(UserSettingKey.HideCloudMessage) === 'true'
+    }
+
+    static set hideCloudMessage(newValue: boolean) {
+        localStorage.setItem(UserSettingKey.HideCloudMessage, JSON.stringify(newValue))
     }
 }
 


### PR DESCRIPTION
#### Summary
Fixes two issues - Personal server was not storing setting for hiding the cloud message, so the message never went away and the "Share" button was also being displayed.

#### Ticket Link
  Fixes https://github.com/mattermost/focalboard/issues/3217
  Fixes https://github.com/mattermost/focalboard/issues/3216

