### PR TITLE
GH-3293 - Fix issue with deleted members not being updated via websocket

### DIFF
--- a/webapp/src/store/boards.ts
+++ b/webapp/src/store/boards.ts
@@ -71,17 +71,17 @@ export const updateMembersEnsuringBoardsAndUsers = createAsyncThunk(
         // ensure the users for the new memberships get loaded
         const boardUsers = thunkAPI.getState().users.boardUsers
         members.forEach(async (m) => {
+            const deleted = !m.schemeAdmin && !m.schemeEditor && !m.schemeViewer && !m.schemeCommenter
+            if (deleted) {
+                thunkAPI.dispatch(removeBoardUsersById([m.userId]))
+                return
+            }
             if (boardUsers[m.userId]) {
                 return
             }
             const user = await client.getUser(m.userId)
             if (user) {
-                const deleted = !m.schemeAdmin && !m.schemeEditor && !m.schemeViewer && !m.schemeCommenter
-                if (deleted) {
-                    thunkAPI.dispatch(removeBoardUsersById([user.id]))
-                } else {
-                    thunkAPI.dispatch(addBoardUsers([user]))
-                }
+                thunkAPI.dispatch(addBoardUsers([user]))
             }
         })
 


### PR DESCRIPTION

#### Summary
Separated logic to handle deleted members before handling adding members. Previously deleted items would return prematurely because they already existed in `boardUsers`.

#### Ticket Link
  Fixes https://github.com/mattermost/focalboard/issues/3293
