### PR TITLE
Fix cypress from bad cherry-pick

### DIFF
--- a/webapp/src/components/sidebar/__snapshots__/sidebar.test.tsx.snap
+++ b/webapp/src/components/sidebar/__snapshots__/sidebar.test.tsx.snap
@@ -51,9 +51,9 @@ exports[`components/sidebarSidebar dont show hidden boards 1`] = `
                   >
                     <div
                       class="version"
-                      title="v7.3.0"
+                      title="v7.2.0"
                     >
-                      v7.3.0
+                      v7.2.0
                     </div>
                   </div>
                 </div>


### PR DESCRIPTION
#### Summary
A cherry-pick from main was displaying `v7.3.0`, which was correct on `main`. Updated for `release-7.2` back to `v7.2.0`
