### PR TITLE
add coalesce around boards description

### DIFF
--- a/server/services/store/sqlstore/migrations/000018_add_teams_and_boards.up.sql
+++ b/server/services/store/sqlstore/migrations/000018_add_teams_and_boards.up.sql
@@ -133,7 +133,7 @@ CREATE TABLE IF NOT EXISTS {{.prefix}}boards_history (
   INSERT INTO {{.prefix}}boards (
       SELECT B.id, B.insert_at, C.TeamId, B.channel_id, B.created_by, B.modified_by, C.type,
                  COALESCE(B.title, ''),
-                (B.fields->>'description')::text,
+                 COALESCE((B.fields->>'description')::text, ''),
                  B.fields->>'icon',
                  COALESCE((fields->'showDescription')::text::boolean, false),
                  COALESCE((fields->'isTemplate')::text::boolean, false),
@@ -147,7 +147,7 @@ CREATE TABLE IF NOT EXISTS {{.prefix}}boards_history (
   INSERT INTO {{.prefix}}boards_history (
       SELECT B.id, B.insert_at, C.TeamId, B.channel_id, B.created_by, B.modified_by, C.type,
                  COALESCE(B.title, ''),
-                 (B.fields->>'description')::text,
+                 COALESCE((B.fields->>'description')::text, ''),
                  B.fields->>'icon',
                  COALESCE((fields->'showDescription')::text::boolean, false),
                  COALESCE((fields->'isTemplate')::text::boolean, false),
@@ -163,7 +163,7 @@ CREATE TABLE IF NOT EXISTS {{.prefix}}boards_history (
   INSERT INTO {{.prefix}}boards (
       SELECT B.id, B.insert_at, C.TeamId, B.channel_id, B.created_by, B.modified_by, C.Type,
                  COALESCE(B.title, ''),
-                 JSON_UNQUOTE(JSON_EXTRACT(B.fields,'$.description')),
+                 COALESCE(JSON_UNQUOTE(JSON_EXTRACT(B.fields,'$.description')), ''),
                  JSON_UNQUOTE(JSON_EXTRACT(B.fields,'$.icon')),
                  COALESCE(B.fields->'$.showDescription', 'false') = 'true',
                  COALESCE(JSON_EXTRACT(B.fields, '$.isTemplate'), 'false') = 'true',
@@ -177,7 +177,7 @@ CREATE TABLE IF NOT EXISTS {{.prefix}}boards_history (
   INSERT INTO {{.prefix}}boards_history (
       SELECT B.id, B.insert_at, C.TeamId, B.channel_id, B.created_by, B.modified_by, C.Type,
                  COALESCE(B.title, ''),
-                 JSON_UNQUOTE(JSON_EXTRACT(B.fields,'$.description')),
+                 COALESCE(JSON_UNQUOTE(JSON_EXTRACT(B.fields,'$.description')), ''),
                  JSON_UNQUOTE(JSON_EXTRACT(B.fields,'$.icon')),
                  COALESCE(B.fields->'$.showDescription', 'false') = 'true',
                  COALESCE(JSON_EXTRACT(B.fields, '$.isTemplate'), 'false') = 'true',
@@ -194,7 +194,7 @@ CREATE TABLE IF NOT EXISTS {{.prefix}}boards_history (
   INSERT INTO {{.prefix}}boards (
       SELECT id, insert_at, '0', channel_id, created_by, modified_by, 'O',
                  COALESCE(B.title, ''),
-                 (fields->>'description')::text,
+                 COALESCE((fields->>'description')::text, ''),
                  B.fields->>'icon',
                  COALESCE((fields->'showDescription')::text::boolean, false),
                  COALESCE((fields->'isTemplate')::text::boolean, false),
@@ -207,7 +207,7 @@ CREATE TABLE IF NOT EXISTS {{.prefix}}boards_history (
   INSERT INTO {{.prefix}}boards_history (
       SELECT id, insert_at, '0', channel_id, created_by, modified_by, 'O',
                  COALESCE(B.title, ''),
-                 (fields->>'description')::text,
+                 COALESCE((fields->>'description')::text, ''),
                  B.fields->>'icon',
                  COALESCE((fields->'showDescription')::text::boolean, false),
                  COALESCE((fields->'isTemplate')::text::boolean, false),
@@ -222,7 +222,7 @@ CREATE TABLE IF NOT EXISTS {{.prefix}}boards_history (
   INSERT INTO {{.prefix}}boards (
       SELECT id, insert_at, '0', channel_id, created_by, modified_by, 'O',
                  COALESCE(B.title, ''),
-                 JSON_UNQUOTE(JSON_EXTRACT(fields,'$.description')),
+                 COALESCE(JSON_UNQUOTE(JSON_EXTRACT(B.fields,'$.description')), ''),
                  JSON_UNQUOTE(JSON_EXTRACT(fields,'$.icon')),
                  COALESCE(B.fields->'$.showDescription', 'false') = 'true',
                  COALESCE(JSON_EXTRACT(B.fields, '$.isTemplate'), 'false') = 'true',
@@ -235,7 +235,7 @@ CREATE TABLE IF NOT EXISTS {{.prefix}}boards_history (
   INSERT INTO {{.prefix}}boards_history (
       SELECT id, insert_at, '0', channel_id, created_by, modified_by, 'O',
                  COALESCE(B.title, ''),
-                 JSON_UNQUOTE(JSON_EXTRACT(fields,'$.description')),
+                 COALESCE(JSON_UNQUOTE(JSON_EXTRACT(B.fields,'$.description')), ''),
                  JSON_UNQUOTE(JSON_EXTRACT(fields,'$.icon')),
                  COALESCE(B.fields->'$.showDescription', 'false') = 'true',
                  COALESCE(JSON_EXTRACT(B.fields, '$.isTemplate'), 'false') = 'true',
@@ -250,7 +250,7 @@ CREATE TABLE IF NOT EXISTS {{.prefix}}boards_history (
   INSERT INTO {{.prefix}}boards
       SELECT id, insert_at, '0', channel_id, created_by, modified_by, 'O',
                  COALESCE(title, ''),
-                 json_extract(fields, '$.description'),
+                 COALESCE(json_extract(fields, '$.description'), ''),
                  json_extract(fields, '$.icon'), json_extract(fields, '$.showDescription'), json_extract(fields, '$.isTemplate'),
                  COALESCE(json_extract(fields, '$.templateVer'), 0),
                  '{}', json_extract(fields, '$.cardProperties'), create_at,
@@ -261,7 +261,7 @@ CREATE TABLE IF NOT EXISTS {{.prefix}}boards_history (
   INSERT INTO {{.prefix}}boards_history
       SELECT id, insert_at, '0', channel_id, created_by, modified_by, 'O',
                  COALESCE(title, ''),
-                 json_extract(fields, '$.description'),
+                 COALESCE(json_extract(fields, '$.description'), ''),
                  json_extract(fields, '$.icon'), json_extract(fields, '$.showDescription'), json_extract(fields, '$.isTemplate'),
                  COALESCE(json_extract(fields, '$.templateVer'), 0),
                  '{}', json_extract(fields, '$.cardProperties'), create_at,


### PR DESCRIPTION
#### Summary

- Fixes an issue with migrations for v7.2 on Community clone.
- On community, some boards don't have a `description` field in their json properties. This PR adds a `COALESCE` around the descriptions during migrations.

#### Ticket Link
Partially fixes -
https://github.com/mattermost/focalboard/issues/2994
