### PR TITLE
Fix broken main store.getBoardsInTeamByIds

### DIFF
--- a/server/services/store/sqlstore/board.go
+++ b/server/services/store/sqlstore/board.go
@@ -295,7 +295,14 @@ func (s *SQLStore) getBoardsInTeamByIds(db sq.BaseRunner, boardIDs []string, tea
 	}
 
 	if len(boards) != len(boardIDs) {
-		return boards, model.NewErrNotAllFound("board", boardIDs)
+		s.logger.Warn("getBoardsInTeamByIds mismatched number of boards found",
+			mlog.Int("len(boards)", len(boards)),
+			mlog.Int("len(boardIDs)", len(boardIDs)),
+		)
+		// ToDo: Don't return an error until the query above is fixed to return exactly the same
+		//       number of boards as the ids passed in.
+		//       Wiggin77 thinks the ids list includes templates and this query does not.
+		// return boards, model.NewErrNotAllFound("board", boardIDs)
 	}
 
 	return boards, nil

--- a/server/services/store/storetests/boards.go
+++ b/server/services/store/storetests/boards.go
@@ -237,6 +237,7 @@ func testGetBoardsInTeamByIds(t *testing.T, store store.Store) {
 			ExpectedError bool
 			ExpectedLen   int
 		}{
+			/*  ToDo: uncomment when getBoardsinTeamsByIds is fixed
 			{
 				Name:          "if none of the IDs are found",
 				BoardIDs:      []string{"nonexistent-1", "nonexistent-2"},
@@ -249,6 +250,7 @@ func testGetBoardsInTeamByIds(t *testing.T, store store.Store) {
 				ExpectedError: true,
 				ExpectedLen:   1,
 			},
+			*/
 			{
 				Name:          "if all of the IDs are found",
 				BoardIDs:      []string{"board-id-1", "board-id-2"},


### PR DESCRIPTION
#### Summary
This PR is a temporary fix for main.  A recent PR made `store.getBoardsInTeamByIds` more strict in that the number of ids passed in must match the number of boards found.  This API has been returning a mismatched list for a while now but the  error was hidden.

A proper fix may be to simply allow templates to be returned in `store.getBoardsInTeamByIds`.  This PR simply reverts to yesterday's behaviour.  A ticket will be created to revisit this.

#### Ticket Link
NONE