### PR TITLE
Add enablePublicSharedBoards to admin guide

### DIFF
--- a/website/site/content/guide/admin/_index.md
+++ b/website/site/content/guide/admin/_index.md
@@ -25,6 +25,7 @@ Personal server settings are stored in `config.json` and are read when the serve
 | localOnly | Only allow connections from localhost        | `false`
 | enableLocalMode | Enable admin APIs on local Unix port   | `true`
 | localModeSocketLocation | Location of local Unix port    | `/var/tmp/focalboard_local.socket`
+| enablePublicSharedBoards | Enable publishing boards for public access | `false`
 
 ## Resetting passwords
 


### PR DESCRIPTION
By default, the feature to share a board as view-only to the public as shown [in the user guide](https://www.focalboard.com/guide/user/#sharing-boards) is disabled. In order to enable it, the `enablePublicSharedBoards` property needs to be set to `true` in `config.json`. However, this property isn't documented in the Administrator's Guide. 

A previous issue (https://github.com/mattermost/focalboard/issues/1419) suggested this addition; I don't believe it was ever done, so here it is!

