### PR TITLE
Exclude enterprise from go.work by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,7 @@ prebuild: ## Run prebuild actions (install dependencies etc.).
 
 ci: webapp-ci server-test ## Simulate CI, locally.
 
+setup-go-work: export EXCLUDE_ENTERPRISE ?= true
 setup-go-work: ## Sets up a go.work file
 	go run ./build/gowork/main.go
 


### PR DESCRIPTION
#### Summary
This PR ensures that the `go.work` generated by Makefile does not include an entry for `enterprise` repo by default.  Most developers won't have or need `enterprise`. Those that do can add `EXCLUDE_ENTERPRISE=false` to their environment vars and regenerate the `go.work` file.

This won't be added to the developer docs since it does not apply to most developers, but will be communicated in the appropriate channels.

#### Ticket Link
NONE