### PR TITLE
Manual cherry pick of #3378

### DIFF
--- a/server/services/store/mattermostauthlayer/mattermostauthlayer.go
+++ b/server/services/store/mattermostauthlayer/mattermostauthlayer.go
@@ -656,8 +656,16 @@ func (s *MattermostAuthLayer) GetMemberForBoard(boardID, userID string) (*model.
 		if b.ChannelID != "" {
 			_, err := s.pluginAPI.GetChannelMember(b.ChannelID, userID)
 			if err != nil {
+				var appErr *mmModel.AppError
+				if errors.As(err, &appErr) && appErr.StatusCode == http.StatusNotFound {
+					// Plugin API returns error if channel member doesn't exist.
+					// We're fine if it doesn't exist, so its not an error for us.
+					return nil, nil
+				}
+
 				return nil, err
 			}
+
 			return &model.BoardMember{
 				BoardID:         boardID,
 				UserID:          userID,

--- a/server/services/store/mattermostauthlayer/mattermostauthlayer.go
+++ b/server/services/store/mattermostauthlayer/mattermostauthlayer.go
@@ -3,6 +3,7 @@ package mattermostauthlayer
 import (
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"strings"
 


### PR DESCRIPTION
Cherry pick of #3378 on release-7.2.

/cc  @harshilsharma63

```release-note
NONE
```

Manually cherry picked because it was dependent on https://github.com/mattermost/focalboard/pull/3381, which will not be cherry picked.

Simply needed the import statement.
