### PR TITLE
[GH-3412] feat: add opengraph tags to website

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thank you for your interest in contributing! Please read the [Focalboard Contrib
 
 When you submit a pull request, it goes through a code review process outlined [here](https://developers.mattermost.com/contribute/getting-started/code-review/).
 
-After a noteable bug fix or improvement is merged, submit a pull request to the [CHANGELOG](CHANGELOG.md) under the next release section.
+After a notable bug fix or improvement is merged, submit a pull request to the [CHANGELOG](CHANGELOG.md) under the next release section.
 
 ## Bug Reports
 

--- a/website/site/config.toml
+++ b/website/site/config.toml
@@ -15,7 +15,7 @@ pygmentsStyle = "manni"
 [params]
   # Meta
   author = ""
-  description = ""
+  description = "Focalboard is an open source alternative to tools like Asana, Trello, and Notion. Available as a stand-alone application or integrated into the Mattermost platform, Focalboard helps developers stay aligned to complete tasks, reach milestones, and achieve their goals."
   email = ""
   ghrepo = "https://github.com/mattermost/focalboard/"
 

--- a/website/site/layouts/partials/head.html
+++ b/website/site/layouts/partials/head.html
@@ -1,10 +1,37 @@
 <meta charset="utf-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
-<title> {{ .Title }}</title>
-<meta name="viewport" content="width=device-width, initial-scale=1"> {{ with .Site.Params.author }}
-<meta name="author" content="{{ . }}">{{ end }} {{ with .Site.Params.description }}
-<meta name="description" content="{{ . }}">{{ end }} {{ with .Site.LanguageCode }}
-<meta http-equiv="content-language" content="{{ . }}" />{{ end }}
+
+{{ if in .Title "Focalboard" }}
+<title>{{ .Title }}</title>
+{{ else }}
+<title>{{ .Title }} | Focalboard</title>
+{{ end }}
+
+<meta name="viewport" content="width=device-width, initial-scale=1">
+
+{{ with .Site.Params.author }}
+<meta name="author" content="{{ . }}">
+{{ end }}
+
+{{ with .Site.Params.description }}
+<meta name="description" content="{{ . }}">
+<meta property="og:description" content="{{ . }}">
+{{ end }}
+
+{{ with .Site.LanguageCode }}
+<meta http-equiv="content-language" content="{{ . }}" />
+<meta property="og:locale" content="{{ replace . "-" "_" }}" />
+{{ end }}
+
+<meta property="og:site_name" content="{{ .Site.Title }}">
+<meta property="og:title" content="{{ .Title }}">
+<meta property="og:image" content="{{ .Site.BaseURL }}img/hero.jpg">
+<meta property="og:image:url" content="{{ .Site.BaseURL }}img/hero.jpg">
+<meta property="og:image:type" content="image/jpeg">
+<meta property="og:image:width" content="2048">
+<meta property="og:image:height" content="1306">
+<meta property="og:image:alt" content="Screenshot showcasing the UI of Focalboard, focused on a project status board.">
+<meta property="og:type" content="website">
 
 <!-- canonical link tag -->
 {{ if .Params.canonicalUrl }}


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

Adds OpenGraph tags to the website so it looks more attractive when shared in instant messengers or social media.

More information in the GitHub issue.

You're welcome to suggest changing any particular tag that was set, I just chose what I thought were sensible values.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

* Closes #3412

#### Previews

![image](https://user-images.githubusercontent.com/22801583/180613111-a5b0341a-ef14-4753-899a-1bbb26d724de.png)

![image](https://user-images.githubusercontent.com/22801583/180613090-510ad1c9-9282-4607-b60a-5b9dba9b4bef.png)