### PR TITLE
GH-3768 - Search icon fix

### DIFF
--- a/mattermost-plugin/server/manifest.go
+++ b/mattermost-plugin/server/manifest.go
@@ -45,8 +45,7 @@ const manifestStr = `
         "type": "bool",
         "help_text": "This allows board editors to share boards that can be accessed by anyone with the link.",
         "placeholder": "",
-        "default": false,
-        "hosting": ""
+        "default": false
       }
     ]
   }

--- a/mattermost-plugin/server/manifest.go
+++ b/mattermost-plugin/server/manifest.go
@@ -45,7 +45,8 @@ const manifestStr = `
         "type": "bool",
         "help_text": "This allows board editors to share boards that can be accessed by anyone with the link.",
         "placeholder": "",
-        "default": false
+        "default": false,
+        "hosting": ""
       }
     ]
   }

--- a/mattermost-plugin/webapp/src/components/boardSelector.scss
+++ b/mattermost-plugin/webapp/src/components/boardSelector.scss
@@ -132,10 +132,11 @@
                 position: absolute;
                 left: 13px;
                 font-size: 18px;
-                top: 13px;
                 width: 20px;
-                height: 20px;
+                height: 100%;
                 opacity: 0.48;
+                display: flex;
+                align-items: center;
             }
 
             .searchQuery {

--- a/webapp/src/components/searchDialog/searchDialog.scss
+++ b/webapp/src/components/searchDialog/searchDialog.scss
@@ -5,6 +5,7 @@
     .dialog {
         .toolbar {
             flex-direction: row-reverse;
+            padding: 0;
         }
     }
 
@@ -118,10 +119,11 @@
                 position: absolute;
                 left: 13px;
                 font-size: 18px;
-                top: 14px;
                 width: 20px;
-                height: 20px;
+                height: 100%;
                 opacity: 0.48;
+                display: flex;
+                align-items: center;
             }
 
             .searchQuery {

--- a/webapp/src/components/viewHeader/viewHeader.scss
+++ b/webapp/src/components/viewHeader/viewHeader.scss
@@ -72,8 +72,10 @@
 
     .board-search-icon {
         position: absolute;
-        top: 9px;
         left: 10px;
         color: rgba(var(--center-channel-color-rgb), 0.64);
+        display: flex;
+        align-items: center;
+        height: 100%;
     }
 }


### PR DESCRIPTION
#### Summary
GH-3768 - Search icon fix
Aligning via flexbox so we don't have to manually define `top`

#### Ticket Link
Fixes #3768 