### PR TITLE
fix: handles clientConfig causing board error

### DIFF
--- a/webapp/src/components/onboardingTour/tourTipRenderer/tourTipRenderer.tsx
+++ b/webapp/src/components/onboardingTour/tourTipRenderer/tourTipRenderer.tsx
@@ -38,7 +38,8 @@ const TourTipRenderer = (props: Props): JSX.Element | null => {
     const onboardingTourStarted = useAppSelector(getOnboardingTourStarted)
     const onboardingTourCategory = useAppSelector(getOnboardingTourCategory)
     const onboardingTourStep = useAppSelector(getOnboardingTourStep)
-    const showTour = !clientConfig.featureFlags.disableTour && isOnboardingBoard && onboardingTourStarted && onboardingTourCategory === props.category
+    const disableTour = clientConfig?.featureFlags?.disableTour || false
+    const showTour = !disableTour && isOnboardingBoard && onboardingTourStarted && onboardingTourCategory === props.category
     let showTourTip = showTour && onboardingTourStep === props.step.toString()
 
     if (props.requireCard) {


### PR DESCRIPTION
#### Summary

Adds a check to see if the clientConfig object is null or empty.
If null or empty clientConfig then sets the disableTour to false.

#### Ticket Link
Fixes: #3259

Signed-off by: imasdekar <imasdekar@disroot.org>

