### PR TITLE
fix: `Viewer` only on a template, not board

### DIFF
--- a/webapp/src/components/shareBoard/__snapshots__/teamPermissionsRow.test.tsx.snap
+++ b/webapp/src/components/shareBoard/__snapshots__/teamPermissionsRow.test.tsx.snap
@@ -62,29 +62,7 @@ exports[`src/components/shareBoard/teamPermissionsRow should match snapshot 1`] 
                   />
                 </div>
               </div>
-              <div>
-                <div
-                  aria-label="Viewer"
-                  class="MenuOption TextOption menu-option"
-                  role="button"
-                >
-                  <div
-                    class="d-flex"
-                  >
-                    <div
-                      class="noicon"
-                    />
-                  </div>
-                  <div
-                    class="menu-name"
-                  >
-                    Viewer
-                  </div>
-                  <div
-                    class="noicon"
-                  />
-                </div>
-              </div>
+              <div />
               <div>
                 <div
                   aria-label="None"
@@ -216,29 +194,7 @@ exports[`src/components/shareBoard/teamPermissionsRow should match snapshot in p
                   />
                 </div>
               </div>
-              <div>
-                <div
-                  aria-label="Viewer"
-                  class="MenuOption TextOption menu-option"
-                  role="button"
-                >
-                  <div
-                    class="d-flex"
-                  >
-                    <div
-                      class="noicon"
-                    />
-                  </div>
-                  <div
-                    class="menu-name"
-                  >
-                    Viewer
-                  </div>
-                  <div
-                    class="noicon"
-                  />
-                </div>
-              </div>
+              <div />
               <div>
                 <div
                   aria-label="None"

--- a/webapp/src/components/shareBoard/teamPermissionsRow.tsx
+++ b/webapp/src/components/shareBoard/teamPermissionsRow.tsx
@@ -83,13 +83,14 @@ const TeamPermissionsRow = (): JSX.Element => {
                                     name={intl.formatMessage({id: 'BoardMember.schemeEditor', defaultMessage: 'Editor'})}
                                     onClick={() => updateBoardType(board, BoardTypeOpen, 'editor')}
                                 />}
+                            {board.isTemplate &&
                             <Menu.Text
                                 id='Viewer'
                                 check={board.minimumRole === 'viewer'}
                                 icon={board.type === BoardTypeOpen && board.minimumRole === 'viewer' ? <CheckIcon/> : null}
                                 name={intl.formatMessage({id: 'BoardMember.schemeViwer', defaultMessage: 'Viewer'})}
                                 onClick={() => updateBoardType(board, BoardTypeOpen, 'viewer')}
-                            />
+                            />}
                             <Menu.Text
                                 id='None'
                                 check={true}


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute

Assign two reviewers for this pull request from the names suggested. If no names are suggested or you are not sure who to assign, set `Core Focalboard` as the reviewer.
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the ticket).
-->
Add a conditional to only render `Viewer` on a (custom) template sharing dialog, not on a board. Notice this is direct to 7.2 w/ no cherrypick. I discussed this with @wuwinson and we agreed that `main` is working as expected for 7.3, which will have more roles e.g. `Commenter`.

<img width="691" alt="image" src="https://user-images.githubusercontent.com/6335792/184690718-e3fa54eb-c955-4b8e-acf2-675d264ce43c.png">

<img width="685" alt="image" src="https://user-images.githubusercontent.com/6335792/184690784-0e2fca1f-9e18-4cce-96d0-dc084ae88ee3.png">


#### Ticket Link
<!--
If this pull request addresses a Github issue, please link the relevant issue, e.g.

  Fixes https://github.com/mattermost/focalboard/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
closes #3678 