### PR TITLE
Updates db indexes to improve performance

### DIFF
--- a/server/services/store/sqlstore/migrations/000025_indexes_update.down.sql
+++ b/server/services/store/sqlstore/migrations/000025_indexes_update.down.sql
@@ -1,0 +1,39 @@
+DROP INDEX idx_subscriptions_subscriber_id ON {{.prefix}}subscriptions;
+DROP INDEX idx_blocks_board_id_parent_id ON {{.prefix}}blocks;
+
+{{if .mysql}}
+ALTER TABLE {{.prefix}}blocks DROP PRIMARY KEY;
+ALTER TABLE {{.prefix}}blocks ADD PRIMARY KEY (channel_id, id);
+{{end}}
+
+{{if .postgres}}
+ALTER TABLE {{.prefix}}blocks DROP CONSTRAINT {{.prefix}}blocks_pkey1;
+ALTER TABLE {{.prefix}}blocks ADD PRIMARY KEY (channel_id, id);
+{{end}}
+
+{{if .sqlite}}
+ALTER TABLE {{.prefix}}blocks RENAME TO {{.prefix}}blocks_tmp;
+
+CREATE TABLE {{.prefix}}blocks (
+        id VARCHAR(36),
+        insert_at DATETIME NOT NULL DEFAULT(STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW')),
+        parent_id VARCHAR(36),
+        schema BIGINT,
+        type TEXT,
+        title TEXT,
+        fields TEXT,
+        create_at BIGINT,
+        update_at BIGINT,
+        delete_at BIGINT,
+        root_id VARCHAR(36),
+        modified_by VARCHAR(36),
+        channel_id VARCHAR(36),
+        created_by VARCHAR(36),
+        board_id VARCHAR(36),
+        PRIMARY KEY (channel_id, id)
+);
+
+INSERT INTO {{.prefix}}blocks SELECT * FROM {{.prefix}}blocks_tmp;
+
+DROP TABLE {{.prefix}}blocks_tmp;
+{{end}}

--- a/server/services/store/sqlstore/migrations/000025_indexes_update.up.sql
+++ b/server/services/store/sqlstore/migrations/000025_indexes_update.up.sql
@@ -1,0 +1,44 @@
+{{- /* delete old blocks PK and add id as the new one */ -}}
+{{if .mysql}}
+ALTER TABLE {{.prefix}}blocks DROP PRIMARY KEY;
+ALTER TABLE {{.prefix}}blocks ADD PRIMARY KEY (id);
+{{end}}
+
+{{if .postgres}}
+ALTER TABLE {{.prefix}}blocks DROP CONSTRAINT {{.prefix}}blocks_pkey1;
+ALTER TABLE {{.prefix}}blocks ADD PRIMARY KEY (id);
+{{end}}
+
+{{- /* there is no way for SQLite to update the PK or add a unique constraint */ -}}
+{{if .sqlite}}
+ALTER TABLE {{.prefix}}blocks RENAME TO {{.prefix}}blocks_tmp;
+
+CREATE TABLE {{.prefix}}blocks (
+        id VARCHAR(36),
+        insert_at DATETIME NOT NULL DEFAULT(STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW')),
+        parent_id VARCHAR(36),
+        schema BIGINT,
+        type TEXT,
+        title TEXT,
+        fields TEXT,
+        create_at BIGINT,
+        update_at BIGINT,
+        delete_at BIGINT,
+        root_id VARCHAR(36),
+        modified_by VARCHAR(36),
+        channel_id VARCHAR(36),
+        created_by VARCHAR(36),
+        board_id VARCHAR(36),
+        PRIMARY KEY (id)
+);
+
+INSERT INTO {{.prefix}}blocks SELECT * FROM {{.prefix}}blocks_tmp;
+
+DROP TABLE {{.prefix}}blocks_tmp;
+{{end}}
+
+{{- /* most block searches use board_id or a combination of board and parent ids */ -}}
+CREATE INDEX idx_blocks_board_id_parent_id ON {{.prefix}}blocks (board_id, parent_id);
+
+{{- /* get subscriptions is used once per board page load */ -}}
+CREATE INDEX idx_subscriptions_subscriber_id ON {{.prefix}}subscriptions (subscriber_id);

--- a/server/services/store/storetests/blocks.go
+++ b/server/services/store/storetests/blocks.go
@@ -984,12 +984,12 @@ func testGetBlockMetadata(t *testing.T, store store.Store) {
 	})
 
 	t.Run("get block history before updateAt", func(t *testing.T) {
-		rBlocks, err2 := store.GetBlocksWithType(boardID, "test")
+		rBlock, err2 := store.GetBlock("block3")
 		require.NoError(t, err2)
-		require.NotZero(t, rBlocks[2].UpdateAt)
+		require.NotZero(t, rBlock.UpdateAt)
 
 		opts := model.QueryBlockHistoryOptions{
-			BeforeUpdateAt: rBlocks[2].UpdateAt,
+			BeforeUpdateAt: rBlock.UpdateAt,
 			Descending:     true,
 		}
 		blocks, err = store.GetBlockHistoryDescendants(boardID, opts)

--- a/server/services/store/storetests/blocks.go
+++ b/server/services/store/storetests/blocks.go
@@ -966,12 +966,12 @@ func testGetBlockMetadata(t *testing.T, store store.Store) {
 	})
 
 	t.Run("get block history after updateAt", func(t *testing.T) {
-		rBlocks, err2 := store.GetBlocksWithType(boardID, "test")
+		rBlock, err2 := store.GetBlock("block3")
 		require.NoError(t, err2)
-		require.NotZero(t, rBlocks[2].UpdateAt)
+		require.NotZero(t, rBlock.UpdateAt)
 
 		opts := model.QueryBlockHistoryOptions{
-			AfterUpdateAt: rBlocks[2].UpdateAt,
+			AfterUpdateAt: rBlock.UpdateAt,
 			Descending:    false,
 		}
 		blocks, err = store.GetBlockHistoryDescendants(boardID, opts)


### PR DESCRIPTION
#### Summary
This changes update and add some focalboard indexes to improve data access speed. The rationale for the changes is as follows:

- `focalboard_blocks (channel_id, id)` was not in use at all after the permission changes, so it doesn't make sense to keep as the PK of the table.
- `focalboard_blocks (id)` makes sense now as a PK, and improves:
  - `getBlocksByIDs` (MySQL 0.215 => 0.001 | PostgreSQL 87.063 ms => 0.082 ms)
- `idx_blocks_board_id_parent_id` improves:
  - `getWithParentAndType` (MySQL 0.197 => 0.001 | PostgreSQL 81.356 ms => 0.068 ms)
  - `getBlocksWithParent` (MySQL 0.195 => 0.001 | PostgreSQL 93.420 ms => 0.055 ms)
  - `getSubTree2` (MySQL 0.162 => 0.001 | PostgreSQL 88.920 ms => 0.092 ms)
  - `getBlocksWithType` (MySQL 0.215 => 0.003 | PostgreSQL 84.725 ms => 0.055 ms)
  - `getBlocksForBoard` (MySQL 0.194 => 0.001 | PostgreSQL 85.891 ms => 0.058 ms)
- `idx_subscriptions_subscriber_id` covers subscription fetching for a given user, which is run once per board load on an otherwise full scan of the table:
  - `getSubscriptions` (MySQL 0.023 => 0.001 | PostgreSQL 14,559 ms => 1.838 ms)

These tests have been run in plugin mode, on the following datasets:
- MySQL
  - Boards: 74827
  - Blocks: 299446
  - Users: 301
  - Subscriptions: 74790

- PostgreSQL
  - Boards: 145411
  - Blocks: 582028
  - Users: 982
  - Subscriptions: 145404

And the time the indexes took to apply was of 13.2615s for MySQL and 3.3575s for PostgreSQL.

#### Card Link
https://community.mattermost.com/boards/team/qghzt68dq7bopgqamcnziq69ao/b4ctmm917q3rzdfi451qtuxjzcw/612a901f-5c6d-4dde-8e35-3c16b6024a67/c94wm8nfiftfbbng3ni6dpb971a