### PR TITLE
[MM-45761] - Telemetry: Track how many users end up in purchase/prici…

### DIFF
--- a/mattermost-plugin/webapp/src/components/cloudUpgradeNudge/cloudUpgradeNudge.tsx
+++ b/mattermost-plugin/webapp/src/components/cloudUpgradeNudge/cloudUpgradeNudge.tsx
@@ -8,7 +8,7 @@ const PostTypeCloudUpgradeNudge = (props: {post: Post}): JSX.Element => {
     const ctaHandler = (e: React.MouseEvent) => {
         e.preventDefault()
         const windowAny = (window as any)
-        windowAny?.openPricingModal()()
+        windowAny?.openPricingModal()('boards > click_view_upgrade_options_nudge')
     }
 
     // custom post type doesn't support styling via CSS  stylesheet.

--- a/webapp/src/components/cardDetail/cardDetail.tsx
+++ b/webapp/src/components/cardDetail/cardDetail.tsx
@@ -165,7 +165,7 @@ const CardDetail = (props: Props): JSX.Element|null => {
                             role='button'
                             onClick={() => {
                                 props.onClose();
-                                (window as any).openPricingModal()()
+                                (window as any).openPricingModal()('boards > learn_more_about_our_plans_click')
                             }}
                         >
                             <FormattedMessage
@@ -178,7 +178,7 @@ const CardDetail = (props: Props): JSX.Element|null => {
                         className='CardDetail__limited-button'
                         onClick={() => {
                             props.onClose();
-                            (window as any).openPricingModal()()
+                            (window as any).openPricingModal()('boards > upgrade_click')
                         }}
                         emphasis='primary'
                         size='large'

--- a/webapp/src/components/cardLimitNotification.tsx
+++ b/webapp/src/components/cardLimitNotification.tsx
@@ -119,7 +119,7 @@ const CardLimitNotification = (props: Props) => {
     }, [me?.id])
 
     const onClick = useCallback(() => {
-        (window as any).openPricingModal()()
+        (window as any).openPricingModal()('boards > card_limit_notification_upgrade_to_a_paid_plan_click')
         TelemetryClient.trackEvent(TelemetryCategory, TelemetryActions.LimitCardLimitLinkOpen, {})
     }, [])
 

--- a/webapp/src/components/viewLImitDialog/viewLimitDialog.tsx
+++ b/webapp/src/components/viewLImitDialog/viewLimitDialog.tsx
@@ -80,7 +80,7 @@ export const ViewLimitModal = (props: Props): JSX.Element => {
         telemetryClient.trackEvent(TelemetryCategory, TelemetryActions.ViewLimitCTAPerformed, {board: board.id})
 
         if (isAdmin) {
-            (window as any)?.openPricingModal()()
+            (window as any)?.openPricingModal()('boards > view_limit_dialog')
         } else {
             await octoClient.notifyAdminUpgrade()
             props.showNotifyAdminSuccess()

--- a/webapp/src/types/index.d.ts
+++ b/webapp/src/types/index.d.ts
@@ -8,7 +8,7 @@ export interface IAppWindow extends Window {
     msCrypto: Crypto
     openInNewBrowser?: ((href: string) => void) | null
     webkit?: {messageHandlers: {nativeApp?: {postMessage: <T>(message: T) => void}}}
-    openPricingModal?: () => () => void
+    openPricingModal?: () => (callerInfo: string) => void
 }
 
 // SuiteWindow documents all custom properties


### PR DESCRIPTION
#### Summary
This PR adds the ability to know in which component the purchase modal opening was initiated from

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-45761
https://mattermost.atlassian.net/browse/MM-45014

#### Related PRs
https://github.com/mattermost/mattermost-webapp/pull/10920

#### Release Note

```release-note
NONE
```
