### PR TITLE
Check on GetBoardsForUserAndTeam if the board result list is incomplete and continue if that's the case

### DIFF
--- a/server/services/store/mattermostauthlayer/mattermostauthlayer.go
+++ b/server/services/store/mattermostauthlayer/mattermostauthlayer.go
@@ -911,12 +911,15 @@ func (s *MattermostAuthLayer) GetBoardsForUserAndTeam(userID, teamID string, inc
 
 	boards, err := s.Store.GetBoardsInTeamByIds(boardIDs, teamID)
 	// ToDo: check if the query is being used appropriately from the
-	//       interface, Wiggin77 thinks we're passing IDs that belong
-	//       to boards and templates, and the store method only
-	//       fetches boards, so we need to accept a partial result as
-	//       valid
-	var naf *model.ErrNotAllFound
-	if err != nil && !errors.As(err, &naf) {
+	//       interface, as we're getting ID sets on request that
+	//       return partial results that seem to be valid
+	if model.IsErrNotFound(err) {
+		if boards == nil {
+			boards = []*model.Board{}
+		}
+		return boards, nil
+	}
+	if err != nil {
 		return nil, err
 	}
 

--- a/server/services/store/mattermostauthlayer/mattermostauthlayer.go
+++ b/server/services/store/mattermostauthlayer/mattermostauthlayer.go
@@ -910,7 +910,13 @@ func (s *MattermostAuthLayer) GetBoardsForUserAndTeam(userID, teamID string, inc
 	}
 
 	boards, err := s.Store.GetBoardsInTeamByIds(boardIDs, teamID)
-	if err != nil {
+	// ToDo: check if the query is being used appropriately from the
+	//       interface, Wiggin77 thinks we're passing IDs that belong
+	//       to boards and templates, and the store method only
+	//       fetches boards, so we need to accept a partial result as
+	//       valid
+	var naf *model.ErrNotAllFound
+	if err != nil && !errors.As(err, &naf) {
 		return nil, err
 	}
 

--- a/server/services/store/sqlstore/board.go
+++ b/server/services/store/sqlstore/board.go
@@ -299,10 +299,7 @@ func (s *SQLStore) getBoardsInTeamByIds(db sq.BaseRunner, boardIDs []string, tea
 			mlog.Int("len(boards)", len(boards)),
 			mlog.Int("len(boardIDs)", len(boardIDs)),
 		)
-		// ToDo: Don't return an error until the query above is fixed to return exactly the same
-		//       number of boards as the ids passed in.
-		//       Wiggin77 thinks the ids list includes templates and this query does not.
-		// return boards, model.NewErrNotAllFound("board", boardIDs)
+		return boards, model.NewErrNotAllFound("board", boardIDs)
 	}
 
 	return boards, nil

--- a/server/services/store/sqlstore/board.go
+++ b/server/services/store/sqlstore/board.go
@@ -279,7 +279,6 @@ func (s *SQLStore) getBoardsInTeamByIds(db sq.BaseRunner, boardIDs []string, tea
 		Select(boardFields("b.")...).
 		From(s.tablePrefix + "boards as b").
 		Where(sq.Eq{"b.team_id": teamID}).
-		Where(sq.Eq{"b.is_template": false}).
 		Where(sq.Eq{"b.id": boardIDs})
 
 	rows, err := query.Query()

--- a/server/services/store/storetests/boards.go
+++ b/server/services/store/storetests/boards.go
@@ -242,7 +242,6 @@ func testGetBoardsInTeamByIds(t *testing.T, store store.Store) {
 			ExpectedError bool
 			ExpectedLen   int
 		}{
-			/*  ToDo: uncomment when getBoardsinTeamsByIds is fixed
 			{
 				Name:          "if none of the IDs are found",
 				BoardIDs:      []string{"nonexistent-1", "nonexistent-2"},
@@ -255,7 +254,6 @@ func testGetBoardsInTeamByIds(t *testing.T, store store.Store) {
 				ExpectedError: true,
 				ExpectedLen:   1,
 			},
-			*/
 			{
 				Name:          "if all of the IDs are found",
 				BoardIDs:      []string{"board-id-1", "board-id-2"},


### PR DESCRIPTION
#### Summary
Follow up to https://github.com/mattermost/focalboard/pull/3840 that moves the responsibility of ignoring the `NotAllFound` error to the caller, so in this case, the `GetBoardsForUserAndTeam` explicitly decides that if the result list is incomplete, it's ok and can be returned.

Store method is left untouched so other callers can decide not to continue if the list is incomplete.