### PR TITLE
Fix Templates with empty name are shown as empty on the template list

### DIFF
--- a/webapp/i18n/en.json
+++ b/webapp/i18n/en.json
@@ -279,7 +279,7 @@
   "View.NewCalendarTitle": "Calendar view",
   "View.NewGalleryTitle": "Gallery view",
   "View.NewTableTitle": "Table view",
-  "View.NewTemplateTitle": "Untitled Template",
+  "View.NewTemplateTitle": "Untitled",
   "View.Table": "Table",
   "ViewHeader.add-template": "New template",
   "ViewHeader.delete-template": "Delete",

--- a/webapp/src/components/boardTemplateSelector/boardTemplateSelectorItem.tsx
+++ b/webapp/src/components/boardTemplateSelector/boardTemplateSelectorItem.tsx
@@ -41,7 +41,7 @@ const BoardTemplateSelectorItem = (props: Props) => {
             onClick={onClickHandler}
         >
             <span className='template-icon'>{template.icon || <CompassIcon icon='product-boards'/>}</span>
-            <span className='template-name'>{template.title}</span>
+            <span className='template-name'>{template.title || intl.formatMessage({id: 'View.NewTemplateTitle', defaultMessage: 'Untitled'})}</span>
 
             {/* don't show template menu options for default templates */}
             {template.teamId !== Constants.globalTeamId &&


### PR DESCRIPTION
Hi! So, this PR is related to PR #3577, I tried following the steps as instructed, but I think I messed up in the merging part and the PR got closed 😅. I'm kinda new to Open Source contributions outside of my own repos. Also, sorry for the late reply on this.

Summary

Fix templates with empty name are shown as empty on the template list

 - When no name is specified for a certain template, now the default name for untitled templates is displayed to the user.
 
 - Changes the default name for untitled templates in english to just "Untitled"

Ticket Link

Fixes https://github.com/mattermost/focalboard/issues/3400