### PR TITLE
Read Mattermost s3 timeout value and used a default if not exist

### DIFF
--- a/mattermost-plugin/server/boards/boardsapp_util.go
+++ b/mattermost-plugin/server/boards/boardsapp_util.go
@@ -13,6 +13,8 @@ import (
 	mm_model "github.com/mattermost/mattermost-server/v6/model"
 )
 
+const defaultS3Timeout = 60 * 1000 // 60 seconds
+
 func createBoardsConfig(mmconfig mm_model.Config, baseURL string, serverID string) *config.Configuration {
 	filesS3Config := config.AmazonS3Config{}
 	if mmconfig.FileSettings.AmazonS3AccessKeyId != nil {
@@ -44,6 +46,11 @@ func createBoardsConfig(mmconfig mm_model.Config, baseURL string, serverID strin
 	}
 	if mmconfig.FileSettings.AmazonS3Trace != nil {
 		filesS3Config.Trace = *mmconfig.FileSettings.AmazonS3Trace
+	}
+	if mmconfig.FileSettings.AmazonS3RequestTimeoutMilliseconds == nil {
+		filesS3Config.Timeout = defaultS3Timeout
+	} else {
+		filesS3Config.Timeout = *mmconfig.FileSettings.AmazonS3RequestTimeoutMilliseconds
 	}
 
 	enableTelemetry := false

--- a/mattermost-plugin/server/boards/boardsapp_util.go
+++ b/mattermost-plugin/server/boards/boardsapp_util.go
@@ -47,10 +47,10 @@ func createBoardsConfig(mmconfig mm_model.Config, baseURL string, serverID strin
 	if mmconfig.FileSettings.AmazonS3Trace != nil {
 		filesS3Config.Trace = *mmconfig.FileSettings.AmazonS3Trace
 	}
-	if mmconfig.FileSettings.AmazonS3RequestTimeoutMilliseconds == nil {
-		filesS3Config.Timeout = defaultS3Timeout
-	} else {
+	if mmconfig.FileSettings.AmazonS3RequestTimeoutMilliseconds != nil && *mmconfig.FileSettings.AmazonS3RequestTimeoutMilliseconds > 0 {
 		filesS3Config.Timeout = *mmconfig.FileSettings.AmazonS3RequestTimeoutMilliseconds
+	} else {
+		filesS3Config.Timeout = defaultS3Timeout
 	}
 
 	enableTelemetry := false

--- a/server/server/server.go
+++ b/server/server/server.go
@@ -94,6 +94,7 @@ func New(params Params) (*Server, error) {
 	filesBackendSettings.AmazonS3SignV2 = params.Cfg.FilesS3Config.SignV2
 	filesBackendSettings.AmazonS3SSE = params.Cfg.FilesS3Config.SSE
 	filesBackendSettings.AmazonS3Trace = params.Cfg.FilesS3Config.Trace
+	filesBackendSettings.AmazonS3RequestTimeoutMilliseconds = params.Cfg.FilesS3Config.Timeout
 
 	filesBackend, appErr := filestore.NewFileBackend(filesBackendSettings)
 	if appErr != nil {

--- a/server/services/config/config.go
+++ b/server/services/config/config.go
@@ -22,6 +22,7 @@ type AmazonS3Config struct {
 	SignV2          bool
 	SSE             bool
 	Trace           bool
+	Timeout         int64
 }
 
 // Configuration is the app configuration stored in a json file.


### PR DESCRIPTION
Fixes #3773

We weren't reading Mattermost's S3 timeout value. So when initialized the S3 client, the timeout used the default value of `int64`, which is 0. So upload requests timed out in 0 milliseconds.