### PR TITLE
GH-3597 Make sure template exists before creating card

### DIFF
--- a/webapp/src/components/viewHeader/newCardButton.tsx
+++ b/webapp/src/components/viewHeader/newCardButton.tsx
@@ -25,13 +25,14 @@ type Props = {
 const NewCardButton = (props: Props): JSX.Element => {
     const cardTemplates: Card[] = useAppSelector(getCurrentBoardTemplates)
     const currentView = useAppSelector(getCurrentView)
+    let defaultTemplateID = ''
     const intl = useIntl()
 
     return (
         <ButtonWithMenu
             onClick={() => {
-                if (currentView.fields.defaultTemplateId) {
-                    props.addCardFromTemplate(currentView.fields.defaultTemplateId)
+                if (defaultTemplateID) {
+                    props.addCardFromTemplate(defaultTemplateID)
                 } else {
                     props.addCard()
                 }
@@ -57,14 +58,19 @@ const NewCardButton = (props: Props): JSX.Element => {
                     <Menu.Separator/>
                 </>}
 
-                {cardTemplates.map((cardTemplate) => (
-                    <NewCardButtonTemplateItem
-                        key={cardTemplate.id}
-                        cardTemplate={cardTemplate}
-                        addCardFromTemplate={props.addCardFromTemplate}
-                        editCardTemplate={props.editCardTemplate}
-                    />
-                ))}
+                {cardTemplates.map((cardTemplate) => {
+                    if (cardTemplate.id == currentView.fields.defaultTemplateId){
+                        defaultTemplateID = currentView.fields.defaultTemplateId
+                    }
+                    return (
+                        <NewCardButtonTemplateItem
+                            key={cardTemplate.id}
+                            cardTemplate={cardTemplate}
+                            addCardFromTemplate={props.addCardFromTemplate}
+                            editCardTemplate={props.editCardTemplate}
+                        />
+                    )
+                })}
 
                 <EmptyCardButton
                     addCard={props.addCard}


### PR DESCRIPTION
#### Summary
Some boards created from earlier templates have an invalid `defaultTemplateID`. This PR will make sure the templateID exists before using it as the default.

#### Ticket Link
  Fixes https://github.com/mattermost/focalboard/issues/3597

