### PR TITLE
Fix mock early finish issue on test helpers

### DIFF
--- a/mattermost-plugin/server/data_retention_test.go
+++ b/mattermost-plugin/server/data_retention_test.go
@@ -26,7 +26,6 @@ func SetupTestHelperMockStore(t *testing.T) *TestHelperMockStore {
 	th := &TestHelperMockStore{}
 
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	mockStore := mockstore.NewMockStore(ctrl)
 
 	th.Server = newTestServerMock(mockStore)

--- a/server/app/blocks_test.go
+++ b/server/app/blocks_test.go
@@ -179,7 +179,6 @@ func TestUndeleteBlock(t *testing.T) {
 			gomock.Eq(model.QueryBlockHistoryOptions{Limit: 1, Descending: true}),
 		).Return([]model.Block{block}, nil)
 		th.Store.EXPECT().UndeleteBlock(gomock.Eq("block-id"), gomock.Eq("user-id-1")).Return(blockError{"error"})
-		th.Store.EXPECT().GetBlock(gomock.Eq("block-id")).Return(&block, nil)
 		_, err := th.App.UndeleteBlock("block-id", "user-id-1")
 		require.Error(t, err, "error")
 	})
@@ -343,8 +342,6 @@ func TestInsertBlocks(t *testing.T) {
 		}
 		board := &model.Board{ID: boardID}
 		th.Store.EXPECT().GetBoard(boardID).Return(board, nil)
-		th.Store.EXPECT().InsertBlock(&block, "user-id-1").Return(nil)
-		th.Store.EXPECT().GetMembersForBoard(boardID).Return([]*model.BoardMember{}, nil)
 
 		// setting up mocks for limits
 		fakeLicense := &mmModel.License{

--- a/server/app/files_test.go
+++ b/server/app/files_test.go
@@ -240,7 +240,6 @@ func TestSaveFile(t *testing.T) {
 		mockedFileBackend := &mocks.FileBackend{}
 		th.App.filesBackend = mockedFileBackend
 		mockedError := &TestError{}
-		th.Store.EXPECT().SaveFileInfo(gomock.Any()).Return(nil)
 
 		writeFileFunc := func(reader io.Reader, path string) int64 {
 			paths := strings.Split(path, string(os.PathSeparator))

--- a/server/app/helper_test.go
+++ b/server/app/helper_test.go
@@ -27,7 +27,6 @@ type TestHelper struct {
 
 func SetupTestHelper(t *testing.T) (*TestHelper, func()) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	cfg := config.Configuration{}
 	store := mockstore.NewMockStore(ctrl)
 	filesBackend := &mocks.FileBackend{}

--- a/server/app/teams_test.go
+++ b/server/app/teams_test.go
@@ -57,14 +57,16 @@ func TestGetRootTeam(t *testing.T) {
 			th, tearDown := SetupTestHelper(t)
 			defer tearDown()
 			th.Store.EXPECT().GetTeam("0").Return(tc.teamToReturnBeforeUpsert, nil)
-			th.Store.EXPECT().UpsertTeamSignupToken(gomock.Any()).DoAndReturn(
-				func(arg0 model.Team) error {
-					if tc.isError {
-						return errUpsertSignupToken
-					}
-					th.Store.EXPECT().GetTeam("0").Return(tc.teamToReturnAfterUpsert, nil)
-					return nil
-				})
+			if tc.teamToReturnBeforeUpsert == nil {
+				th.Store.EXPECT().UpsertTeamSignupToken(gomock.Any()).DoAndReturn(
+					func(arg0 model.Team) error {
+						if tc.isError {
+							return errUpsertSignupToken
+						}
+						th.Store.EXPECT().GetTeam("0").Return(tc.teamToReturnAfterUpsert, nil)
+						return nil
+					})
+			}
 			rootTeam, err := th.App.GetRootTeam()
 
 			if tc.isError {

--- a/server/auth/auth_test.go
+++ b/server/auth/auth_test.go
@@ -32,9 +32,7 @@ var mockSession = &model.Session{
 
 func setupTestHelper(t *testing.T) *TestHelper {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	ctrlPermissions := gomock.NewController(t)
-	defer ctrlPermissions.Finish()
 	cfg := config.Configuration{}
 	mockStore := mockstore.NewMockStore(ctrl)
 	mockPermissions := mockpermissions.NewMockStore(ctrlPermissions)


### PR DESCRIPTION
#### Summary
This PR removes all calls to `mockController.Finish()` avoiding redundant calls and early finishes, that were causing test expectations not to be checked. It includes as well the fixes for the failing tests

#### Card
https://community-daily.mattermost.com/boards/workspace/qgsck6cts3fwpqwyjiupjm5cde/b4ctmm917q3rzdfi451qtuxjzcw/v4mi5d7u6afbhfrks5783gbmj9o/ce11bfa5yjib63ck8iu8hgrkmdr