### PR TITLE
fix: Calendar card "..." action menu overlapping behind adjacent cards

### DIFF
--- a/webapp/src/components/calendar/fullCalendar.tsx
+++ b/webapp/src/components/calendar/fullCalendar.tsx
@@ -253,11 +253,13 @@ const CalendarFullView = (props: Props): JSX.Element|null => {
                 events={myEventsList}
                 editable={isEditable()}
                 eventResizableFromStart={isEditable()}
+                // this is the reverse of the default ordering (https://fullcalendar.io/docs/eventOrder)
+                // which gets reversed in CSS so the stacking contexts play nicely w/ "..." menus
+                eventOrder='-start,duration,-allDay,-title'
                 headerToolbar={toolbar}
                 buttonText={buttonText}
                 eventContent={renderEventContent}
                 eventChange={eventChange}
-
                 selectable={isSelectable}
                 selectMirror={true}
                 select={onNewEvent}

--- a/webapp/src/components/calendar/fullCalendar.tsx
+++ b/webapp/src/components/calendar/fullCalendar.tsx
@@ -253,9 +253,6 @@ const CalendarFullView = (props: Props): JSX.Element|null => {
                 events={myEventsList}
                 editable={isEditable()}
                 eventResizableFromStart={isEditable()}
-                // this is the reverse of the default ordering (https://fullcalendar.io/docs/eventOrder)
-                // which gets reversed in CSS so the stacking contexts play nicely w/ "..." menus
-                eventOrder='-start,duration,-allDay,-title'
                 headerToolbar={toolbar}
                 buttonText={buttonText}
                 eventContent={renderEventContent}

--- a/webapp/src/components/calendar/fullcalendar.scss
+++ b/webapp/src/components/calendar/fullcalendar.scss
@@ -5,6 +5,13 @@
     margin-bottom: 10px;
     overflow: auto;
 
+    // reverse the order, which is already reversed when rendered by Full Calendar
+    // this is a pseudo-hack to allow the CSS stacking contexts to play nicely
+    .fc-daygrid-day-events {
+        display: flex;
+        flex-direction: column-reverse;
+    }
+
     .fc-daygrid-event,
     .fc-daygrid-day-number {
         text-decoration: none;

--- a/webapp/src/components/calendar/fullcalendar.scss
+++ b/webapp/src/components/calendar/fullcalendar.scss
@@ -5,11 +5,9 @@
     margin-bottom: 10px;
     overflow: auto;
 
-    // reverse the order, which is already reversed when rendered by Full Calendar
-    // this is a pseudo-hack to allow the CSS stacking contexts to play nicely
-    .fc-daygrid-day-events {
-        display: flex;
-        flex-direction: column-reverse;
+    .fc-daygrid-event,
+    .fc-event-main {
+        @include z-index(unset);
     }
 
     .fc-daygrid-event,

--- a/webapp/src/styles/_z-index.scss
+++ b/webapp/src/styles/_z-index.scss
@@ -36,6 +36,7 @@ $z-index: (
     table-header:               1,
     value-selector-delete:      1,
     dialog-backdrop:           -1,
+    unset:                   unset
 );
 
 @function z-index($key) {


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

This PR `unset`s some `z-index` values that Full Calendar sets to prevent the "..." action menu from being overlapped by adjacent events in Calendar view.

I went through a couple iterations to get to this solution, but it ended up being the last "hacky" (subjectively) even though it is overriding CSS from a vendored dependency. For some context, other "solutions" I tried:

1. Reverse the event render order in Full Calendar and then use flexbox to reverse it. This didn't work with multi-day events along with the "show more" calendar widget.
2. Use a SCSS `@for` loop to set descending `:nth-child` `z-index` values e.g. https://stackoverflow.com/a/36609688

Before:

![image](https://user-images.githubusercontent.com/6335792/181791939-4877fedd-251c-44ff-91e7-5133110bcdcb.png)

After:

![image](https://user-images.githubusercontent.com/6335792/181792052-f3b31d49-7f4b-4df3-a973-8c8b0c343ae2.png)

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

closes #3425 

