### PR TITLE
Fix @-mentions in boards & for guests

### DIFF
--- a/server/services/store/mattermostauthlayer/mattermostauthlayer.go
+++ b/server/services/store/mattermostauthlayer/mattermostauthlayer.go
@@ -380,8 +380,8 @@ func (s *MattermostAuthLayer) SearchUsersByTeam(teamID string, searchQuery strin
 			boardsIDs = append(boardsIDs, board.ID)
 		}
 		query = query.
-			Join(s.tablePrefix + "board_members as bm ON bm.UserID = u.ID").
-			Where(sq.Eq{"bm.BoardId": boardsIDs})
+			Join(s.tablePrefix + "board_members as bm ON bm.user_id = u.ID").
+			Where(sq.Eq{"bm.board_id": boardsIDs})
 	}
 
 	rows, err := query.Query()

--- a/server/services/store/mattermostauthlayer/mattermostauthlayer.go
+++ b/server/services/store/mattermostauthlayer/mattermostauthlayer.go
@@ -860,11 +860,19 @@ func (s *MattermostAuthLayer) GetBoardsForUserAndTeam(userID, teamID string, inc
 		return nil, err
 	}
 
-	// TODO: Handle the includePublicBoards
-
 	boardIDs := []string{}
 	for _, m := range members {
 		boardIDs = append(boardIDs, m.BoardID)
+	}
+
+	if includePublicBoards {
+		boards, err := s.SearchBoardsForUserInTeam(teamID, "", userID)
+		if err != nil {
+			return nil, err
+		}
+		for _, b := range boards {
+			boardIDs = append(boardIDs, b.ID)
+		}
 	}
 
 	boards, err := s.Store.GetBoardsInTeamByIds(boardIDs, teamID)

--- a/server/services/store/mattermostauthlayer/mattermostauthlayer.go
+++ b/server/services/store/mattermostauthlayer/mattermostauthlayer.go
@@ -866,7 +866,8 @@ func (s *MattermostAuthLayer) GetBoardsForUserAndTeam(userID, teamID string, inc
 	}
 
 	if includePublicBoards {
-		boards, err := s.SearchBoardsForUserInTeam(teamID, "", userID)
+		var boards []*model.Board
+		boards, err = s.SearchBoardsForUserInTeam(teamID, "", userID)
 		if err != nil {
 			return nil, err
 		}

--- a/webapp/src/components/markdownEditorInput/markdownEditorInput.tsx
+++ b/webapp/src/components/markdownEditorInput/markdownEditorInput.tsx
@@ -16,7 +16,7 @@ import {debounce} from "lodash"
 
 import {useAppSelector} from '../../store/hooks'
 import {IUser} from '../../user'
-import {getBoardUsersList} from '../../store/users'
+import {getBoardUsersList, getMe} from '../../store/users'
 import createLiveMarkdownPlugin from '../live-markdown-plugin/liveMarkdownPlugin'
 
 import './markdownEditorInput.scss'
@@ -56,13 +56,14 @@ const MarkdownEditorInput = (props: Props): ReactElement => {
     const board = useAppSelector(getCurrentBoard)
     const clientConfig = useAppSelector<ClientConfig>(getClientConfig)
     const ref = useRef<Editor>(null)
+    const me = useAppSelector<IUser|null>(getMe)
 
     const [suggestions, setSuggestions] = useState<Array<MentionUser>>([])
 
     const loadSuggestions = async (term: string) => {
         let users: Array<IUser>
 
-        if (board && board.type === BoardTypeOpen) {
+        if (!me?.is_guest && (board && board.type === BoardTypeOpen)) {
             users = await octoClient.searchTeamUsers(term)
         } else {
             users = boardUsers

--- a/webapp/src/components/markdownEditorInput/markdownEditorInput.tsx
+++ b/webapp/src/components/markdownEditorInput/markdownEditorInput.tsx
@@ -37,6 +37,7 @@ type MentionUser = {
     name: string
     avatar: string
     is_bot: boolean
+    is_guest: boolean
     displayName: string
 }
 
@@ -65,10 +66,18 @@ const MarkdownEditorInput = (props: Props): ReactElement => {
             users = await octoClient.searchTeamUsers(term)
         } else {
             users = boardUsers
+                .filter(user => {
+                    // no search term
+                    if (!term) return true
+                    // does the search term occur anywhere in the display name?
+                    return Utils.getUserDisplayName(user, clientConfig.teammateNameDisplay).includes(term)
+                })
+                // first 10 results
+                .slice(0, 10)
         }
 
-        const mentions = users.map(
-            (user) => ({
+        const mentions: Array<MentionUser> = users.map(
+            (user: IUser): MentionUser => ({
                 name: user.username,
                 avatar: `${imageURLForUser ? imageURLForUser(user.id) : ''}`,
                 is_bot: user.is_bot,


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute

Assign two reviewers for this pull request from the names suggested. If no names are suggested or you are not sure who to assign, set `Core Focalboard` as the reviewer.
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the ticket).
-->
Fixing bugs related to `@mention`s and Guest accounts:
- filter the in-memory board users list for private boards (where the Redux state is used, no API calls)
- fix in an invalid DB query for searching users as a guest
- handle `includePublicBoards` when getting boards for a user & team
- don't use the API search for users when `@mention`ing as a guest

#### Ticket Link
<!--
If this pull request addresses a Github issue, please link the relevant issue, e.g.

  Fixes https://github.com/mattermost/focalboard/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
closes #2604 

cc @wuwinson @jespino this should handle #3746 as-is too (intentionally not using a closing keyword there 🙂)
