### PR TITLE
fix: share modal user list overflow out of dialog

### DIFF
--- a/webapp/src/components/shareBoard/shareBoard.scss
+++ b/webapp/src/components/shareBoard/shareBoard.scss
@@ -7,6 +7,7 @@
         max-width: 90%;
         height: auto;
         position: relative;
+        overflow: unset;
     }
 
     .confirmation-dialog-box {


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

Allows the user list on the share dialog to overflow outside of the modal bounds—particularly useful when sharing templates as there's less content inside the modal already.

<img width="836" alt="image" src="https://user-images.githubusercontent.com/6335792/180086175-f8ef3a2f-9fc8-4a28-8c9c-9cd9d4371a23.png">


#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
closes #2950 

