### PR TITLE
GH-3050 - Fix deleting empty property

### DIFF
--- a/server/integrationtests/boards_and_blocks_test.go
+++ b/server/integrationtests/boards_and_blocks_test.go
@@ -693,16 +693,6 @@ func TestDeleteBoardsAndBlocks(t *testing.T) {
 			require.False(t, success)
 		})
 
-		t.Run("no blocks", func(t *testing.T) {
-			dbab := &model.DeleteBoardsAndBlocks{
-				Boards: []string{board.ID},
-			}
-
-			success, resp := th.Client.DeleteBoardsAndBlocks(dbab)
-			th.CheckBadRequest(resp)
-			require.False(t, success)
-		})
-
 		t.Run("boards from different teams", func(t *testing.T) {
 			newOtherTeamsBoard := &model.Board{
 				TeamID: "another-team-id",

--- a/server/model/boards_and_blocks.go
+++ b/server/model/boards_and_blocks.go
@@ -94,10 +94,6 @@ func (dbab *DeleteBoardsAndBlocks) IsValid() error {
 		return ErrNoBoardsInBoardsAndBlocks
 	}
 
-	if len(dbab.Blocks) == 0 {
-		return ErrNoBlocksInBoardsAndBlocks
-	}
-
 	return nil
 }
 
@@ -129,10 +125,6 @@ func (dbab *PatchBoardsAndBlocks) IsValid() error {
 
 	if len(dbab.BoardIDs) != len(dbab.BoardPatches) {
 		return ErrBoardIDsAndPatchesMissmatchInBoardsAndBlocks
-	}
-
-	if len(dbab.BlockIDs) == 0 {
-		return ErrNoBlocksInBoardsAndBlocks
 	}
 
 	if len(dbab.BlockIDs) != len(dbab.BlockPatches) {

--- a/server/model/boards_and_blocks_test.go
+++ b/server/model/boards_and_blocks_test.go
@@ -183,19 +183,6 @@ func TestIsValidPatchBoardsAndBlocks(t *testing.T) {
 		require.ErrorIs(t, pbab.IsValid(), ErrBoardIDsAndPatchesMissmatchInBoardsAndBlocks)
 	})
 
-	t.Run("no block ids", func(t *testing.T) {
-		pbab := &PatchBoardsAndBlocks{
-			BoardIDs: []string{"board-id-1", "board-id-2"},
-			BoardPatches: []*BoardPatch{
-				{Title: &newTitle},
-				{Description: &newDescription},
-			},
-			BlockIDs: []string{},
-		}
-
-		require.ErrorIs(t, pbab.IsValid(), ErrNoBlocksInBoardsAndBlocks)
-	})
-
 	t.Run("missmatch block IDs and patches", func(t *testing.T) {
 		pbab := &PatchBoardsAndBlocks{
 			BoardIDs: []string{"board-id-1", "board-id-2"},


### PR DESCRIPTION
#### Summary
When trying to delete a new property with no values, an error is thrown because there are no blocks to patch only a board. Remove the check for blocks length > 0

#### Ticket Link
  Fixes https://github.com/mattermost/focalboard/issues/3050

