### PR TITLE
MM-47076 Use version of Reaact DOM provided by web app

### DIFF
--- a/mattermost-plugin/webapp/webpack.config.js
+++ b/mattermost-plugin/webapp/webpack.config.js
@@ -174,6 +174,7 @@ if (TARGET_IS_PRODUCT) {
 
     config.externals = {
         react: 'React',
+        'react-dom': 'ReactDOM',
         redux: 'Redux',
         'react-redux': 'ReactRedux',
         'mm-react-router-dom': 'ReactRouterDom',


### PR DESCRIPTION
For some more context, see [here](https://community.mattermost.com/core/pl/1fkkx7pj1jrwffrc6drh3x71eh). The short version though is that we updated the web app to React 17, and there's a chance that plugins will have some issues with it because they're compiled with the React 16 version of ReactDOM. I'm submitting PRs to the 3 products, the demo plugin, and the plugin template to have them use the web app's version of React DOM to fix any immediate issues, but we'll want to properly migrate them to React 17 going forward.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-47028

#### Related Pull Requests
https://github.com/mattermost/mattermost-plugin-playbooks/pull/1489
