### PR TITLE
Enforce passing the environment variable to the gowork generator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ ci: webapp-ci server-test ## Simulate CI, locally.
 
 setup-go-work: export EXCLUDE_ENTERPRISE ?= true
 setup-go-work: ## Sets up a go.work file
-	go run ./build/gowork/main.go
+	EXCLUDE_ENTERPRISE=$(EXCLUDE_ENTERPRISE) go run ./build/gowork/main.go
 
 templates-archive: setup-go-work ## Build templates archive file
 	cd server/assets/build-template-archive; go run -tags '$(BUILD_TAGS)' main.go --dir="../templates-boardarchive" --out="../templates.boardarchive"


### PR DESCRIPTION
#### Summary
When generating the `go.work` file, the environment variable `EXCLUDE_ENTERPRISE` was not passed to the generator (at least on Linux) which lead to the inclusion of the enterprise repo for external contributors. This PR forces `make` to pass the env variable to the generator.

Thanks to @clmnin for reporting this.

#### Ticket Link
#3591