### PR TITLE
Avoid panic in request error handling

### DIFF
--- a/server/api/api.go
+++ b/server/api/api.go
@@ -4587,7 +4587,7 @@ func (a *API) errorResponse(w http.ResponseWriter, api string, code int, message
 		)
 	}
 
-	w.Header().Set("Content-Type", "application/json")
+	setResponseHeader(w, "Content-Type", "application/json")
 	data, err := json.Marshal(model.ErrorResponse{Error: message, ErrorCode: code})
 	if err != nil {
 		data = []byte("{}")
@@ -4597,18 +4597,26 @@ func (a *API) errorResponse(w http.ResponseWriter, api string, code int, message
 }
 
 func stringResponse(w http.ResponseWriter, message string) {
-	w.Header().Set("Content-Type", "text/plain")
+	setResponseHeader(w, "Content-Type", "text/plain")
 	_, _ = fmt.Fprint(w, message)
 }
 
 func jsonStringResponse(w http.ResponseWriter, code int, message string) {
-	w.Header().Set("Content-Type", "application/json")
+	setResponseHeader(w, "Content-Type", "application/json")
 	w.WriteHeader(code)
 	fmt.Fprint(w, message)
 }
 
 func jsonBytesResponse(w http.ResponseWriter, code int, json []byte) {
-	w.Header().Set("Content-Type", "application/json")
+	setResponseHeader(w, "Content-Type", "application/json")
 	w.WriteHeader(code)
 	_, _ = w.Write(json)
+}
+
+func setResponseHeader(w http.ResponseWriter, key string, value string) {
+	header := w.Header()
+	if header == nil {
+		return
+	}
+	header.Set(key, value)
 }


### PR DESCRIPTION
#### Summary
This PR addresses a panic that happened on community instance during shutdown as reported by SRE.  While plugins were shutting down, as part of server shutdown, a `TeamBoardsInsights` call was received.  The insights call failed, which routes to an `errorResponse` call.  The `errorResponse` tried to write to a response that was already dead, which caused a panic.

Team insights call:
```
{"timestamp":"2022-08-02 07:06:43.608 Z","level":"debug","msg":"github.com/mattermost/focalboard/server/api.(*API).handleTeamBoardsInsights(0xc0005fe400, 0x1464408, 0xc000b5fa90, 0xc000789c00)","plugin_id":"focalboard"}
{"timestamp":"2022-08-02 07:06:43.608 Z","level":"debug","msg":"\tgithub.com/mattermost/focalboard/server@v0.0.0-20210525112228-f43e4028dbdc/api/api.go:217 +0x80c","plugin_id":"focalboard"}
```

Error response
```
{"timestamp":"2022-08-02 07:06:43.608 Z","level":"debug","msg":"github.com/mattermost/focalboard/server/api.(*API).errorResponse(0xc0005fe400, 0x1464408, 0xc000b5fa90, 0xc00072b020, 0x38, 0x1f4, 0xc00063c330, 0x11, 0x144db60, 0xc000b7e410)","plugin_id":"focalboard"}
{"timestamp":"2022-08-02 07:06:43.608 Z","level":"debug","msg":"\tgithub.com/mattermost/focalboard/server@v0.0.0-20210525112228-f43e4028dbdc/api/api.go:2148 +0x625","plugin_id":"focalboard"}
```

Panic while setting response header in `errorResponse`
```
{"timestamp":"2022-08-02 07:06:43.608 Z","level":"debug","msg":"panic: assignment to entry in nil map [recovered]","plugin_id":"focalboard"}
{"timestamp":"2022-08-02 07:06:43.608 Z","level":"debug","msg":"\tpanic: assignment to entry in nil map","plugin_id":"focalboard"}
{"timestamp":"2022-08-02 07:06:43.608 Z","level":"debug","msg":"","plugin_id":"focalboard"}
{"timestamp":"2022-08-02 07:06:43.608 Z","level":"debug","msg":"goroutine 329974 [running]:","plugin_id":"focalboard"}
{"timestamp":"2022-08-02 07:06:43.608 Z","level":"debug","msg":"net/textproto.MIMEHeader.Set(...)","plugin_id":"focalboard"}
{"timestamp":"2022-08-02 07:06:43.608 Z","level":"debug","msg":"\tnet/textproto/header.go:22","plugin_id":"focalboard"}
{"timestamp":"2022-08-02 07:06:43.608 Z","level":"debug","msg":"net/http.Header.Set(...)","plugin_id":"focalboard"}
{"timestamp":"2022-08-02 07:06:43.608 Z","level":"debug","msg":"\tnet/http/header.go:37","plugin_id":"focalboard"}
```

#### Ticket Link
NONE