### PR TITLE
Restricted scope of board-category change WS event to correct user

### DIFF
--- a/server/ws/plugin_adapter.go
+++ b/server/ws/plugin_adapter.go
@@ -486,8 +486,8 @@ func (pa *PluginAdapter) BroadcastCategoryChange(category model.Category) {
 
 	go func() {
 		clusterMessage := &ClusterMessage{
-			Payload:     payload,
-			EnsureUsers: []string{category.UserID},
+			Payload: payload,
+			UserID:  category.UserID,
 		}
 
 		pa.sendMessageToCluster("websocket_message", clusterMessage)
@@ -511,7 +511,18 @@ func (pa *PluginAdapter) BroadcastCategoryBoardChange(teamID, userID string, boa
 		BoardCategories: &boardCategory,
 	}
 
-	pa.sendTeamMessage(websocketActionUpdateCategoryBoard, teamID, utils.StructToMap(message))
+	payload := utils.StructToMap(message)
+
+	go func() {
+		clusterMessage := &ClusterMessage{
+			Payload: payload,
+			UserID:  userID,
+		}
+
+		pa.sendMessageToCluster("websocket_message", clusterMessage)
+	}()
+
+	pa.sendUserMessageSkipCluster(websocketActionUpdateCategoryBoard, utils.StructToMap(message), userID)
 }
 
 func (pa *PluginAdapter) BroadcastBlockDelete(teamID, blockID, boardID string) {

--- a/server/ws/plugin_adapter_cluster.go
+++ b/server/ws/plugin_adapter_cluster.go
@@ -10,6 +10,7 @@ import (
 type ClusterMessage struct {
 	TeamID      string
 	BoardID     string
+	UserID      string
 	Payload     map[string]interface{}
 	EnsureUsers []string
 }
@@ -66,6 +67,11 @@ func (pa *PluginAdapter) HandleClusterEvent(ev mmModel.PluginClusterEvent) {
 			mlog.String("id", ev.Id),
 			mlog.Map("payload", clusterMessage.Payload),
 		)
+		return
+	}
+
+	if clusterMessage.UserID != "" {
+		pa.sendUserMessageSkipCluster(action, clusterMessage.Payload, clusterMessage.UserID)
 		return
 	}
 


### PR DESCRIPTION
Fixes #3559

The issue was that the WS event for notifying change of a board's category was being sent to all users in team. It should be sent only to the user who performed the action. In this PR I've reduced the WS event's scope only to the correct user for both direct WS event and events received via cluster.