### PR TITLE
Remove duplicated store and app method to get blocks that belong to a board

### DIFF
--- a/server/app/blocks.go
+++ b/server/app/blocks.go
@@ -65,10 +65,6 @@ func (a *App) DuplicateBlock(boardID string, blockID string, userID string, asTe
 	return blocks, err
 }
 
-func (a *App) GetBlocksWithBoardID(boardID string) ([]model.Block, error) {
-	return a.store.GetBlocksWithBoardID(boardID)
-}
-
 func (a *App) PatchBlock(blockID string, blockPatch *model.BlockPatch, modifiedByID string) error {
 	oldBlock, err := a.store.GetBlock(blockID)
 	if err != nil {

--- a/server/app/export.go
+++ b/server/app/export.go
@@ -82,7 +82,7 @@ func (a *App) writeArchiveBoard(zw *zip.Writer, board model.Board, opt model.Exp
 	var files []string
 	// write the board's blocks
 	// TODO: paginate this
-	blocks, err := a.GetBlocksWithBoardID(board.ID)
+	blocks, err := a.GetBlocksForBoard(board.ID)
 	if err != nil {
 		return err
 	}

--- a/server/services/permissions/mmpermissions/mocks/mockpluginapi.go
+++ b/server/services/permissions/mmpermissions/mocks/mockpluginapi.go
@@ -457,21 +457,6 @@ func (mr *MockAPIMockRecorder) EnablePlugin(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnablePlugin", reflect.TypeOf((*MockAPI)(nil).EnablePlugin), arg0)
 }
 
-// EnsureBotUser mocks base method.
-func (m *MockAPI) EnsureBotUser(arg0 *model.Bot) (string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EnsureBotUser", arg0)
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// EnsureBotUser indicates an expected call of EnsureBotUser.
-func (mr *MockAPIMockRecorder) EnsureBotUser(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureBotUser", reflect.TypeOf((*MockAPI)(nil).EnsureBotUser), arg0)
-}
-
 // ExecuteSlashCommand mocks base method.
 func (m *MockAPI) ExecuteSlashCommand(arg0 *model.CommandArgs) (*model.CommandResponse, error) {
 	m.ctrl.T.Helper()
@@ -694,21 +679,6 @@ func (m *MockAPI) GetChannelsForTeamForUser(arg0, arg1 string, arg2 bool) ([]*mo
 func (mr *MockAPIMockRecorder) GetChannelsForTeamForUser(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetChannelsForTeamForUser", reflect.TypeOf((*MockAPI)(nil).GetChannelsForTeamForUser), arg0, arg1, arg2)
-}
-
-// GetCloudLimits mocks base method.
-func (m *MockAPI) GetCloudLimits() (*model.ProductLimits, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetCloudLimits")
-	ret0, _ := ret[0].(*model.ProductLimits)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetCloudLimits indicates an expected call of GetCloudLimits.
-func (mr *MockAPIMockRecorder) GetCloudLimits() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCloudLimits", reflect.TypeOf((*MockAPI)(nil).GetCloudLimits))
 }
 
 // GetCommand mocks base method.

--- a/server/services/store/sqlstore/blocks.go
+++ b/server/services/store/sqlstore/blocks.go
@@ -126,23 +126,6 @@ func (s *SQLStore) getBlocksByIDs(db sq.BaseRunner, ids []string) ([]model.Block
 	return blocks, nil
 }
 
-func (s *SQLStore) getBlocksWithBoardID(db sq.BaseRunner, boardID string) ([]model.Block, error) {
-	query := s.getQueryBuilder(db).
-		Select(s.blockFields()...).
-		From(s.tablePrefix + "blocks").
-		Where(sq.Eq{"board_id": boardID})
-
-	rows, err := query.Query()
-	if err != nil {
-		s.logger.Error(`GetBlocksWithBoardID ERROR`, mlog.Err(err))
-
-		return nil, err
-	}
-	defer s.CloseRows(rows)
-
-	return s.blocksFromRows(rows)
-}
-
 func (s *SQLStore) getBlocksWithType(db sq.BaseRunner, boardID, blockType string) ([]model.Block, error) {
 	query := s.getQueryBuilder(db).
 		Select(s.blockFields()...).

--- a/server/services/store/sqlstore/boards_and_blocks.go
+++ b/server/services/store/sqlstore/boards_and_blocks.go
@@ -161,7 +161,7 @@ func (s *SQLStore) duplicateBoard(db sq.BaseRunner, boardID string, userID strin
 	}
 
 	bab.Boards = []*model.Board{board}
-	blocks, err := s.getBlocksWithBoardID(db, boardID)
+	blocks, err := s.getBlocksForBoard(db, boardID)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/server/services/store/sqlstore/public_methods.go
+++ b/server/services/store/sqlstore/public_methods.go
@@ -304,11 +304,6 @@ func (s *SQLStore) GetBlocksForBoard(boardID string) ([]model.Block, error) {
 
 }
 
-func (s *SQLStore) GetBlocksWithBoardID(boardID string) ([]model.Block, error) {
-	return s.getBlocksWithBoardID(s.db, boardID)
-
-}
-
 func (s *SQLStore) GetBlocksWithParent(boardID string, parentID string) ([]model.Block, error) {
 	return s.getBlocksWithParent(s.db, boardID, parentID)
 

--- a/server/services/store/store.go
+++ b/server/services/store/store.go
@@ -17,7 +17,6 @@ type Store interface {
 	GetBlocksWithParentAndType(boardID, parentID string, blockType string) ([]model.Block, error)
 	GetBlocksWithParent(boardID, parentID string) ([]model.Block, error)
 	GetBlocksByIDs(ids []string) ([]model.Block, error)
-	GetBlocksWithBoardID(boardID string) ([]model.Block, error)
 	GetBlocksWithType(boardID, blockType string) ([]model.Block, error)
 	GetSubTree2(boardID, blockID string, opts model.QuerySubtreeOptions) ([]model.Block, error)
 	GetBlocksForBoard(boardID string) ([]model.Block, error)

--- a/server/services/store/storetests/blocks.go
+++ b/server/services/store/storetests/blocks.go
@@ -753,14 +753,14 @@ func testGetBlocks(t *testing.T, store store.Store) {
 
 	t.Run("not existing board", func(t *testing.T) {
 		time.Sleep(1 * time.Millisecond)
-		blocks, err = store.GetBlocksWithBoardID("not-exists")
+		blocks, err = store.GetBlocksForBoard("not-exists")
 		require.NoError(t, err)
 		require.Len(t, blocks, 0)
 	})
 
 	t.Run("all blocks of the a board", func(t *testing.T) {
 		time.Sleep(1 * time.Millisecond)
-		blocks, err = store.GetBlocksWithBoardID(boardID)
+		blocks, err = store.GetBlocksForBoard(boardID)
 		require.NoError(t, err)
 		require.Len(t, blocks, 5)
 	})

--- a/server/services/store/storetests/data_retention.go
+++ b/server/services/store/storetests/data_retention.go
@@ -100,7 +100,7 @@ func LoadData(t *testing.T, store store.Store) {
 func testRunDataRetention(t *testing.T, store store.Store, batchSize int) {
 	LoadData(t, store)
 
-	blocks, err := store.GetBlocksWithBoardID(boardID)
+	blocks, err := store.GetBlocksForBoard(boardID)
 	require.NoError(t, err)
 	require.Len(t, blocks, 4)
 	initialCount := len(blocks)
@@ -117,7 +117,7 @@ func testRunDataRetention(t *testing.T, store store.Store, batchSize int) {
 		require.True(t, deletions > int64(initialCount))
 
 		// expect all blocks to be deleted.
-		blocks, errBlocks := store.GetBlocksWithBoardID(boardID)
+		blocks, errBlocks := store.GetBlocksForBoard(boardID)
 		require.NoError(t, errBlocks)
 		require.Equal(t, 0, len(blocks))
 

--- a/server/ws/mocks/mockpluginapi.go
+++ b/server/ws/mocks/mockpluginapi.go
@@ -457,21 +457,6 @@ func (mr *MockAPIMockRecorder) EnablePlugin(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnablePlugin", reflect.TypeOf((*MockAPI)(nil).EnablePlugin), arg0)
 }
 
-// EnsureBotUser mocks base method.
-func (m *MockAPI) EnsureBotUser(arg0 *model.Bot) (string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EnsureBotUser", arg0)
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// EnsureBotUser indicates an expected call of EnsureBotUser.
-func (mr *MockAPIMockRecorder) EnsureBotUser(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureBotUser", reflect.TypeOf((*MockAPI)(nil).EnsureBotUser), arg0)
-}
-
 // ExecuteSlashCommand mocks base method.
 func (m *MockAPI) ExecuteSlashCommand(arg0 *model.CommandArgs) (*model.CommandResponse, error) {
 	m.ctrl.T.Helper()
@@ -694,21 +679,6 @@ func (m *MockAPI) GetChannelsForTeamForUser(arg0, arg1 string, arg2 bool) ([]*mo
 func (mr *MockAPIMockRecorder) GetChannelsForTeamForUser(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetChannelsForTeamForUser", reflect.TypeOf((*MockAPI)(nil).GetChannelsForTeamForUser), arg0, arg1, arg2)
-}
-
-// GetCloudLimits mocks base method.
-func (m *MockAPI) GetCloudLimits() (*model.ProductLimits, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetCloudLimits")
-	ret0, _ := ret[0].(*model.ProductLimits)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetCloudLimits indicates an expected call of GetCloudLimits.
-func (mr *MockAPIMockRecorder) GetCloudLimits() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCloudLimits", reflect.TypeOf((*MockAPI)(nil).GetCloudLimits))
 }
 
 // GetCommand mocks base method.


### PR DESCRIPTION
#### Summary
Removes duplicated logic to get blocks that belong to a board.