### PR TITLE
fix: return empty props in single-user mode

### DIFF
--- a/server/api/users.go
+++ b/server/api/users.go
@@ -114,6 +114,7 @@ func (a *API) handleGetMe(w http.ResponseWriter, r *http.Request) {
 			Email:    model.SingleUser,
 			CreateAt: ws.UpdateAt,
 			UpdateAt: now,
+			Props:    map[string]interface{}{},
 		}
 	} else {
 		user, err = a.app.GetUser(userID)


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute

Assign two reviewers for this pull request from the names suggested. If no names are suggested or you are not sure who to assign, set `Core Focalboard` as the reviewer.
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the ticket).
-->
In single-user mode, the `props` for a user was being returned as `null` and not an empty `{}` object. This was breaking the frontend due to a runtime error of trying to access the `props.hiddenBoardIDs` since `props` itself was `null`.

There will be a discrete cherrypick PR to `release-7.2`, too.

#### Ticket Link
<!--
If this pull request addresses a Github issue, please link the relevant issue, e.g.

  Fixes https://github.com/mattermost/focalboard/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
closes #3683