### PR TITLE
Fixing create-board from board selector in desktop app

### DIFF
--- a/webapp/src/components/workspace.tsx
+++ b/webapp/src/components/workspace.tsx
@@ -85,6 +85,28 @@ function CenterContent(props: Props) {
         }
     }, [cardLimitTimestamp, match.params.boardId, templates])
 
+    const templateSelector = (
+        <BoardTemplateSelector
+            title={
+                <FormattedMessage
+                    id='BoardTemplateSelector.plugin.no-content-title'
+                    defaultMessage='Create a board'
+                />
+            }
+            description={
+                <FormattedMessage
+                    id='BoardTemplateSelector.plugin.no-content-description'
+                    defaultMessage='Add a board to the sidebar using any of the templates defined below or start from scratch.'
+                />
+            }
+            channelId={match.params.channelId}
+        />
+    )
+
+    if (match.params.channelId) {
+        return templateSelector
+    }
+
     if (board && !isBoardHidden() && activeView) {
         let property = groupByProperty
         if ((!property || property.type !== 'select') && activeView.fields.viewType === 'board') {
@@ -117,23 +139,7 @@ function CenterContent(props: Props) {
         return null
     }
 
-    return (
-        <BoardTemplateSelector
-            title={
-                <FormattedMessage
-                    id='BoardTemplateSelector.plugin.no-content-title'
-                    defaultMessage='Create a board'
-                />
-            }
-            description={
-                <FormattedMessage
-                    id='BoardTemplateSelector.plugin.no-content-description'
-                    defaultMessage='Add a board to the sidebar using any of the templates defined below or start from scratch.'
-                />
-            }
-            channelId={match.params.channelId}
-        />
-    )
+    return templateSelector
 }
 
 const Workspace = (props: Props) => {


### PR DESCRIPTION
#### Summary
The desktop app was using a different approach (instead of open in a new tab it
opens it directly in the current tab) that makes the current board something
that exists so it wasn't changing when the url was there, so I now force to
show the template selector whenever you are creating a new board from a
channel.

#### Ticket Link
Fixes #3572