### PR TITLE
Register API router in product mode

### DIFF
--- a/mattermost-plugin/product/api_adapter.go
+++ b/mattermost-plugin/product/api_adapter.go
@@ -6,6 +6,8 @@ package product
 import (
 	"database/sql"
 
+	"github.com/gorilla/mux"
+
 	"github.com/mattermost/mattermost-server/v6/app/request"
 	mm_model "github.com/mattermost/mattermost-server/v6/model"
 	"github.com/mattermost/mattermost-server/v6/shared/mlog"
@@ -203,6 +205,13 @@ func (a *serviceAPIAdapter) GetMasterDB() (*sql.DB, error) {
 //
 func (a *serviceAPIAdapter) GetDiagnosticID() string {
 	return a.api.systemService.GetDiagnosticId()
+}
+
+//
+// Router service
+//
+func (a *serviceAPIAdapter) RegisterRouter(sub *mux.Router) {
+	a.api.routerService.RegisterRouter(boardsProductName, sub)
 }
 
 // Ensure the adapter implements ServicesAPI.

--- a/mattermost-plugin/product/api_adapter.go
+++ b/mattermost-plugin/product/api_adapter.go
@@ -208,7 +208,7 @@ func (a *serviceAPIAdapter) GetDiagnosticID() string {
 }
 
 //
-// Router service
+// Router service.
 //
 func (a *serviceAPIAdapter) RegisterRouter(sub *mux.Router) {
 	a.api.routerService.RegisterRouter(boardsProductName, sub)

--- a/mattermost-plugin/server/api_adapter.go
+++ b/mattermost-plugin/server/api_adapter.go
@@ -6,6 +6,7 @@ package main
 import (
 	"database/sql"
 
+	"github.com/gorilla/mux"
 	"github.com/mattermost/focalboard/server/model"
 
 	"github.com/mattermost/mattermost-server/v6/plugin"
@@ -206,6 +207,13 @@ func (a *pluginAPIAdapter) GetMasterDB() (*sql.DB, error) {
 //
 func (a *pluginAPIAdapter) GetDiagnosticID() string {
 	return a.api.GetDiagnosticId()
+}
+
+//
+// Router service
+//
+func (a *pluginAPIAdapter) RegisterRouter(sub *mux.Router) {
+	// NOOP for plugin
 }
 
 // Ensure the adapter implements ServicesAPI.

--- a/mattermost-plugin/server/api_adapter.go
+++ b/mattermost-plugin/server/api_adapter.go
@@ -210,7 +210,7 @@ func (a *pluginAPIAdapter) GetDiagnosticID() string {
 }
 
 //
-// Router service
+// Router service.
 //
 func (a *pluginAPIAdapter) RegisterRouter(sub *mux.Router) {
 	// NOOP for plugin

--- a/mattermost-plugin/server/boards/boardsapp.go
+++ b/mattermost-plugin/server/boards/boardsapp.go
@@ -170,6 +170,11 @@ func (b *BoardsApp) Start() error {
 	if err := b.server.Start(); err != nil {
 		return fmt.Errorf("error starting Boards server: %w", err)
 	}
+
+	b.servicesAPI.RegisterRouter(b.server.GetRootRouter())
+
+	b.logger.Info("Boards product successfully started.")
+
 	return nil
 }
 

--- a/server/model/mocks/mockservicesapi.go
+++ b/server/model/mocks/mockservicesapi.go
@@ -9,6 +9,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
+	mux "github.com/gorilla/mux"
 	model "github.com/mattermost/mattermost-server/v6/model"
 	mlog "github.com/mattermost/mattermost-server/v6/shared/mlog"
 )
@@ -384,6 +385,18 @@ func (m *MockServicesAPI) PublishWebSocketEvent(arg0 string, arg1 map[string]int
 func (mr *MockServicesAPIMockRecorder) PublishWebSocketEvent(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PublishWebSocketEvent", reflect.TypeOf((*MockServicesAPI)(nil).PublishWebSocketEvent), arg0, arg1, arg2)
+}
+
+// RegisterRouter mocks base method.
+func (m *MockServicesAPI) RegisterRouter(arg0 *mux.Router) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "RegisterRouter", arg0)
+}
+
+// RegisterRouter indicates an expected call of RegisterRouter.
+func (mr *MockServicesAPIMockRecorder) RegisterRouter(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterRouter", reflect.TypeOf((*MockServicesAPI)(nil).RegisterRouter), arg0)
 }
 
 // UpdateUser mocks base method.

--- a/server/model/services_api.go
+++ b/server/model/services_api.go
@@ -8,6 +8,8 @@ package model
 import (
 	"database/sql"
 
+	"github.com/gorilla/mux"
+
 	mm_model "github.com/mattermost/mattermost-server/v6/model"
 	"github.com/mattermost/mattermost-server/v6/shared/mlog"
 )
@@ -67,4 +69,7 @@ type ServicesAPI interface {
 
 	// System service
 	GetDiagnosticID() string
+
+	// Router service
+	RegisterRouter(sub *mux.Router)
 }

--- a/server/services/permissions/mmpermissions/mocks/mockpluginapi.go
+++ b/server/services/permissions/mmpermissions/mocks/mockpluginapi.go
@@ -457,21 +457,6 @@ func (mr *MockAPIMockRecorder) EnablePlugin(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnablePlugin", reflect.TypeOf((*MockAPI)(nil).EnablePlugin), arg0)
 }
 
-// EnsureBotUser mocks base method.
-func (m *MockAPI) EnsureBotUser(arg0 *model.Bot) (string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EnsureBotUser", arg0)
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// EnsureBotUser indicates an expected call of EnsureBotUser.
-func (mr *MockAPIMockRecorder) EnsureBotUser(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureBotUser", reflect.TypeOf((*MockAPI)(nil).EnsureBotUser), arg0)
-}
-
 // ExecuteSlashCommand mocks base method.
 func (m *MockAPI) ExecuteSlashCommand(arg0 *model.CommandArgs) (*model.CommandResponse, error) {
 	m.ctrl.T.Helper()
@@ -694,21 +679,6 @@ func (m *MockAPI) GetChannelsForTeamForUser(arg0, arg1 string, arg2 bool) ([]*mo
 func (mr *MockAPIMockRecorder) GetChannelsForTeamForUser(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetChannelsForTeamForUser", reflect.TypeOf((*MockAPI)(nil).GetChannelsForTeamForUser), arg0, arg1, arg2)
-}
-
-// GetCloudLimits mocks base method.
-func (m *MockAPI) GetCloudLimits() (*model.ProductLimits, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetCloudLimits")
-	ret0, _ := ret[0].(*model.ProductLimits)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetCloudLimits indicates an expected call of GetCloudLimits.
-func (mr *MockAPIMockRecorder) GetCloudLimits() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCloudLimits", reflect.TypeOf((*MockAPI)(nil).GetCloudLimits))
 }
 
 // GetCommand mocks base method.

--- a/server/ws/mocks/mockpluginapi.go
+++ b/server/ws/mocks/mockpluginapi.go
@@ -457,21 +457,6 @@ func (mr *MockAPIMockRecorder) EnablePlugin(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnablePlugin", reflect.TypeOf((*MockAPI)(nil).EnablePlugin), arg0)
 }
 
-// EnsureBotUser mocks base method.
-func (m *MockAPI) EnsureBotUser(arg0 *model.Bot) (string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EnsureBotUser", arg0)
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// EnsureBotUser indicates an expected call of EnsureBotUser.
-func (mr *MockAPIMockRecorder) EnsureBotUser(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureBotUser", reflect.TypeOf((*MockAPI)(nil).EnsureBotUser), arg0)
-}
-
 // ExecuteSlashCommand mocks base method.
 func (m *MockAPI) ExecuteSlashCommand(arg0 *model.CommandArgs) (*model.CommandResponse, error) {
 	m.ctrl.T.Helper()
@@ -694,21 +679,6 @@ func (m *MockAPI) GetChannelsForTeamForUser(arg0, arg1 string, arg2 bool) ([]*mo
 func (mr *MockAPIMockRecorder) GetChannelsForTeamForUser(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetChannelsForTeamForUser", reflect.TypeOf((*MockAPI)(nil).GetChannelsForTeamForUser), arg0, arg1, arg2)
-}
-
-// GetCloudLimits mocks base method.
-func (m *MockAPI) GetCloudLimits() (*model.ProductLimits, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetCloudLimits")
-	ret0, _ := ret[0].(*model.ProductLimits)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetCloudLimits indicates an expected call of GetCloudLimits.
-func (mr *MockAPIMockRecorder) GetCloudLimits() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCloudLimits", reflect.TypeOf((*MockAPI)(nil).GetCloudLimits))
 }
 
 // GetCommand mocks base method.


### PR DESCRIPTION
#### Summary
This PR fixes an issue setting up Boards in product mode.  The call to register the API router was missing.

This change has no effect when running as plugin.

#### Ticket Link
NONE