### PR TITLE
Preserve old handleServeFile endpoint behavior after refactor

### DIFF
--- a/server/api/files.go
+++ b/server/api/files.go
@@ -119,7 +119,7 @@ func (a *API) handleServeFile(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", contentType)
 
 	fileInfo, err := a.app.GetFileInfo(filename)
-	if err != nil {
+	if err != nil && !model.IsErrNotFound(err) {
 		a.errorResponse(w, r, err)
 		return
 	}


### PR DESCRIPTION
#### Summary
This PR makes the `handleServeFile` endpoint behave the same way it was before the server error refactor changes.