### PR TITLE
Fix migration 27 and update boards_migrator_test to support sqlite

### DIFF
--- a/server/services/store/sqlstore/migrations/000027_migrate_user_props_to_preferences.up.sql
+++ b/server/services/store/sqlstore/migrations/000027_migrate_user_props_to_preferences.up.sql
@@ -38,15 +38,15 @@
         UPDATE {{.prefix}}users SET props = (props::jsonb - 'focalboard_welcomePageViewed' - 'hiddenBoardIDs' - 'focalboard_tourCategory' - 'focalboard_onboardingTourStep' - 'focalboard_onboardingTourStarted' - 'focalboard_version72MessageCanceled' - 'focalboard_lastWelcomeVersion')::json;
 
     {{else}}
-            {{- /* Surprisingly SQLite and MySQL have same JSON functions and syntax! */ -}}
+        {{- /* Surprisingly SQLite and MySQL have same JSON functions and syntax! */ -}}
 
         INSERT INTO {{.prefix}}preferences (UserId, Category, Name, Value) SELECT Id, 'focalboard', 'welcomePageViewed', replace(JSON_EXTRACT(Props, '$."focalboard_welcomePageViewed"'), '"', '') from {{.prefix}}users WHERE JSON_EXTRACT(Props, '$.focalboard_welcomePageViewed') IS NOT NULL;
-        INSERT INTO {{.prefix}}preferences (UserId, Category, Name, Value) SELECT Id, 'focalboard', 'hiddenBoardIDs', replace(replace(replace(JSON_EXTRACT(Props, '$."hiddenBoardIDs'), '"[', '['), ']"', ']'), '\\"', '"') from {{.prefix}}users WHERE JSON_EXTRACT(Props, '$.hiddenBoardIDs') IS NOT NULL;
+        INSERT INTO {{.prefix}}preferences (UserId, Category, Name, Value) SELECT Id, 'focalboard', 'hiddenBoardIDs', replace(replace(replace(JSON_EXTRACT(Props, '$."hiddenBoardIDs"'), '"[', '['), ']"', ']'), '\\"', '"') from {{.prefix}}users WHERE JSON_EXTRACT(Props, '$.hiddenBoardIDs') IS NOT NULL;
         INSERT INTO {{.prefix}}preferences (UserId, Category, Name, Value) SELECT Id, 'focalboard', 'tourCategory', replace(JSON_EXTRACT(Props, '$."focalboard_tourCategory"'), '"', '') from {{.prefix}}users WHERE JSON_EXTRACT(Props, '$.focalboard_tourCategory') IS NOT NULL;
         INSERT INTO {{.prefix}}preferences (UserId, Category, Name, Value) SELECT Id, 'focalboard', 'onboardingTourStep', replace(JSON_EXTRACT(Props, '$."focalboard_onboardingTourStep"'), '"', '') from {{.prefix}}users WHERE JSON_EXTRACT(Props, '$.focalboard_onboardingTourStep') IS NOT NULL;
         INSERT INTO {{.prefix}}preferences (UserId, Category, Name, Value) SELECT Id, 'focalboard', 'onboardingTourStarted', replace(JSON_EXTRACT(Props, '$."focalboard_onboardingTourStarted"'), '"', '') from {{.prefix}}users WHERE JSON_EXTRACT(Props, '$.focalboard_onboardingTourStarted') IS NOT NULL;
         INSERT INTO {{.prefix}}preferences (UserId, Category, Name, Value) SELECT Id, 'focalboard', 'version72MessageCanceled', replace(JSON_EXTRACT(Props, '$."focalboard_version72MessageCanceled"'), '"', '') from {{.prefix}}users WHERE JSON_EXTRACT(Props, '$.focalboard_version72MessageCanceled') IS NOT NULL;
-        INSERT INTO {{.prefix}}preferences (UserId, Category, Name, Value) SELECT Id, 'focalboard', 'lastWelcomeVersion', replace(JSON_EXTRACT(Props, 'focalboard_lastWelcomeVersion"'), '"', '') from {{.prefix}}users WHERE JSON_EXTRACT(Props, '$.focalboard_lastWelcomeVersion') IS NOT NULL;
+        INSERT INTO {{.prefix}}preferences (UserId, Category, Name, Value) SELECT Id, 'focalboard', 'lastWelcomeVersion', replace(JSON_EXTRACT(Props, '$."focalboard_lastWelcomeVersion"'), '"', '') from {{.prefix}}users WHERE JSON_EXTRACT(Props, '$.focalboard_lastWelcomeVersion') IS NOT NULL;
 
         UPDATE {{.prefix}}users SET Props =  JSON_REMOVE(Props, '$."focalboard_welcomePageViewed"', '$."hiddenBoardIDs"', '$."focalboard_tourCategory"', '$."focalboard_onboardingTourStep"', '$."focalboard_onboardingTourStarted"', '$."focalboard_version72MessageCanceled"', '$."focalboard_lastWelcomeVersion"');
     {{end}}

--- a/server/services/store/sqlstore/migrationstests/fixtures/test27MigrateUserPropsToPreferences.sql
+++ b/server/services/store/sqlstore/migrationstests/fixtures/test27MigrateUserPropsToPreferences.sql
@@ -1,0 +1,4 @@
+INSERT INTO focalboard_users
+(id, username, props)
+VALUES
+('user-id', 'johndoe', '{"focalboard_welcomePageViewed": true, "hiddenBoardIDs": ["board1", "board2"], "focalboard_tourCategory": "onboarding", "focalboard_onboardingTourStep": 1, "focalboard_onboardingTourStarted": true, "focalboard_version72MessageCanceled": true, "focalboard_lastWelcomeVersion": 7}');

--- a/server/services/store/sqlstore/migrationstests/migration_27_test.go
+++ b/server/services/store/sqlstore/migrationstests/migration_27_test.go
@@ -15,6 +15,10 @@ func Test27MigrateUserPropsToPreferences(t *testing.T) {
 		th.f.MigrateToStep(26).
 			ExecFile("./fixtures/test27MigrateUserPropsToPreferences.sql")
 
+		// first we check that the data was correctly loaded from the
+		// fixtures. We could perfectly skip this step, but as the
+		// failing data is in a JSON field, I preferred to leave it
+		// for clarity
 		user := struct {
 			ID       string
 			Username string
@@ -42,8 +46,10 @@ func Test27MigrateUserPropsToPreferences(t *testing.T) {
 		require.Contains(t, userProps, "focalboard_lastWelcomeVersion")
 		require.Equal(t, float64(7), userProps["focalboard_lastWelcomeVersion"])
 
+		// we apply the migration
 		th.f.MigrateToStep(27)
 
+		// then we load the preferences on a new struct
 		userPreferences := []struct {
 			Name  string
 			Value string
@@ -64,7 +70,11 @@ func Test27MigrateUserPropsToPreferences(t *testing.T) {
 			return "this should never be reached"
 		}
 
+		// and we check that the values are correct
 		welcomePageViewedValue := getValue("welcomePageViewed")
+		// the checks for true or 1 make the test work for all DBs,
+		// that were representing the boolean values in the JSON
+		// struct in different ways
 		require.True(t, welcomePageViewedValue == "true" || welcomePageViewedValue == "1")
 
 		hiddenBoardIDsValue := getValue("hiddenBoardIDs")

--- a/server/services/store/sqlstore/migrationstests/migration_27_test.go
+++ b/server/services/store/sqlstore/migrationstests/migration_27_test.go
@@ -1,0 +1,87 @@
+package migrationstests
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test27MigrateUserPropsToPreferences(t *testing.T) {
+	t.Run("should correctly migrate properties on personal server and desktop", func(t *testing.T) {
+		th, tearDown := SetupTestHelper(t)
+		defer tearDown()
+
+		th.f.MigrateToStep(26).
+			ExecFile("./fixtures/test27MigrateUserPropsToPreferences.sql")
+
+		user := struct {
+			ID       string
+			Username string
+			Props    string
+		}{}
+
+		err := th.f.DB().Get(&user, "SELECT id, username, props FROM focalboard_users WHERE id = 'user-id'")
+		require.NoError(t, err)
+		userProps := map[string]any{}
+		require.NoError(t, json.Unmarshal([]byte(user.Props), &userProps))
+
+		require.Equal(t, "johndoe", user.Username)
+		require.Contains(t, userProps, "focalboard_welcomePageViewed")
+		require.True(t, userProps["focalboard_welcomePageViewed"].(bool))
+		require.Contains(t, userProps, "hiddenBoardIDs")
+		require.ElementsMatch(t, []string{"board1", "board2"}, userProps["hiddenBoardIDs"])
+		require.Contains(t, userProps, "focalboard_tourCategory")
+		require.Equal(t, "onboarding", userProps["focalboard_tourCategory"])
+		require.Contains(t, userProps, "focalboard_onboardingTourStep")
+		require.Equal(t, float64(1), userProps["focalboard_onboardingTourStep"])
+		require.Contains(t, userProps, "focalboard_onboardingTourStarted")
+		require.True(t, userProps["focalboard_onboardingTourStarted"].(bool))
+		require.Contains(t, userProps, "focalboard_version72MessageCanceled")
+		require.True(t, userProps["focalboard_version72MessageCanceled"].(bool))
+		require.Contains(t, userProps, "focalboard_lastWelcomeVersion")
+		require.Equal(t, float64(7), userProps["focalboard_lastWelcomeVersion"])
+
+		th.f.MigrateToStep(27)
+
+		userPreferences := []struct {
+			Name  string
+			Value string
+		}{}
+
+		nErr := th.f.DB().Select(&userPreferences, "SELECT name, value FROM focalboard_preferences WHERE UserId = 'user-id'")
+		require.NoError(t, nErr)
+
+		// helper function to quickly get a preference value from the
+		// userPreferences slice
+		getValue := func(name string) string {
+			for _, userPreference := range userPreferences {
+				if userPreference.Name == name {
+					return userPreference.Value
+				}
+			}
+			require.FailNow(t, "could not found preference", "while searching for name %q", name)
+			return "this should never be reached"
+		}
+
+		welcomePageViewedValue := getValue("welcomePageViewed")
+		require.True(t, welcomePageViewedValue == "true" || welcomePageViewedValue == "1")
+
+		hiddenBoardIDsValue := getValue("hiddenBoardIDs")
+		require.Contains(t, hiddenBoardIDsValue, "board1")
+		require.Contains(t, hiddenBoardIDsValue, "board2")
+
+		require.Equal(t, "onboarding", getValue("tourCategory"))
+
+		onboardingTourStepValue := getValue("onboardingTourStep")
+		require.True(t, onboardingTourStepValue == "true" || onboardingTourStepValue == "1")
+
+		onboardingTourStartedValue := getValue("onboardingTourStarted")
+		require.True(t, onboardingTourStartedValue == "true" || onboardingTourStartedValue == "1")
+
+		version72MessageCanceledValue := getValue("version72MessageCanceled")
+		require.True(t, version72MessageCanceledValue == "true" || version72MessageCanceledValue == "1")
+
+		require.Equal(t, "7", getValue("lastWelcomeVersion"))
+	})
+}


### PR DESCRIPTION
#### Summary
This PR fixes migration 27, adds a test for the fix and the personal server/desktop migration and modifies the testing mechanism to correctly support SQLite