### PR TITLE
Fix broken image in plugin

### DIFF
--- a/mattermost-plugin/webapp/src/components/rhsChannelBoards.tsx
+++ b/mattermost-plugin/webapp/src/components/rhsChannelBoards.tsx
@@ -25,6 +25,7 @@ import {useAppSelector, useAppDispatch} from '../../../../webapp/src/store/hooks
 import AddIcon from '../../../../webapp/src/widgets/icons/add'
 import Button from '../../../../webapp/src/widgets/buttons/button'
 
+import {Utils} from '../../../../webapp/src/utils'
 import {WSClient} from '../../../../webapp/src/wsclient'
 
 import boardsScreenshots from '../../../../webapp/static/boards-screenshots.png'
@@ -107,7 +108,7 @@ const RHSChannelBoards = () => {
                             defaultMessage='Boards is a project management tool that helps define, organize, track and manage work across teams, using a familiar kanban board view.'
                         />
                     </div>
-                    <div className='boards-screenshots'><img src={boardsScreenshots}/></div>
+                    <div className='boards-screenshots'><img src={Utils.buildURL(boardsScreenshots, true)}/></div>
                     <Button
                         onClick={() => dispatch(setLinkToChannel(currentChannel.id))}
                         emphasis='primary'


### PR DESCRIPTION
I moved this image with the MPA changes, and Webpack is no longer able to find it on its own when running as a plugin

#### Ticket Link
None
