### PR TITLE
fix: display non-explicit members in Share Board modal <Select>

### DIFF
--- a/webapp/src/components/shareBoard/shareBoard.tsx
+++ b/webapp/src/components/shareBoard/shareBoard.tsx
@@ -360,7 +360,13 @@ export default function ShareBoardDialog(props: Props): JSX.Element {
                             value={selectedUser}
                             className={'userSearchInput'}
                             cacheOptions={true}
-                            filterOption={(o) => !members[o.value]}
+                            filterOption={(o) => {
+                                // render non-explicit members
+                                if (members[o.value])
+                                    return members[o.value].synthetic
+                                // not a member, definitely render
+                                return true
+                            }}
                             loadOptions={async (inputValue: string) => {
                                 const result = []
                                 if (Utils.isFocalboardPlugin()) {

--- a/webapp/src/components/shareBoard/shareBoard.tsx
+++ b/webapp/src/components/shareBoard/shareBoard.tsx
@@ -362,8 +362,9 @@ export default function ShareBoardDialog(props: Props): JSX.Element {
                             cacheOptions={true}
                             filterOption={(o) => {
                                 // render non-explicit members
-                                if (members[o.value])
+                                if (members[o.value]) {
                                     return members[o.value].synthetic
+                                }
                                 // not a member, definitely render
                                 return true
                             }}


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute

Assign two reviewers for this pull request from the names suggested. If no names are suggested or you are not sure who to assign, set `Core Focalboard` as the reviewer.
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the ticket).
-->
Previously, the `<Select>` in the Share Board modal was only filtering on if the user was a member of the board, regardless of explicit or implicit type. This fixes the logic to include implicit members so they could be made explicit if desired.

#### Ticket Link
<!--
If this pull request addresses a Github issue, please link the relevant issue, e.g.

  Fixes https://github.com/mattermost/focalboard/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
closes #3808 