### PR TITLE
Update version banner URL to redirect permalink

### DIFF
--- a/webapp/src/components/messages/versionMessage.tsx
+++ b/webapp/src/components/messages/versionMessage.tsx
@@ -18,7 +18,7 @@ import CompassIcon from '../../widgets/icons/compassIcon'
 import TelemetryClient, {TelemetryCategory, TelemetryActions} from '../../telemetry/telemetryClient'
 
 import './versionMessage.scss'
-const helpURL = 'https://docs.mattermost.com/welcome/whats-new-in-v72.html'
+const helpURL = 'https://mattermost.com/pl/whats-new-boards/'
 
 const VersionMessage = React.memo(() => {
     const intl = useIntl()


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute

Assign two reviewers for this pull request from the names suggested. If no names are suggested or you are not sure who to assign, set `Core Focalboard` as the reviewer.
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the ticket).
-->
@justinegeffen reached out to get the URL updated in the "what's new" version banner to point to a mattermost.com permalink redirect. Because of version/release reasons, I'm setting the cherrypick to 7.2 so it rolls out with the upcoming 7.2.1 (any concerns @sbishel?) and we'll need to manually run a `/cherry-pick release-7.3` so it makes it to 7.3 as well.

I'm not sure if this is how all mattermost.com/pl/ URLs work, but I'm concerned that it's a HTTP 301 (permanent) redirect when IMHO I think it should be a HTTP 302 (temporary) redirect. I'm 5/5 on this because web browser clients will typically make the 301 request _once_ and then any subsequent requests will just be redirected at the client level i.e. cached so if the redirect location changes e.g. new docs URL then the expected redirect won't happen. cc @emdecr maybe you know?

#### Ticket Link
<!--
If this pull request addresses a Github issue, please link the relevant issue, e.g.

  Fixes https://github.com/mattermost/focalboard/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
n/a, thread conversation: https://community.mattermost.com/core/pl/nqer1j7cypyyfqf85n3jbd3cty