### PR TITLE
Added functionality to close boardSelector after linking board

### DIFF
--- a/mattermost-plugin/webapp/src/components/boardSelector.tsx
+++ b/mattermost-plugin/webapp/src/components/boardSelector.tsx
@@ -100,6 +100,10 @@ const BoardSelector = () => {
         const newBoard = createBoard({...board, channelId: currentChannel})
         await mutator.updateBoard(newBoard, board, 'linked channel')
         setShowLinkBoardConfirmation(null)
+        dispatch(setLinkToChannel(''))
+        setResults([])
+        setIsSearching(false)
+        setSearchQuery('')
     }
 
     const unlinkBoard = async (board: Board): Promise<void> => {


### PR DESCRIPTION

#### Summary
This PR will add the functionality to close the boardSelector from the channel's RHS after selecting the board.
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the ticket).
-->

#### Ticket Link
Fixes https://github.com/mattermost/focalboard/issues/3679
<!--
If this pull request addresses a Github issue, please link the relevant issue, e.g.

  Fixes https://github.com/mattermost/focalboard/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
