### PR TITLE
update: instructions for prebuild for dev setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,18 +74,27 @@ You can build standalone apps that package the server to run locally against SQL
 * **Windows**:
     * *Requires Windows 10, [Windows 10 SDK](https://developer.microsoft.com/en-us/windows/downloads/sdk-archive/) 10.0.19041.0, and .NET 4.8 developer pack*
     * Open a `git-bash` prompt.
+    * Run `make prebuild`
+    * The above prebuild step needs to be run only when you make changes to or want to install your npm dependencies, etc.
+    * Once the prebuild is completed, you can keep repeating the below steps to build the app & see the changes.
     * Run `make win-wpf-app`
     * Run `cd win-wpf/msix && focalboard.exe`
 * **Mac**:
     * *Requires macOS 11.3+ and Xcode 13.2.1+*
-    * `make mac-app`
-    * `open mac/dist/Focalboard.app`
+    * Run `make prebuild`
+    * The above prebuild step needs to be run only when you make changes to or want to install your npm dependencies, etc.
+    * Once the prebuild is completed, you can keep repeating the below steps to build the app & see the changes.
+    * Run `make mac-app`
+    * Run `open mac/dist/Focalboard.app`
 * **Linux**:
     * *Tested on Ubuntu 18.04*
     * Install `webgtk` dependencies
-        * `sudo apt-get install libgtk-3-dev`
-        * `sudo apt-get install libwebkit2gtk-4.0-dev`
-    * `make linux-app`
+        * Run `sudo apt-get install libgtk-3-dev`
+        * Run `sudo apt-get install libwebkit2gtk-4.0-dev`
+    * Run `make prebuild`
+    * The above prebuild step needs to be run only when you make changes to or want to install your npm dependencies, etc.
+    * Once the prebuild is completed, you can keep repeating the below steps to build the app & see the changes.
+    * Run `make linux-app`
     * Uncompress `linux/dist/focalboard-linux.tar.gz` to a directory of your choice
     * Run `focalboard-app` from the directory you have chosen
 * **Docker**:


### PR DESCRIPTION
#### Summary

- Updates the readme to add instructions for running the prebuild step for standalone desktop app dev setup

#### Ticket Link
Related Issue: #3221

Signed-off by: imasdekar <imasdekar@disroot.org>

