### PR TITLE
fix: render default LHS board icon

### DIFF
--- a/webapp/src/components/sidebar/__snapshots__/sidebarBoardItem.test.tsx.snap
+++ b/webapp/src/components/sidebar/__snapshots__/sidebarBoardItem.test.tsx.snap
@@ -1,5 +1,86 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`components/sidebarBoardItem renders default icon if no custom icon set 1`] = `
+<div>
+  <div
+    class="SidebarBoardItem subitem active"
+  >
+    <div
+      class="octo-sidebar-icon"
+    >
+      <svg
+        class="BoardIcon Icon"
+        fill="currentColor"
+        height="24"
+        viewBox="0 0 24 24"
+        width="24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <g
+          opacity="0.8"
+        >
+          <path
+            clip-rule="evenodd"
+            d="M4 4H20V20H4V4ZM2 4C2 2.89543 2.89543 2 4 2H20C21.1046 2 22 2.89543 22 4V20C22 21.1046 21.1046 22 20 22H4C2.89543 22 2 21.1046 2 20V4ZM8 6H6V12H8V6ZM11 6H13V16H11V6ZM18 6H16V9H18V6Z"
+            fill="currentColor"
+            fill-rule="evenodd"
+          />
+        </g>
+      </svg>
+    </div>
+    <div
+      class="octo-sidebar-title"
+      title="board title"
+    >
+      board title
+    </div>
+    <div
+      aria-label="menuwrapper"
+      class="MenuWrapper x"
+      role="button"
+    >
+      <button
+        class="IconButton"
+        type="button"
+      >
+        <i
+          class="CompassIcon icon-dots-horizontal OptionsIcon"
+        />
+      </button>
+    </div>
+  </div>
+  <div
+    class="SidebarBoardItem sidebar-view-item active"
+  >
+    <svg
+      class="BoardIcon Icon"
+      fill="currentColor"
+      height="24"
+      viewBox="0 0 24 24"
+      width="24"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <g
+        opacity="0.8"
+      >
+        <path
+          clip-rule="evenodd"
+          d="M4 4H20V20H4V4ZM2 4C2 2.89543 2.89543 2 4 2H20C21.1046 2 22 2.89543 22 4V20C22 21.1046 21.1046 22 20 22H4C2.89543 22 2 21.1046 2 20V4ZM8 6H6V12H8V6ZM11 6H13V16H11V6ZM18 6H16V9H18V6Z"
+          fill="currentColor"
+          fill-rule="evenodd"
+        />
+      </g>
+    </svg>
+    <div
+      class="octo-sidebar-title"
+      title="view title"
+    >
+      view title
+    </div>
+  </div>
+</div>
+`;
+
 exports[`components/sidebarBoardItem sidebar board item 1`] = `
 <div>
   <div

--- a/webapp/src/components/sidebar/sidebarBoardItem.scss
+++ b/webapp/src/components/sidebar/sidebarBoardItem.scss
@@ -153,6 +153,11 @@
         }
     }
 
+    .octo-sidebar-icon > .Icon {
+        width: 19px;
+        vertical-align: top;
+    }
+
     .Menu.noselect.left {
         position: fixed;
         right: calc(100% - 480px + 50px);

--- a/webapp/src/components/sidebar/sidebarBoardItem.test.tsx
+++ b/webapp/src/components/sidebar/sidebarBoardItem.test.tsx
@@ -87,4 +87,28 @@ describe('components/sidebarBoardItem', () => {
         const {container} = render(component)
         expect(container).toMatchSnapshot()
     })
+
+    test('renders default icon if no custom icon set', () => {
+        const mockStore = configureStore([])
+        const store = mockStore(state)
+        const noIconBoard = { ...board, icon: '' }
+
+        const component = wrapIntl(
+            <ReduxProvider store={store}>
+                <Router history={history}>
+                    <SidebarBoardItem
+                        categoryBoards={categoryBoards1}
+                        board={noIconBoard}
+                        allCategories={allCategoryBoards}
+                        isActive={true}
+                        showBoard={jest.fn()}
+                        showView={jest.fn()}
+                        onDeleteRequest={jest.fn()}
+                    />
+                </Router>
+            </ReduxProvider>,
+        )
+        const {container} = render(component)
+        expect(container).toMatchSnapshot()
+    })
 })

--- a/webapp/src/components/sidebar/sidebarBoardItem.tsx
+++ b/webapp/src/components/sidebar/sidebarBoardItem.tsx
@@ -114,7 +114,7 @@ const SidebarBoardItem = (props: Props) => {
                 onClick={() => props.showBoard(board.id)}
             >
                 <div className='octo-sidebar-icon'>
-                    {board.icon}
+                    {board.icon || <BoardIcon/>}
                 </div>
                 <div
                     className='octo-sidebar-title'


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

Fixes LHS board title alignment by rendering a default (`<BoardIcon>`) icon if there is not a custom one set.

![image](https://user-images.githubusercontent.com/6335792/178365659-b066c0e5-a759-4bce-a705-d2d472b4e055.png)


#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
closes #2958 
