### PR TITLE
fix: always try the `lastBoardId` when switching teams

### DIFF
--- a/webapp/src/pages/boardPage/teamToBoardAndViewRedirect.tsx
+++ b/webapp/src/pages/boardPage/teamToBoardAndViewRedirect.tsx
@@ -25,9 +25,7 @@ const TeamToBoardAndViewRedirect = (): null => {
         let boardID = match.params.boardId
         if (!match.params.boardId) {
             // first preference is for last visited board
-            if (boards[UserSettings.lastBoardId[teamId]]) {
-                boardID = UserSettings.lastBoardId[teamId]
-            }
+            boardID = UserSettings.lastBoardId[teamId]
 
             // if last visited board is unavailable, use the first board in categories list
             if (!boardID && categories.length > 0) {


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute

Assign two reviewers for this pull request from the names suggested. If no names are suggested or you are not sure who to assign, set `Core Focalboard` as the reviewer.
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the ticket).
-->

Credit to @sbishel. ✨ 

This changes behavior to always try and use the `lastBoardId` for a given `teamId` that is persisted in localStorage. Now, when switching between teams the last board + view will be shown instead of template selector.

Similar to #3651, we're confident enough in these changes locally that we're looking to get this merged in, another RC cut, and test on the bugbash server.

cc @ogi-m if you're able to help validate this fix

#### Ticket Link
<!--
If this pull request addresses a Github issue, please link the relevant issue, e.g.

  Fixes https://github.com/mattermost/focalboard/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
closes #3654 
