### PR TITLE
Catch exception on failed WS command to avoid interface from breaking

### DIFF
--- a/webapp/src/wsclient.ts
+++ b/webapp/src/wsclient.ts
@@ -172,13 +172,17 @@ class WSClient {
     }
 
     sendCommand(command: WSCommand): void {
-        if (this.client !== null) {
-            const {action, ...data} = command
-            this.client.sendMessage(this.clientPrefix + action, data)
-            return
-        }
+        try {
+            if (this.client !== null) {
+                const { action, ...data } = command
+                this.client.sendMessage(this.clientPrefix + action, data)
+                return
+            }
 
-        this.ws?.send(JSON.stringify(command))
+            this.ws?.send(JSON.stringify(command))
+        } catch(e) {
+            Utils.logError(`WSClient failed to send command ${command.action}: ${e}`)
+        }
     }
 
     sendAuthenticationCommand(token: string): void {

--- a/webapp/src/wsclient.ts
+++ b/webapp/src/wsclient.ts
@@ -174,13 +174,13 @@ class WSClient {
     sendCommand(command: WSCommand): void {
         try {
             if (this.client !== null) {
-                const { action, ...data } = command
+                const {action, ...data} = command
                 this.client.sendMessage(this.clientPrefix + action, data)
                 return
             }
 
             this.ws?.send(JSON.stringify(command))
-        } catch(e) {
+        } catch (e) {
             Utils.logError(`WSClient failed to send command ${command.action}: ${e}`)
         }
     }


### PR DESCRIPTION
#### Summary
This PR avoids the interface breaking completely on a failed WS message sent and prints the error that caused the failure