### PR TITLE
fix: Person autocomplete in table

### DIFF
--- a/webapp/src/components/table/table.scss
+++ b/webapp/src/components/table/table.scss
@@ -204,6 +204,7 @@
             width: inherit;
         }
 
+        .Person.octo-propertyvalue,
         .DateRange.octo-propertyvalue {
             overflow: unset;
         }


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute

Assign two reviewers for this pull request from the names suggested. If no names are suggested or you are not sure who to assign, set `Core Focalboard` as the reviewer.
-->

#### Summary
Person autocomplete in table view fixed. The dropdown was rendering but because table cell had `overflow: hidden` styling, it was not visible. Overwrote the style for Person cell.

#### Ticket Link
Fixes https://github.com/mattermost/focalboard/issues/3903
