### PR TITLE
Removing the Admin role option from team minimum role

### DIFF
--- a/webapp/src/components/shareBoard/teamPermissionsRow.tsx
+++ b/webapp/src/components/shareBoard/teamPermissionsRow.tsx
@@ -72,13 +72,6 @@ const TeamPermissionsRow = (): JSX.Element => {
                         </button>
                         <Menu position='left'>
                             <Menu.Text
-                                id='Admin'
-                                check={board.minimumRole === 'admin'}
-                                icon={board.type === BoardTypeOpen && board.minimumRole === 'admin' ? <CheckIcon/> : null}
-                                name={intl.formatMessage({id: 'BoardMember.schemeAdmin', defaultMessage: 'Admin'})}
-                                onClick={() => updateBoardType(board, BoardTypeOpen, 'admin')}
-                            />
-                            <Menu.Text
                                 id='Editor'
                                 check={board.minimumRole === '' || board.minimumRole === 'editor' }
                                 icon={board.type === BoardTypeOpen && board.minimumRole === 'editor' ? <CheckIcon/> : null}


### PR DESCRIPTION
#### Summary
This PR removes the Admin option from the selector of roles for the minimum
role in the team.

#### Ticket Link
Fixes #3243