### PR TITLE
GH-3815 Fix for Error Page redirection

### DIFF
--- a/webapp/src/pages/boardPage/boardPage.tsx
+++ b/webapp/src/pages/boardPage/boardPage.tsx
@@ -197,9 +197,13 @@ const BoardPage = (props: Props): JSX.Element => {
             // and set it as most recently viewed board
             UserSettings.setLastBoardID(teamId, match.params.boardId)
 
-            if (viewId && viewId !== Constants.globalTeamId) {
+            if (viewId !== Constants.globalTeamId) {
+                // reset current, even if empty string
                 dispatch(setCurrentView(viewId))
-                UserSettings.setLastViewId(match.params.boardId, viewId)
+                if (viewId) {
+                    // don't reset per board if empty string
+                    UserSettings.setLastViewId(match.params.boardId, viewId)
+                }
             }
 
             if (!props.readonly && me) {


### PR DESCRIPTION
#### Summary

This error was caused due to attempting to combine a Kanban view with another board that didn't contain a "Select" property. 

When clicking on the Board Name in the sidebar, the board is initially loaded with the "CurrentView" from the redux store. If that view is a Kanban, and the board doesn't contain a "select" property an error is thrown and the board redirects to the error page.

This PR clears the "CurrentViewID" from the react store even if it is empty (''). This prevents the board from loading with an improper view.

#### Ticket Link
  Fixes https://github.com/mattermost/focalboard/issues/3815

Fixes https://github.com/mattermost/focalboard/issues/3780