### PR TITLE
fix[GH-3764]: webpack extension

### DIFF
--- a/webapp/webpack.common.js
+++ b/webapp/webpack.common.js
@@ -1,7 +1,8 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
-const tsTransformer = require('@formatjs/ts-transformer');
 const path = require('path');
+
+const tsTransformer = require('@formatjs/ts-transformer');
 const CopyPlugin = require('copy-webpack-plugin');
 var HtmlWebpackPlugin = require('html-webpack-plugin');
 
@@ -70,8 +71,8 @@ function makeCommonConfig() {
                     test: /\.(eot|tiff|svg|woff2|woff|ttf|png|jpg|jpeg|gif)$/,
                     type: 'asset/resource',
                     generator: {
-                        filename: 'static/[name].[ext]',
-                    }
+                        filename: 'static/[name][ext]',
+                    },
                 },
             ],
         },


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute

Assign two reviewers for this pull request from the names suggested. If no names are suggested or you are not sure who to assign, set `Core Focalboard` as the reviewer.
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the ticket).
-->

there is an extra point in the webpack configuration.

Before fix : 

<img width="242" alt="image" src="https://user-images.githubusercontent.com/25395032/193481605-e5a08e23-4c26-4a55-b577-119f3f99c9f7.png">

After fix : 

<img width="242" alt="image" src="https://user-images.githubusercontent.com/25395032/193481721-644b1c21-c707-4579-88f2-3bd64928df79.png">

_mattermost-plugin is already fixed => https://github.com/mattermost/focalboard/blob/main/mattermost-plugin/webapp/webpack.config.js#L118_


#### Ticket Link
<!--
If this pull request addresses a Github issue, please link the relevant issue, e.g.

  Fixes https://github.com/mattermost/focalboard/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Fix #3764 