### PR TITLE
GH-3589 - Make sure websocket is ready, fix for Cypress failures

### DIFF
--- a/webapp/src/wsclient.ts
+++ b/webapp/src/wsclient.ts
@@ -473,7 +473,7 @@ class WSClient {
     }
 
     hasConn(): boolean {
-        return this.ws !== null || this.client !== null
+        return this.ws?.readyState === 1 || this.client !== null
     }
 
     updateHandler(message: WSMessage): void {


### PR DESCRIPTION
#### Summary

Check that ws is readyState. This will hopefully fix periodic Cypress Test failures. I was not able to reproduce the failures locally to ensure this fixed it.

#### Ticket Link

  Fixes https://github.com/mattermost/focalboard/issues/3589