### PR TITLE
Gh3277 x86 mac prod build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,12 @@ server: ## Build server for local environment.
 server-mac: ## Build server for Mac.
 	mkdir -p bin/mac
 	$(eval LDFLAGS += -X "github.com/mattermost/focalboard/server/model.Edition=mac")
+ifeq ($(FB_PROD),)
 	cd server; env GOOS=darwin GOARCH=$(MAC_GO_ARCH) go build -ldflags '$(LDFLAGS)' -o ../bin/mac/focalboard-server ./main
+else
+# Always build x86 for production, to work on both Apple Silicon and legacy Macs
+	cd server; env GOOS=darwin GOARCH=amd64 CGO_ENABLED=1 go build -ldflags '$(LDFLAGS)' -o ../bin/mac/focalboard-server ./main
+endif
 
 server-linux: ## Build server for Linux.
 	mkdir -p bin/linux


### PR DESCRIPTION
#### Summary
Added an `FB_PROD` flag to build the server for x86 on Mac for production. This will support both Apple Silicon (M1, M2, etc.) and legacy x86 Macs.

#### Ticket Link
#3277