### PR TITLE
Fix the team highlight and the back to channels team selection

### DIFF
--- a/mattermost-plugin/webapp/src/index.tsx
+++ b/mattermost-plugin/webapp/src/index.tsx
@@ -252,10 +252,14 @@ export default class Plugin {
 
         let fbPrevTeamID = store.getState().teams.currentId
         store.subscribe(() => {
-            const currentTeamID = store.getState().teams.currentId
-            if (currentTeamID && currentTeamID !== fbPrevTeamID) {
+            const currentTeamID: string = store.getState().teams.currentId
+            const currentUserId = mmStore.getState().entities.users.currentUserId
+            if (currentTeamID !== fbPrevTeamID) {
                 fbPrevTeamID = currentTeamID
-                selectTeam(currentTeamID)
+                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                // @ts-ignore
+                mmStore.dispatch(selectTeam(currentTeamID))
+                localStorage.setItem(`user_prev_team:${currentUserId}`, currentTeamID)
             }
         })
 
@@ -380,11 +384,6 @@ export default class Plugin {
             }
         }
 
-        windowAny.setTeamInSidebar = (teamID: string) => {
-            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-            // @ts-ignore
-            mmStore.dispatch(selectTeam(teamID))
-        }
         windowAny.getCurrentTeamId = (): string => {
             // eslint-disable-next-line @typescript-eslint/ban-ts-comment
             // @ts-ignore

--- a/webapp/src/pages/boardPage/boardPage.tsx
+++ b/webapp/src/pages/boardPage/boardPage.tsx
@@ -30,6 +30,7 @@ import {
 import {getCurrentViewId, setCurrent as setCurrentView} from '../../store/views'
 import {initialLoad, initialReadOnlyLoad, loadBoardData} from '../../store/initialLoad'
 import {useAppSelector, useAppDispatch} from '../../store/hooks'
+import {setTeam} from '../../store/teams'
 import {updateViews} from '../../store/views'
 import {updateCards} from '../../store/cards'
 import {updateComments} from '../../store/comments'
@@ -95,10 +96,7 @@ const BoardPage = (props: Props): JSX.Element => {
     useEffect(() => {
         UserSettings.lastTeamId = teamId
         octoClient.teamId = teamId
-        const windowAny = (window as any)
-        if (windowAny.setTeamInSidebar) {
-            windowAny.setTeamInSidebar(teamId)
-        }
+        dispatch(setTeam(teamId))
     }, [teamId])
 
     const loadAction: (boardId: string) => any = useMemo(() => {

--- a/webapp/src/types/index.d.ts
+++ b/webapp/src/types/index.d.ts
@@ -16,7 +16,6 @@ export interface IAppWindow extends Window {
 // window object when operating in
 // the Mattermost suite environment
 export type SuiteWindow = Window & {
-    setTeamInSidebar?: (teamID: string) => void
     getCurrentTeamId?: () => string
     baseURL?: string
     frontendBaseURL?: string


### PR DESCRIPTION
#### Summary
This fixes the selection of the team when you are directly open a link, and
also the keep that team selected when you back to channels.

#### Ticket Link
Fixes #3499
Fixes #3498