### PR TITLE
Fix a placeholder message when sharing template

### DIFF
--- a/webapp/i18n/en.json
+++ b/webapp/i18n/en.json
@@ -221,6 +221,7 @@
   "ShareBoard.userPermissionsRemoveMemberText": "Remove member",
   "ShareBoard.userPermissionsYouText": "(You)",
   "ShareTemplate.Title": "Share Template",
+  "ShareTemplate.searchPlaceholder": "Search for people",
   "Sidebar.about": "About Focalboard",
   "Sidebar.add-board": "+ Add board",
   "Sidebar.changePassword": "Change password",

--- a/webapp/src/components/shareBoard/__snapshots__/shareBoard.test.tsx.snap
+++ b/webapp/src/components/shareBoard/__snapshots__/shareBoard.test.tsx.snap
@@ -2379,7 +2379,7 @@ exports[`src/components/shareBoard/shareBoard return shareBoard template and cli
                     class=" css-14el2xx-placeholder"
                     id="react-select-14-placeholder"
                   >
-                    Search for people and channels
+                    Search for people
                   </div>
                   <div
                     class=" css-ox1y69-Input"
@@ -2573,7 +2573,7 @@ exports[`src/components/shareBoard/shareBoard return shareBoard template and cli
                     class=" css-14el2xx-placeholder"
                     id="react-select-14-placeholder"
                   >
-                    Search for people and channels
+                    Search for people
                   </div>
                   <div
                     class=" css-ox1y69-Input"
@@ -4185,7 +4185,7 @@ exports[`src/components/shareBoard/shareBoard should match snapshot, with templa
                     class=" css-14el2xx-placeholder"
                     id="react-select-13-placeholder"
                   >
-                    Search for people and channels
+                    Search for people
                   </div>
                   <div
                     class=" css-ox1y69-Input"

--- a/webapp/src/components/shareBoard/shareBoard.test.tsx
+++ b/webapp/src/components/shareBoard/shareBoard.test.tsx
@@ -709,7 +709,7 @@ describe('src/components/shareBoard/shareBoard', () => {
         })
 
         expect(container).toMatchSnapshot()
-        const selectElement = screen.getByText('Search for people and channels')
+        const selectElement = screen.getByText('Search for people')
         expect(selectElement).toBeDefined()
 
         await act(async () => {

--- a/webapp/src/components/shareBoard/shareBoard.tsx
+++ b/webapp/src/components/shareBoard/shareBoard.tsx
@@ -389,7 +389,10 @@ export default function ShareBoardDialog(props: Props): JSX.Element {
                             getOptionValue={(u) => u.id}
                             getOptionLabel={(u: IUser|Channel) => (u as IUser).username || (u as Channel).display_name}
                             isMulti={false}
-                            placeholder={intl.formatMessage({id: 'ShareBoard.searchPlaceholder', defaultMessage: 'Search for people and channels'})}
+                            placeholder={board.isTemplate ?
+                                intl.formatMessage({id: 'ShareTemplate.searchPlaceholder', defaultMessage: 'Search for people'}) :
+                                intl.formatMessage({id: 'ShareBoard.searchPlaceholder', defaultMessage: 'Search for people and channels'})
+                            }
                             onChange={(newValue) => {
                                 if (newValue && (newValue as IUser).username) {
                                     mutator.createBoardMember(boardId, newValue.id)


### PR DESCRIPTION
#### Summary

When sharing template, `Search for people and channels` is displayed in placeholder, but channels cannot be searched.

![スクリーンショット 2022-09-19 14 32 27](https://user-images.githubusercontent.com/1453749/190954926-0c306f66-325b-43e6-9113-33e8ccefdea7.png)

This PR fixes a message in placeholder.
#### Ticket Link

N/A.
Following [Contributing to Mattermost without a ticket](https://developers.mattermost.com/contribute/getting-started/contributions-without-ticket/).