### PR TITLE
Add `disable_notify` flag for InsertBlocks API

### DIFF
--- a/mattermost-plugin/product/boards_product.go
+++ b/mattermost-plugin/product/boards_product.go
@@ -70,7 +70,7 @@ type boardsProduct struct {
 }
 
 //nolint:gocyclo
-func newBoardsProduct(mmServer *app.Server, services map[app.ServiceKey]interface{}) (app.Product, error) {
+func newBoardsProduct(_ *app.Server, services map[app.ServiceKey]interface{}) (app.Product, error) {
 	boards := &boardsProduct{}
 
 	for key, service := range services {

--- a/server/api/api.go
+++ b/server/api/api.go
@@ -810,6 +810,11 @@ func (a *API) handlePostBlocks(w http.ResponseWriter, r *http.Request) {
 	//   description: Board ID
 	//   required: true
 	//   type: string
+	// - name: disable_notify
+	//   in: query
+	//   description: Disables notifications (for bulk data inserting)
+	//   required: false
+	//   type: bool
 	// - name: Body
 	//   in: body
 	//   description: array of blocks to insert or update
@@ -834,6 +839,9 @@ func (a *API) handlePostBlocks(w http.ResponseWriter, r *http.Request) {
 
 	boardID := mux.Vars(r)["boardID"]
 	userID := getUserID(r)
+
+	val := r.URL.Query().Get("disable_notify")
+	disableNotify := val == "true"
 
 	// in phase 1 we use "manage_board_cards", but we would have to
 	// check on specific actions for phase 2
@@ -887,6 +895,7 @@ func (a *API) handlePostBlocks(w http.ResponseWriter, r *http.Request) {
 
 	auditRec := a.makeAuditRecord(r, "postBlocks", audit.Fail)
 	defer a.audit.LogRecord(audit.LevelModify, auditRec)
+	auditRec.AddMeta("disable_notify", disableNotify)
 
 	ctx := r.Context()
 	session := ctx.Value(sessionContextKey).(*model.Session)
@@ -902,7 +911,7 @@ func (a *API) handlePostBlocks(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	newBlocks, err := a.app.InsertBlocks(blocks, session.UserID, true)
+	newBlocks, err := a.app.InsertBlocks(blocks, session.UserID, !disableNotify)
 	if err != nil {
 		if errors.Is(err, app.ErrViewsLimitReached) {
 			a.errorResponse(w, r.URL.Path, http.StatusBadRequest, err.Error(), err)
@@ -913,7 +922,10 @@ func (a *API) handlePostBlocks(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	a.logger.Debug("POST Blocks", mlog.Int("block_count", len(blocks)))
+	a.logger.Debug("POST Blocks",
+		mlog.Int("block_count", len(blocks)),
+		mlog.Bool("disable_notify", disableNotify),
+	)
 
 	json, err := json.Marshal(newBlocks)
 	if err != nil {

--- a/server/client/client.go
+++ b/server/client/client.go
@@ -287,6 +287,16 @@ func (c *Client) InsertBlocks(boardID string, blocks []model.Block) ([]model.Blo
 	return model.BlocksFromJSON(r.Body), BuildResponse(r)
 }
 
+func (c *Client) InsertBlocksDisableNotify(boardID string, blocks []model.Block) ([]model.Block, *Response) {
+	r, err := c.DoAPIPost(c.GetBlocksRoute(boardID)+"?disable_notify=true", toJSON(blocks))
+	if err != nil {
+		return nil, BuildErrorResponse(r, err)
+	}
+	defer closeBody(r)
+
+	return model.BlocksFromJSON(r.Body), BuildResponse(r)
+}
+
 func (c *Client) DeleteBlock(boardID, blockID string) (bool, *Response) {
 	r, err := c.DoAPIDelete(c.GetBlockRoute(boardID, blockID), "")
 	if err != nil {


### PR DESCRIPTION
#### Summary
This PR adds an optional `disable_notify` flag for InsertBlocks rest API.  Defaults to false.  When true, subscription notifications are disabled (users won't be notified of board/card changes).  Websocket notifications are unaffected.

This allows bulk add tools, load testers, etc to insert blocks without a notification storm.

#### Ticket Link
NONE