### PR TITLE
Update websocket client to use the new websocket lifecycle hooks

### DIFF
--- a/webapp/src/wsclient.ts
+++ b/webapp/src/wsclient.ts
@@ -65,10 +65,10 @@ export interface Subscription {
 export interface MMWebSocketClient {
     conn: WebSocket | null;
     sendMessage(action: string, data: any, responseCallback?: () => void): void /* eslint-disable-line @typescript-eslint/no-explicit-any */
-    setFirstConnectCallback(callback: () => void): void
-    setReconnectCallback(callback: () => void): void
-    setErrorCallback(callback: (event: Event) => void): void
-    setCloseCallback(callback: (connectFailCount: number) => void): void
+    addFirstConnectListener(callback: () => void): void
+    addReconnectListener(callback: () => void): void
+    addErrorListener(callback: (event: Event) => void): void
+    addCloseListener(callback: (connectFailCount: number) => void): void
 }
 
 type OnChangeHandler = (client: WSClient, items: any[]) => void
@@ -368,10 +368,10 @@ class WSClient {
                 }
             }
 
-            this.client.setFirstConnectCallback(onConnect)
-            this.client.setErrorCallback(onError)
-            this.client.setCloseCallback(onClose)
-            this.client.setReconnectCallback(onReconnect)
+            this.client.addFirstConnectListener(onConnect)
+            this.client.addErrorListener(onError)
+            this.client.addCloseListener(onClose)
+            this.client.addReconnectListener(onReconnect)
 
             return
         }


### PR DESCRIPTION
#### Summary
This PR replaces the old `mattermost-webapp` lifecycle hooks with the new ones, allowing for both clients to be active at the same time without causing any problems to each other.

There is no need to unregister the listeners because with the `WithWebSockets` components we control that the websocket singleton only gets initialized once, and the `close` function never gets called.

As a follow up, we will have to update the minimum required version (https://github.com/mattermost/focalboard/issues/3484)

