### PR TITLE
Move rest API for changepassword to personal server route

### DIFF
--- a/server/api/auth.go
+++ b/server/api/auth.go
@@ -24,9 +24,8 @@ func (a *API) registerAuthRoutes(r *mux.Router) {
 		r.HandleFunc("/logout", a.sessionRequired(a.handleLogout)).Methods("POST")
 		r.HandleFunc("/register", a.handleRegister).Methods("POST")
 		r.HandleFunc("/teams/{teamID}/regenerate_signup_token", a.sessionRequired(a.handlePostTeamRegenerateSignupToken)).Methods("POST")
+		r.HandleFunc("/users/{userID}/changepassword", a.sessionRequired(a.handleChangePassword)).Methods("POST")
 	}
-
-	r.HandleFunc("/users/{userID}/changepassword", a.sessionRequired(a.handleChangePassword)).Methods("POST")
 }
 
 func (a *API) handleLogin(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
#### Summary
The rest api for changing password is not needed for plugin mode.  This PR ensures it does not get registered when in plugin mode.

See https://github.com/mattermost/focalboard/pull/3624#discussion_r942309325


#### Ticket Link
NONE 