### PR TITLE
Cloud Limit Fix - add BoardID to limited card

### DIFF
--- a/server/model/block.go
+++ b/server/model/block.go
@@ -227,6 +227,7 @@ func (b Block) GetLimited() Block {
 		Title:       b.Title,
 		ID:          b.ID,
 		ParentID:    b.ParentID,
+		BoardID:     b.BoardID,
 		Schema:      b.Schema,
 		Type:        b.Type,
 		CreateAt:    b.CreateAt,


### PR DESCRIPTION
#### Summary
Added BoardID to limited card in order for getCurrentBoardHiddenCardsCount() to work.

Without fix, cards are hidden, but HiddenCard Count button and modal were not displayed.
