### PR TITLE
Additional fix for GetMemberForBoard returning nil,nil See #3552

### DIFF
--- a/server/services/store/mattermostauthlayer/mattermostauthlayer.go
+++ b/server/services/store/mattermostauthlayer/mattermostauthlayer.go
@@ -683,7 +683,7 @@ func (s *MattermostAuthLayer) GetMemberForBoard(boardID, userID string) (*model.
 				if errors.As(memberErr, &appErr) && appErr.StatusCode == http.StatusNotFound {
 					// Plugin API returns error if channel member doesn't exist.
 					// We're fine if it doesn't exist, so its not an error for us.
-					return nil, nil
+					return nil, model.NewErrNotFound(userID)
 				}
 
 				return nil, memberErr


### PR DESCRIPTION
#### Summary
Additional fix for `GetMemberForBoard` returning nil,nil    See https://github.com/mattermost/focalboard/pull/3552

#### Ticket Link
NONE