### PR TITLE
[GH-3318] Fix flaky cypress test

### DIFF
--- a/webapp/cypress/integration/cardURLProperty.ts
+++ b/webapp/cypress/integration/cardURLProperty.ts
@@ -72,7 +72,6 @@ describe('Card URL Property', () => {
         cy.findByRole('button', {name: 'Edit'}).should('exist')
         cy.findByRole('button', {name: 'Copy'}).should('not.exist')
 
-        /*        
         // Add gallery view
         addView('Gallery')
         showURLProperty()
@@ -82,7 +81,6 @@ describe('Card URL Property', () => {
         cy.findByRole('link', {name: changedURL}).realHover()
         cy.findByRole('button', {name: 'Edit'}).should('not.exist')
         cy.findByRole('button', {name: 'Copy'}).should('exist')
-*/
 
         // Add calendar view
         addView('Calendar')
@@ -99,9 +97,13 @@ describe('Card URL Property', () => {
 
     const addView = (type: ViewType) => {
         cy.log(`**Add ${type} view**`)
+        // Intercept and wait for getUser request because it is the last one in the effects for BoardPage
+        // After this last request the BoardPage component will not have additional rerenders
+        cy.intercept('GET', '/api/v2/users/u*').as('getUser')
         cy.findByRole('button', {name: 'View menu'}).click()
         cy.findByText('Add view').realHover()
         cy.findByRole('button', {name: type}).click()
+        cy.wait('@getUser')
         cy.findByRole('textbox', {name: `${type} view`}).should('exist')
     }
 


### PR DESCRIPTION
#### Summary
Fix Cypress test `cardURLProperty`:
- during the creation of a new board view and switching to it there are many API requests executed in effects for `BoardPage` component
- some requests trigger additional rerendering of the `BoardPage` component
- Cypress starts to work with the `BoardPage` immediately when on its first render
- additional rerenders after requests can lead to remount of some components related to menu
- so in order to workaround the issue waiting for the last request (which is `getUser`) was introduced in the Cypress test
- after this last request `BoardPage` component doesn't have additional rerenders and Cypress should not have issues with detached elements 

#### Ticket Link
Fixes #3318
