### PR TITLE
don't copy 'comment' blocks

### DIFF
--- a/server/services/store/sqlstore/blocks.go
+++ b/server/services/store/sqlstore/blocks.go
@@ -781,6 +781,9 @@ func (s *SQLStore) duplicateBlock(db sq.BaseRunner, boardID string, blockID stri
 	var rootBlock model.Block
 	allBlocks := []model.Block{}
 	for _, block := range blocks {
+		if block.Type == model.TypeComment {
+			continue
+		}
 		if block.ID == blockID {
 			if block.Fields == nil {
 				block.Fields = make(map[string]interface{})

--- a/server/services/store/sqlstore/boards_and_blocks.go
+++ b/server/services/store/sqlstore/boards_and_blocks.go
@@ -165,7 +165,13 @@ func (s *SQLStore) duplicateBoard(db sq.BaseRunner, boardID string, userID strin
 	if err != nil {
 		return nil, nil, err
 	}
-	bab.Blocks = blocks
+	newBlocks := []model.Block{}
+	for _, b := range blocks {
+		if b.Type != model.TypeComment {
+			newBlocks = append(newBlocks, b)
+		}
+	}
+	bab.Blocks = newBlocks
 
 	bab, err = model.GenerateBoardsAndBlocksIDs(bab, nil)
 	if err != nil {


### PR DESCRIPTION
#### Summary
Fixes issue where comments are copied when duplicating a card or board.

#### Ticket Link

  Fixes https://github.com/mattermost/focalboard/issues/2954

