### PR TITLE
[GH-1950] : Fix border-collapse user agent stylesheet

### DIFF
--- a/webapp/src/styles/_markdown.scss
+++ b/webapp/src/styles/_markdown.scss
@@ -1,6 +1,7 @@
 .markdown__table {
     margin: 5px 0 10px;
     background: var(--center-channel-bg);
+    border-collapse: collapse;
 
     th,
     td {


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute

Assign two reviewers for this pull request from the names suggested. If no names are suggested or you are not sure who to assign, set `Core Focalboard` as the reviewer.
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the ticket).
-->

There is an user agent stylesheet on chrome with a `border-collapse: separate` and `border-spacing: 2px`

https://chromium.googlesource.com/chromium/blink/+/master/Source/core/css/html.css

I reset border-collapse in `.markdown__table` to fix it

#### Ticket Link
<!--
If this pull request addresses a Github issue, please link the relevant issue, e.g.

  Fixes https://github.com/mattermost/focalboard/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

Fix #1950 