### PR TITLE
fix: handles null or empty clientConfig

### DIFF
--- a/webapp/src/route.tsx
+++ b/webapp/src/route.tsx
@@ -30,8 +30,9 @@ function FBRoute(props: RouteProps) {
     const clientConfig = useAppSelector<ClientConfig>(getClientConfig)
 
     let redirect: React.ReactNode = null
+    const disableTour = clientConfig?.featureFlags?.disableTour || false
 
-    const showWelcomePage = !clientConfig.featureFlags.disableTour &&
+    const showWelcomePage = !disableTour &&
         Utils.isFocalboardPlugin() &&
         (me?.id !== 'single-user') &&
         props.path !== '/welcome' &&


### PR DESCRIPTION
#### Summary

Adds a check to see if the clientConfig object is null or empty.
If null or empty clientConfig then sets the disableTour to false.

#### Ticket Link
Related Issue: #3236

Signed-off by: imasdekar <imasdekar@disroot.org>