### PR TITLE
fix: don't re-.push() the URL if already on teamId

### DIFF
--- a/mattermost-plugin/webapp/src/index.tsx
+++ b/mattermost-plugin/webapp/src/index.tsx
@@ -241,7 +241,9 @@ export default class Plugin {
             const currentTeamID = mmStore.getState().entities.teams.currentTeamId
             if (currentTeamID && currentTeamID !== prevTeamID) {
                 if (prevTeamID && window.location.pathname.startsWith(windowAny.frontendBaseURL || '')) {
-                    browserHistory.push(`/team/${currentTeamID}`)
+                    // Don't re-push the URL if we're already on a URL for the current team
+                    if (!window.location.pathname.startsWith(`${(windowAny.frontendBaseURL || '')}/team/${currentTeamID}`))
+                        browserHistory.push(`/team/${currentTeamID}`)
                 }
                 prevTeamID = currentTeamID
                 store.dispatch(setTeam(currentTeamID))


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute

Assign two reviewers for this pull request from the names suggested. If no names are suggested or you are not sure who to assign, set `Core Focalboard` as the reviewer.
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the ticket).
-->
This has been a painful bug.

The root cause is we have logic within `mattermost-plugin/webapp` to do `.subscribe()`-ing to both the Mattermost redux store & the Focalboard redux store and keep a few specific items in sync. For this bug, we we're focusing on the current team ID.

Previously, when syncing, if the current team ID changed we would re-`.push()` the URL to go to the team, even if we were already on a URL for the same team. This was causing a sort of race/circular condition where depending on how the stores sync'd up it might associate the `lastBoardId` with an incorrect `teamId` and it all breaks subtly by rendering the template selector.

This change _should_ fix the above case however we've seen some instances of navigating Boards -> Channels -> Boards not rendering the last viewed board + view for the team. Again, difficult to reproduce so we're getting this merged in to able to test in a bug bash environment.

#### Ticket Link
<!--
If this pull request addresses a Github issue, please link the relevant issue, e.g.

  Fixes https://github.com/mattermost/focalboard/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
closes #3530