### PR TITLE
Print log server information on plugin run

### DIFF
--- a/mattermost-plugin/product/boards_product.go
+++ b/mattermost-plugin/product/boards_product.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 
 	"github.com/mattermost/focalboard/mattermost-plugin/server/boards"
+	"github.com/mattermost/focalboard/server/model"
 
 	"github.com/mattermost/mattermost-server/v6/app"
 	mm_model "github.com/mattermost/mattermost-server/v6/model"
@@ -190,6 +191,7 @@ func (bp *boardsProduct) Start() error {
 	}
 
 	bp.logger.Info("Starting boards service")
+	model.LogServerInfo(bp.logger)
 
 	adapter := newServiceAPIAdapter(bp)
 	boardsApp, err := boards.NewBoardsApp(adapter)

--- a/mattermost-plugin/product/boards_product.go
+++ b/mattermost-plugin/product/boards_product.go
@@ -191,13 +191,14 @@ func (bp *boardsProduct) Start() error {
 	}
 
 	bp.logger.Info("Starting boards service")
-	model.LogServerInfo(bp.logger)
 
 	adapter := newServiceAPIAdapter(bp)
 	boardsApp, err := boards.NewBoardsApp(adapter)
 	if err != nil {
 		return fmt.Errorf("failed to create Boards service: %w", err)
 	}
+
+	model.LogServerInfo(bp.logger)
 
 	bp.boardsApp = boardsApp
 	if err := bp.boardsApp.Start(); err != nil {

--- a/mattermost-plugin/server/plugin.go
+++ b/mattermost-plugin/server/plugin.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 
 	"github.com/mattermost/focalboard/mattermost-plugin/server/boards"
+	"github.com/mattermost/focalboard/server/model"
 
 	pluginapi "github.com/mattermost/mattermost-plugin-api"
 
@@ -51,6 +52,8 @@ func (p *Plugin) OnActivate() error {
 	if err != nil {
 		return fmt.Errorf("cannot activate plugin: %w", err)
 	}
+
+	model.LogServerInfo(logger)
 
 	p.boardsApp = boardsApp
 	return p.boardsApp.Start()

--- a/server/main/main.go
+++ b/server/main/main.go
@@ -53,16 +53,6 @@ func monitorPid(pid int, logger *mlog.Logger) {
 	}()
 }
 
-func logInfo(logger *mlog.Logger) {
-	logger.Info("FocalBoard Server",
-		mlog.String("version", model.CurrentVersion),
-		mlog.String("edition", model.Edition),
-		mlog.String("build_number", model.BuildNumber),
-		mlog.String("build_date", model.BuildDate),
-		mlog.String("build_hash", model.BuildHash),
-	)
-}
-
 func main() {
 	// Command line args
 	pMonitorPid := flag.Int("monitorpid", -1, "a process ID")
@@ -101,7 +91,7 @@ func main() {
 		defer restore()
 	}
 
-	logInfo(logger)
+	model.LogServerInfo(logger)
 
 	singleUser := false
 	if pSingleUser != nil {
@@ -214,7 +204,7 @@ func startServer(webPath string, filesPath string, port int, singleUserToken, db
 		return
 	}
 
-	logInfo(logger)
+	model.LogServerInfo(logger)
 
 	if len(filesPath) > 0 {
 		config.FilesPath = filesPath

--- a/server/model/version.go
+++ b/server/model/version.go
@@ -47,7 +47,7 @@ var (
 )
 
 // LogServerInfo logs information about the server instance.
-func LogServerInfo(logger *mlog.Logger) {
+func LogServerInfo(logger mlog.LoggerIFace) {
 	logger.Info("FocalBoard Server",
 		mlog.String("version", CurrentVersion),
 		mlog.String("edition", Edition),

--- a/server/model/version.go
+++ b/server/model/version.go
@@ -1,5 +1,9 @@
 package model
 
+import (
+	"github.com/mattermost/mattermost-server/v6/shared/mlog"
+)
+
 // This is a list of all the current versions including any patches.
 // It should be maintained in chronological order with most current
 // release at the front of the list.
@@ -41,3 +45,14 @@ var (
 	BuildHash      string
 	Edition        string
 )
+
+// LogServerInfo logs information about the server instance.
+func LogServerInfo(logger *mlog.Logger) {
+	logger.Info("FocalBoard Server",
+		mlog.String("version", CurrentVersion),
+		mlog.String("edition", Edition),
+		mlog.String("build_number", BuildNumber),
+		mlog.String("build_date", BuildDate),
+		mlog.String("build_hash", BuildHash),
+	)
+}


### PR DESCRIPTION
#### Summary
This change prints the same information that the standalone instance does on plugin activation
