### PR TITLE
Fix panic caused by returning nil,nil in GetMemberForBoard

### DIFF
--- a/server/services/store/mattermostauthlayer/mattermostauthlayer.go
+++ b/server/services/store/mattermostauthlayer/mattermostauthlayer.go
@@ -712,6 +712,8 @@ func (s *MattermostAuthLayer) GetMemberForBoard(boardID, userID string) (*model.
 				Synthetic:       true,
 			}, nil
 		}
+	} else {
+		return nil, err
 	}
 	return bm, nil
 }

--- a/server/services/store/mattermostauthlayer/mattermostauthlayer.go
+++ b/server/services/store/mattermostauthlayer/mattermostauthlayer.go
@@ -682,24 +682,23 @@ func (s *MattermostAuthLayer) implicitBoardMembershipsFromRows(rows *sql.Rows) (
 }
 
 func (s *MattermostAuthLayer) GetMemberForBoard(boardID, userID string) (*model.BoardMember, error) {
-	var err error
 	bm, err := s.Store.GetMemberForBoard(boardID, userID)
 	if model.IsErrNotFound(err) {
-		b, err := s.Store.GetBoard(boardID)
-		if err != nil {
-			return nil, err
+		b, boardErr := s.Store.GetBoard(boardID)
+		if boardErr != nil {
+			return nil, boardErr
 		}
 		if b.ChannelID != "" {
-			_, err := s.servicesAPI.GetChannelMember(b.ChannelID, userID)
-			if err != nil {
+			_, memberErr := s.servicesAPI.GetChannelMember(b.ChannelID, userID)
+			if memberErr != nil {
 				var appErr *mmModel.AppError
-				if errors.As(err, &appErr) && appErr.StatusCode == http.StatusNotFound {
+				if errors.As(memberErr, &appErr) && appErr.StatusCode == http.StatusNotFound {
 					// Plugin API returns error if channel member doesn't exist.
 					// We're fine if it doesn't exist, so its not an error for us.
 					return nil, nil
 				}
 
-				return nil, err
+				return nil, memberErr
 			}
 
 			return &model.BoardMember{

--- a/server/services/store/mattermostauthlayer/mattermostauthlayer.go
+++ b/server/services/store/mattermostauthlayer/mattermostauthlayer.go
@@ -682,6 +682,7 @@ func (s *MattermostAuthLayer) implicitBoardMembershipsFromRows(rows *sql.Rows) (
 }
 
 func (s *MattermostAuthLayer) GetMemberForBoard(boardID, userID string) (*model.BoardMember, error) {
+	var err error
 	bm, err := s.Store.GetMemberForBoard(boardID, userID)
 	if model.IsErrNotFound(err) {
 		b, err := s.Store.GetBoard(boardID)


### PR DESCRIPTION
#### Summary
mattermostauthlayer.GetMemberForBoard was returning nil,nil when an error occurred as it was only checking the IsErrNotfound case.  This caused a panic further up the stack (HasPermissionToBoard) in that it expected a valid member returned if err==nil.

This should be added to 7.2 as well. 

#### Ticket Link
NONE