### PR TITLE
Added corner case check for multiperson property

### DIFF
--- a/webapp/src/properties/multiperson/multiperson.tsx
+++ b/webapp/src/properties/multiperson/multiperson.tsx
@@ -61,6 +61,9 @@ const MultiPerson = (props: PropertyProps) => {
     const boardUsers = useAppSelector<IUser[]>(getBoardUsersList)
 
     const formatOptionLabel = (user: any) => {
+        if(!user) {
+            return
+        }
         let profileImg
         if (imageURLForUser) {
             profileImg = imageURLForUser(user.id)
@@ -83,9 +86,9 @@ const MultiPerson = (props: PropertyProps) => {
 
     let users: IUser[]  = []
 
-    if(typeof propertyValue === 'string') {
+    if(typeof propertyValue === 'string' && propertyValue !== '') {
         users  = [boardUsersById[propertyValue as string]]
-    } else if(Array.isArray(propertyValue)) {
+    } else if(Array.isArray(propertyValue) && propertyValue.length > 0) {
         users =  propertyValue.map(id => boardUsersById[id])
     }
 


### PR DESCRIPTION
#### Summary
This PR will add some corner case checks for the multiperson property i.e. when the multiperson property is checked in the kanban view, the remaining card with no multiperson should render without multiperson and should not throw any `undefined` error.

#### Ticket Link
Fixes https://github.com/mattermost/focalboard/issues/3789
<!--
If this pull request addresses a Github issue, please link the relevant issue, e.g.

  Fixes https://github.com/mattermost/focalboard/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
