### PR TITLE
update min server version to 7.2 (#3536)

### DIFF
--- a/mattermost-plugin/plugin.json
+++ b/mattermost-plugin/plugin.json
@@ -7,7 +7,7 @@
     "release_notes_url": "https://github.com/mattermost/focalboard/releases",
     "icon_path": "assets/starter-template-icon.svg",
     "version": "7.2.0",
-    "min_server_version": "7.0.0",
+    "min_server_version": "7.2.0",
     "server": {
         "executables": {
             "linux-amd64": "server/dist/plugin-linux-amd64",


### PR DESCRIPTION
Cherry-pick for `release-7.2` corresponding to https://github.com/mattermost/focalboard/pull/3536