### PR TITLE
Add the creator of the board as a administrator of the board if it still belongs to the channel

### DIFF
--- a/server/services/store/sqlstore/migrations/000018_add_teams_and_boards.up.sql
+++ b/server/services/store/sqlstore/migrations/000018_add_teams_and_boards.up.sql
@@ -302,7 +302,7 @@ INSERT INTO {{.prefix}}board_members (
     SELECT B.Id, CM.UserId, CM.Roles, TRUE, TRUE, FALSE, FALSE
     FROM {{.prefix}}boards AS B
     INNER JOIN ChannelMembers as CM ON CM.ChannelId=B.channel_id
-    WHERE CM.SchemeAdmin=True
+    WHERE CM.SchemeAdmin=True OR (CM.UserId=B.created_by)
 );
 {{end}}
 


### PR DESCRIPTION
The boards creators weren't added as administrators of the boards during the
migration (only the admin administrators), but this PR adds also the creator as
a new admin.

This is done only if the user is still a member of the channel, keeping this
way the original behavior of boards (In 7.1 if you leave the channel, doesn't
matter if you were the creator, you are no longer member of the board).