### PR TITLE
Exclude exhaustive check for product services switch

### DIFF
--- a/mattermost-plugin/product/boards_product.go
+++ b/mattermost-plugin/product/boards_product.go
@@ -70,7 +70,7 @@ type boardsProduct struct {
 	boardsApp *boards.BoardsApp
 }
 
-//nolint:gocyclo
+//nolint:gocyclo,exhaustive
 func newBoardsProduct(_ *app.Server, services map[app.ServiceKey]interface{}) (app.Product, error) {
 	boards := &boardsProduct{}
 


### PR DESCRIPTION
#### Summary
When adding a product service to mmserver it causes a switch statement in Boards to have an incomplete set of case statements until an accompanying PR is made to Boards.  This PR relaxes that exhaustive check for the specific switch statement, otherwise anytime a new service is added to mmserver it will break Boards until the accompanying PR is merged.

#### Ticket Link
NONE