### PR TITLE
Add `disable_notify` to all block APIs that can trigger notifications.

### DIFF
--- a/server/api/blocks.go
+++ b/server/api/blocks.go
@@ -190,7 +190,7 @@ func (a *API) handlePostBlocks(w http.ResponseWriter, r *http.Request) {
 	//   type: string
 	// - name: disable_notify
 	//   in: query
-	//   description: Disables notifications (for bulk data inserting)
+	//   description: Disables notifications (for bulk inserting)
 	//   required: false
 	//   type: bool
 	// - name: Body
@@ -289,7 +289,7 @@ func (a *API) handlePostBlocks(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	newBlocks, err := a.app.InsertBlocks(blocks, session.UserID, !disableNotify)
+	newBlocks, err := a.app.InsertBlocksAndNotify(blocks, session.UserID, !disableNotify)
 	if err != nil {
 		if errors.Is(err, app.ErrViewsLimitReached) {
 			a.errorResponse(w, r.URL.Path, http.StatusBadRequest, err.Error(), err)
@@ -336,6 +336,11 @@ func (a *API) handleDeleteBlock(w http.ResponseWriter, r *http.Request) {
 	//   description: ID of block to delete
 	//   required: true
 	//   type: string
+	// - name: disable_notify
+	//   in: query
+	//   description: Disables notifications (for bulk deletion)
+	//   required: false
+	//   type: bool
 	// security:
 	// - BearerAuth: []
 	// responses:
@@ -352,6 +357,9 @@ func (a *API) handleDeleteBlock(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	boardID := vars["boardID"]
 	blockID := vars["blockID"]
+
+	val := r.URL.Query().Get("disable_notify")
+	disableNotify := val == True
 
 	if !a.permissions.HasPermissionToBoard(userID, boardID, model.PermissionManageBoardCards) {
 		a.errorResponse(w, r.URL.Path, http.StatusForbidden, "", PermissionError{"access denied to make board changes"})
@@ -373,7 +381,7 @@ func (a *API) handleDeleteBlock(w http.ResponseWriter, r *http.Request) {
 	auditRec.AddMeta("boardID", boardID)
 	auditRec.AddMeta("blockID", blockID)
 
-	err = a.app.DeleteBlock(blockID, userID)
+	err = a.app.DeleteBlockAndNotify(blockID, userID, disableNotify)
 	if err != nil {
 		a.errorResponse(w, r.URL.Path, http.StatusInternalServerError, "", err)
 		return
@@ -497,6 +505,11 @@ func (a *API) handlePatchBlock(w http.ResponseWriter, r *http.Request) {
 	//   description: ID of block to patch
 	//   required: true
 	//   type: string
+	// - name: disable_notify
+	//   in: query
+	//   description: Disables notifications (for bulk patching)
+	//   required: false
+	//   type: bool
 	// - name: Body
 	//   in: body
 	//   description: block patch to apply
@@ -519,6 +532,9 @@ func (a *API) handlePatchBlock(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	boardID := vars["boardID"]
 	blockID := vars["blockID"]
+
+	val := r.URL.Query().Get("disable_notify")
+	disableNotify := val == True
 
 	if !a.permissions.HasPermissionToBoard(userID, boardID, model.PermissionManageBoardCards) {
 		a.errorResponse(w, r.URL.Path, http.StatusForbidden, "", PermissionError{"access denied to make board changes"})
@@ -553,7 +569,7 @@ func (a *API) handlePatchBlock(w http.ResponseWriter, r *http.Request) {
 	auditRec.AddMeta("boardID", boardID)
 	auditRec.AddMeta("blockID", blockID)
 
-	err = a.app.PatchBlock(blockID, patch, userID)
+	err = a.app.PatchBlockAndNotify(blockID, patch, userID, disableNotify)
 	if errors.Is(err, app.ErrPatchUpdatesLimitedCards) {
 		a.errorResponse(w, r.URL.Path, http.StatusForbidden, "", err)
 		return
@@ -583,6 +599,11 @@ func (a *API) handlePatchBlocks(w http.ResponseWriter, r *http.Request) {
 	//   description: Workspace ID
 	//   required: true
 	//   type: string
+	// - name: disable_notify
+	//   in: query
+	//   description: Disables notifications (for bulk patching)
+	//   required: false
+	//   type: bool
 	// - name: Body
 	//   in: body
 	//   description: block Ids and block patches to apply
@@ -605,6 +626,9 @@ func (a *API) handlePatchBlocks(w http.ResponseWriter, r *http.Request) {
 
 	vars := mux.Vars(r)
 	teamID := vars["teamID"]
+
+	val := r.URL.Query().Get("disable_notify")
+	disableNotify := val == True
 
 	requestBody, err := ioutil.ReadAll(r.Body)
 	if err != nil {
@@ -638,7 +662,7 @@ func (a *API) handlePatchBlocks(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	err = a.app.PatchBlocks(teamID, patches, userID)
+	err = a.app.PatchBlocksAndNotify(teamID, patches, userID, disableNotify)
 	if errors.Is(err, app.ErrPatchUpdatesLimitedCards) {
 		a.errorResponse(w, r.URL.Path, http.StatusForbidden, "", err)
 		return

--- a/server/api/blocks.go
+++ b/server/api/blocks.go
@@ -289,7 +289,7 @@ func (a *API) handlePostBlocks(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	newBlocks, err := a.app.InsertBlocksAndNotify(blocks, session.UserID, !disableNotify)
+	newBlocks, err := a.app.InsertBlocksAndNotify(blocks, session.UserID, disableNotify)
 	if err != nil {
 		if errors.Is(err, app.ErrViewsLimitReached) {
 			a.errorResponse(w, r.URL.Path, http.StatusBadRequest, err.Error(), err)

--- a/server/app/blocks_test.go
+++ b/server/app/blocks_test.go
@@ -287,7 +287,7 @@ func TestInsertBlocks(t *testing.T) {
 		th.Store.EXPECT().GetBoard(boardID).Return(board, nil)
 		th.Store.EXPECT().InsertBlock(&block, "user-id-1").Return(nil)
 		th.Store.EXPECT().GetMembersForBoard(boardID).Return([]*model.BoardMember{}, nil)
-		_, err := th.App.InsertBlocks([]model.Block{block}, "user-id-1", false)
+		_, err := th.App.InsertBlocks([]model.Block{block}, "user-id-1")
 		require.NoError(t, err)
 	})
 
@@ -297,7 +297,7 @@ func TestInsertBlocks(t *testing.T) {
 		board := &model.Board{ID: boardID}
 		th.Store.EXPECT().GetBoard(boardID).Return(board, nil)
 		th.Store.EXPECT().InsertBlock(&block, "user-id-1").Return(blockError{"error"})
-		_, err := th.App.InsertBlocks([]model.Block{block}, "user-id-1", false)
+		_, err := th.App.InsertBlocks([]model.Block{block}, "user-id-1")
 		require.Error(t, err, "error")
 	})
 
@@ -329,7 +329,7 @@ func TestInsertBlocks(t *testing.T) {
 		th.Store.EXPECT().GetCardLimitTimestamp().Return(int64(1), nil)
 		th.Store.EXPECT().GetBlocksWithParentAndType("test-board-id", "parent_id", "view").Return([]model.Block{{}}, nil)
 
-		_, err := th.App.InsertBlocks([]model.Block{block}, "user-id-1", false)
+		_, err := th.App.InsertBlocks([]model.Block{block}, "user-id-1")
 		require.NoError(t, err)
 	})
 
@@ -359,7 +359,7 @@ func TestInsertBlocks(t *testing.T) {
 		th.Store.EXPECT().GetCardLimitTimestamp().Return(int64(1), nil)
 		th.Store.EXPECT().GetBlocksWithParentAndType("test-board-id", "parent_id", "view").Return([]model.Block{{}, {}}, nil)
 
-		_, err := th.App.InsertBlocks([]model.Block{block}, "user-id-1", false)
+		_, err := th.App.InsertBlocks([]model.Block{block}, "user-id-1")
 		require.Error(t, err)
 	})
 
@@ -400,7 +400,7 @@ func TestInsertBlocks(t *testing.T) {
 		th.Store.EXPECT().GetCardLimitTimestamp().Return(int64(1), nil).Times(2)
 		th.Store.EXPECT().GetBlocksWithParentAndType("test-board-id", "parent_id", "view").Return([]model.Block{{}}, nil).Times(2)
 
-		_, err := th.App.InsertBlocks([]model.Block{view1, view2}, "user-id-1", false)
+		_, err := th.App.InsertBlocks([]model.Block{view1, view2}, "user-id-1")
 		require.Error(t, err)
 	})
 }


### PR DESCRIPTION
#### Summary
This PR adds a `disable_notify` for all block APIs that can trigger subscriber notifications.  This allows for external tools using the APIs to make bulk changes without creating a notification storm.  Does not affect websocket notifications so that connected clients remain synchronized.

Part of the API improvement initiative.

#### Ticket Link
NONE