### PR TITLE
Don't allow changing BoardID when patching blocks

### DIFF
--- a/server/model/block.go
+++ b/server/model/block.go
@@ -94,10 +94,6 @@ type BlockPatch struct {
 	// The block removed fields
 	// required: false
 	DeletedFields []string `json:"deletedFields"`
-
-	// The board id that the block belongs to
-	// required: false
-	BoardID *string `json:"boardId"`
 }
 
 // BlockPatchBatch is a batch of IDs and patches for modify blocks
@@ -147,10 +143,6 @@ func (b Block) LogClone() interface{} {
 func (p *BlockPatch) Patch(block *Block) *Block {
 	if p.ParentID != nil {
 		block.ParentID = *p.ParentID
-	}
-
-	if p.BoardID != nil {
-		block.BoardID = *p.BoardID
 	}
 
 	if p.Schema != nil {

--- a/server/services/store/storetests/blocks.go
+++ b/server/services/store/storetests/blocks.go
@@ -266,20 +266,6 @@ func testPatchBlock(t *testing.T, store store.Store) {
 		require.Len(t, blocks, initialCount)
 	})
 
-	t.Run("invalid rootid", func(t *testing.T) {
-		wrongBoardID := ""
-		blockPatch := model.BlockPatch{
-			BoardID: &wrongBoardID,
-		}
-
-		err := store.PatchBlock("id-test", &blockPatch, "user-id-1")
-		require.Error(t, err)
-
-		blocks, err := store.GetBlocksForBoard(boardID)
-		require.NoError(t, err)
-		require.Len(t, blocks, initialCount)
-	})
-
 	t.Run("invalid fields data", func(t *testing.T) {
 		blockPatch := model.BlockPatch{
 			UpdatedFields: map[string]interface{}{"no-serialiable-value": t.Run},

--- a/webapp/src/blocks/block.ts
+++ b/webapp/src/blocks/block.ts
@@ -13,7 +13,6 @@ type ContentBlockTypes = typeof contentBlockTypes[number]
 type BlockTypes = typeof blockTypes[number]
 
 interface BlockPatch {
-    boardId?: string
     parentId?: string
     schema?: number
     type?: BlockTypes


### PR DESCRIPTION
#### Summary
This PR ensures that blocks cannot change their BoardID when patching.  See https://community.mattermost.com/private-core/pl/m7f7qyd9j7f69qdr1q8zk7jixr  and  https://community.mattermost.com/private-core/pl/1zbd9t8izin4u8t4d8u43ppzsa for rationale.

#### Ticket Link
NONE