### PR TITLE
Add `disableNotify` param to `client` APIs, to match Rest APIs

### DIFF
--- a/server/client/client.go
+++ b/server/client/client.go
@@ -256,8 +256,12 @@ func (c *Client) GetAllBlocksForBoard(boardID string) ([]model.Block, *Response)
 	return model.BlocksFromJSON(r.Body), BuildResponse(r)
 }
 
-func (c *Client) PatchBlock(boardID, blockID string, blockPatch *model.BlockPatch) (bool, *Response) {
-	r, err := c.DoAPIPatch(c.GetBlockRoute(boardID, blockID), toJSON(blockPatch))
+func (c *Client) PatchBlock(boardID, blockID string, blockPatch *model.BlockPatch, disableNotify bool) (bool, *Response) {
+	var queryParams string
+	if disableNotify {
+		queryParams = "?disable_notify=true"
+	}
+	r, err := c.DoAPIPatch(c.GetBlockRoute(boardID, blockID)+queryParams, toJSON(blockPatch))
 	if err != nil {
 		return false, BuildErrorResponse(r, err)
 	}
@@ -307,8 +311,12 @@ func (c *Client) UndeleteBlock(boardID, blockID string) (bool, *Response) {
 	return true, BuildResponse(r)
 }
 
-func (c *Client) InsertBlocks(boardID string, blocks []model.Block) ([]model.Block, *Response) {
-	r, err := c.DoAPIPost(c.GetBlocksRoute(boardID), toJSON(blocks))
+func (c *Client) InsertBlocks(boardID string, blocks []model.Block, disableNotify bool) ([]model.Block, *Response) {
+	var queryParams string
+	if disableNotify {
+		queryParams = "?disable_notify=true"
+	}
+	r, err := c.DoAPIPost(c.GetBlocksRoute(boardID)+queryParams, toJSON(blocks))
 	if err != nil {
 		return nil, BuildErrorResponse(r, err)
 	}
@@ -317,18 +325,12 @@ func (c *Client) InsertBlocks(boardID string, blocks []model.Block) ([]model.Blo
 	return model.BlocksFromJSON(r.Body), BuildResponse(r)
 }
 
-func (c *Client) InsertBlocksDisableNotify(boardID string, blocks []model.Block) ([]model.Block, *Response) {
-	r, err := c.DoAPIPost(c.GetBlocksRoute(boardID)+"?disable_notify=true", toJSON(blocks))
-	if err != nil {
-		return nil, BuildErrorResponse(r, err)
+func (c *Client) DeleteBlock(boardID, blockID string, disableNotify bool) (bool, *Response) {
+	var queryParams string
+	if disableNotify {
+		queryParams = "?disable_notify=true"
 	}
-	defer closeBody(r)
-
-	return model.BlocksFromJSON(r.Body), BuildResponse(r)
-}
-
-func (c *Client) DeleteBlock(boardID, blockID string) (bool, *Response) {
-	r, err := c.DoAPIDelete(c.GetBlockRoute(boardID, blockID), "")
+	r, err := c.DoAPIDelete(c.GetBlockRoute(boardID, blockID)+queryParams, "")
 	if err != nil {
 		return false, BuildErrorResponse(r, err)
 	}

--- a/server/integrationtests/blocks_test.go
+++ b/server/integrationtests/blocks_test.go
@@ -34,7 +34,7 @@ func TestGetBlocks(t *testing.T) {
 			Type:     model.TypeCard,
 		},
 	}
-	newBlocks, resp := th.Client.InsertBlocks(board.ID, newBlocks)
+	newBlocks, resp := th.Client.InsertBlocks(board.ID, newBlocks, false)
 	require.NoError(t, resp.Error)
 	require.Len(t, newBlocks, 2)
 	blockID1 := newBlocks[0].ID
@@ -73,7 +73,7 @@ func TestPostBlock(t *testing.T) {
 			Title:    "New title",
 		}
 
-		newBlocks, resp := th.Client.InsertBlocks(board.ID, []model.Block{block})
+		newBlocks, resp := th.Client.InsertBlocks(board.ID, []model.Block{block}, false)
 		require.NoError(t, resp.Error)
 		require.Len(t, newBlocks, 1)
 		blockID1 = newBlocks[0].ID
@@ -109,7 +109,7 @@ func TestPostBlock(t *testing.T) {
 			},
 		}
 
-		newBlocks, resp := th.Client.InsertBlocks(board.ID, newBlocks)
+		newBlocks, resp := th.Client.InsertBlocks(board.ID, newBlocks, false)
 		require.NoError(t, resp.Error)
 		require.Len(t, newBlocks, 2)
 		blockID2 = newBlocks[0].ID
@@ -140,7 +140,7 @@ func TestPostBlock(t *testing.T) {
 			Title:    "Updated title",
 		}
 
-		newBlocks, resp := th.Client.InsertBlocks(board.ID, []model.Block{block})
+		newBlocks, resp := th.Client.InsertBlocks(board.ID, []model.Block{block}, false)
 		require.NoError(t, resp.Error)
 		require.Len(t, newBlocks, 1)
 		blockID4 := newBlocks[0].ID
@@ -180,7 +180,7 @@ func TestPatchBlock(t *testing.T) {
 		Fields:   map[string]interface{}{"test": "test value", "test2": "test value 2"},
 	}
 
-	newBlocks, resp := th.Client.InsertBlocks(board.ID, []model.Block{block})
+	newBlocks, resp := th.Client.InsertBlocks(board.ID, []model.Block{block}, false)
 	th.CheckOK(resp)
 	require.Len(t, newBlocks, 1)
 	blockID := newBlocks[0].ID
@@ -191,7 +191,7 @@ func TestPatchBlock(t *testing.T) {
 			Title: &newTitle,
 		}
 
-		_, resp := th.Client.PatchBlock(board.ID, blockID, blockPatch)
+		_, resp := th.Client.PatchBlock(board.ID, blockID, blockPatch, false)
 		require.NoError(t, resp.Error)
 
 		blocks, resp := th.Client.GetBlocksForBoard(board.ID)
@@ -216,7 +216,7 @@ func TestPatchBlock(t *testing.T) {
 			},
 		}
 
-		_, resp := th.Client.PatchBlock(board.ID, blockID, blockPatch)
+		_, resp := th.Client.PatchBlock(board.ID, blockID, blockPatch, false)
 		require.NoError(t, resp.Error)
 
 		blocks, resp := th.Client.GetBlocksForBoard(board.ID)
@@ -239,7 +239,7 @@ func TestPatchBlock(t *testing.T) {
 			DeletedFields: []string{"test", "test3", "test100"},
 		}
 
-		_, resp := th.Client.PatchBlock(board.ID, blockID, blockPatch)
+		_, resp := th.Client.PatchBlock(board.ID, blockID, blockPatch, false)
 		require.NoError(t, resp.Error)
 
 		blocks, resp := th.Client.GetBlocksForBoard(board.ID)
@@ -278,7 +278,7 @@ func TestDeleteBlock(t *testing.T) {
 			Title:    "New title",
 		}
 
-		newBlocks, resp := th.Client.InsertBlocks(board.ID, []model.Block{block})
+		newBlocks, resp := th.Client.InsertBlocks(board.ID, []model.Block{block}, false)
 		require.NoError(t, resp.Error)
 		require.Len(t, newBlocks, 1)
 		require.NotZero(t, newBlocks[0].ID)
@@ -301,7 +301,7 @@ func TestDeleteBlock(t *testing.T) {
 		// id,insert_at on block history
 		time.Sleep(10 * time.Millisecond)
 
-		_, resp := th.Client.DeleteBlock(board.ID, blockID)
+		_, resp := th.Client.DeleteBlock(board.ID, blockID, false)
 		require.NoError(t, resp.Error)
 
 		blocks, resp := th.Client.GetBlocksForBoard(board.ID)
@@ -332,7 +332,7 @@ func TestUndeleteBlock(t *testing.T) {
 			Title:    "New title",
 		}
 
-		newBlocks, resp := th.Client.InsertBlocks(board.ID, []model.Block{block})
+		newBlocks, resp := th.Client.InsertBlocks(board.ID, []model.Block{block}, false)
 		require.NoError(t, resp.Error)
 		require.Len(t, newBlocks, 1)
 		require.NotZero(t, newBlocks[0].ID)
@@ -355,7 +355,7 @@ func TestUndeleteBlock(t *testing.T) {
 		// id,insert_at on block history
 		time.Sleep(10 * time.Millisecond)
 
-		_, resp := th.Client.DeleteBlock(board.ID, blockID)
+		_, resp := th.Client.DeleteBlock(board.ID, blockID, false)
 		require.NoError(t, resp.Error)
 
 		blocks, resp := th.Client.GetBlocksForBoard(board.ID)
@@ -381,7 +381,7 @@ func TestUndeleteBlock(t *testing.T) {
 		// id,insert_at on block history
 		time.Sleep(10 * time.Millisecond)
 
-		_, resp := th.Client.DeleteBlock(board.ID, blockID)
+		_, resp := th.Client.DeleteBlock(board.ID, blockID, false)
 		require.NoError(t, resp.Error)
 
 		_, resp = th.Client2.UndeleteBlock(board.ID, blockID)

--- a/server/integrationtests/board_test.go
+++ b/server/integrationtests/board_test.go
@@ -450,7 +450,7 @@ func TestGetAllBlocksForBoard(t *testing.T) {
 			},
 		}
 
-		insertedBlocks, resp := th.Client.InsertBlocks(board.ID, newBlocks)
+		insertedBlocks, resp := th.Client.InsertBlocks(board.ID, newBlocks, false)
 		require.NoError(t, resp.Error)
 		require.Len(t, insertedBlocks, len(newBlocks))
 
@@ -1905,7 +1905,7 @@ func TestDuplicateBoard(t *testing.T) {
 			},
 		}
 
-		newBlocks, resp = th.Client.InsertBlocks(board.ID, newBlocks)
+		newBlocks, resp = th.Client.InsertBlocks(board.ID, newBlocks, false)
 		require.NoError(t, resp.Error)
 		require.Len(t, newBlocks, 1)
 
@@ -1990,7 +1990,7 @@ func TestDuplicateBoard(t *testing.T) {
 			},
 		}
 
-		newBlocks, resp = th.Client.InsertBlocks(board.ID, newBlocks)
+		newBlocks, resp = th.Client.InsertBlocks(board.ID, newBlocks, false)
 		require.NoError(t, resp.Error)
 		require.Len(t, newBlocks, 1)
 

--- a/server/integrationtests/subscriptions_test.go
+++ b/server/integrationtests/subscriptions_test.go
@@ -39,7 +39,7 @@ func createTestSubscriptions(client *client.Client, num int) ([]*model.Subscript
 			Type:     model.TypeCard,
 		}
 
-		newBlocks, resp := client.InsertBlocks(board.ID, []model.Block{newBlock})
+		newBlocks, resp := client.InsertBlocks(board.ID, []model.Block{newBlock}, false)
 		if resp.Error != nil {
 			return nil, "", fmt.Errorf("cannot insert test card block: %w", resp.Error)
 		}


### PR DESCRIPTION
#### Summary
This PR adds the same `disableNotify` param to `client` APIs that was added to Rest APIs via https://github.com/mattermost/focalboard/pull/3720

#### Ticket Link
NONE