### PR TITLE
Adds enablePublicSharedBoards to config.json

### DIFF
--- a/docker/config.json
+++ b/docker/config.json
@@ -13,5 +13,6 @@
     "session_refresh_time": 18000,
     "localOnly": false,
     "enableLocalMode": true,
+    "enablePublicSharedBoards": true,
     "localModeSocketLocation": "/var/tmp/focalboard_local.socket"
 }

--- a/docker/config.json
+++ b/docker/config.json
@@ -13,6 +13,6 @@
     "session_refresh_time": 18000,
     "localOnly": false,
     "enableLocalMode": true,
-    "enablePublicSharedBoards": true,
+    "enablePublicSharedBoards": false,
     "localModeSocketLocation": "/var/tmp/focalboard_local.socket"
 }


### PR DESCRIPTION

This [PR]( https://github.com/mattermost/focalboard/pull/3441) was approved, but the commonly used `docker compose` files where missed.

This PR adds the `enablePublicSharedBoards` flag into the config file for consistency; hopefully users like me aren't questioning their sanity when trying to stand this up and test it for the first time 😉 
