### PR TITLE
Updates the id of the migration lock

### DIFF
--- a/server/services/store/sqlstore/migrate.go
+++ b/server/services/store/sqlstore/migrate.go
@@ -184,7 +184,7 @@ func (s *SQLStore) Migrate() error {
 	}
 
 	opts := []morph.EngineOption{
-		morph.WithLock("mm-lock-key"),
+		morph.WithLock("boards-lock-key"),
 	}
 
 	if s.dbType == model.SqliteDBType {


### PR DESCRIPTION
#### Summary
This PR updates the ID of the lock that boards uses at migration time so it's different from the one Mattermost uses