### PR TITLE
Fix misaligned 'viewer' role on share board/template dialog

### DIFF
--- a/webapp/src/components/shareBoard/__snapshots__/userPermissionsRow.test.tsx.snap
+++ b/webapp/src/components/shareBoard/__snapshots__/userPermissionsRow.test.tsx.snap
@@ -57,8 +57,12 @@ exports[`src/components/shareBoard/userPermissionsRow should match snapshot 1`] 
                     class="d-flex menu-option__check"
                   >
                     <div
-                      class="noicon"
-                    />
+                      class="menu-option__icon"
+                    >
+                      <div
+                        class="empty-icon"
+                      />
+                    </div>
                   </div>
                   <div
                     class="menu-option__content"
@@ -306,8 +310,12 @@ exports[`src/components/shareBoard/userPermissionsRow should match snapshot in p
                     class="d-flex menu-option__check"
                   >
                     <div
-                      class="noicon"
-                    />
+                      class="menu-option__icon"
+                    >
+                      <div
+                        class="empty-icon"
+                      />
+                    </div>
                   </div>
                   <div
                     class="menu-option__content"
@@ -555,8 +563,12 @@ exports[`src/components/shareBoard/userPermissionsRow should match snapshot in t
                     class="d-flex menu-option__check"
                   >
                     <div
-                      class="noicon"
-                    />
+                      class="menu-option__icon"
+                    >
+                      <div
+                        class="empty-icon"
+                      />
+                    </div>
                   </div>
                   <div
                     class="menu-option__content"

--- a/webapp/src/components/shareBoard/userPermissionsRow.tsx
+++ b/webapp/src/components/shareBoard/userPermissionsRow.tsx
@@ -77,7 +77,7 @@ const UserPermissionsRow = (props: Props): JSX.Element => {
                                 <Menu.Text
                                     id={MemberRole.Viewer}
                                     check={true}
-                                    icon={currentRole === MemberRole.Viewer ? <CheckIcon/> : null}
+                                    icon={currentRole === MemberRole.Viewer ? <CheckIcon/> : <div className='empty-icon'/>}
                                     name={intl.formatMessage({id: 'BoardMember.schemeViewer', defaultMessage: 'Viewer'})}
                                     onClick={() => props.onUpdateBoardMember(member, MemberRole.Viewer)}
                                 />}


### PR DESCRIPTION
#### Summary

The viewer button on share dialog was misaligned due to it was missing the `empty-icon` whenever the `currentRole` is not equal to `Viewer` role. This PR fixes it. (Attaching before and after screenshots)

Before

![before](https://user-images.githubusercontent.com/58988126/193869525-941c767b-a9b8-41f2-bd78-e41bb70e5a3e.png)


After

![after](https://user-images.githubusercontent.com/58988126/193869546-925d21bf-0ec3-4ad8-bdee-78d05c714bd8.png)


#### Ticket Link

Fixes https://github.com/mattermost/focalboard/issues/3865

