### PR TITLE
add setting admin role when add member

### DIFF
--- a/webapp/src/components/markdownEditorInput/markdownEditorInput.tsx
+++ b/webapp/src/components/markdownEditorInput/markdownEditorInput.tsx
@@ -125,9 +125,10 @@ const MarkdownEditorInput = (props: Props): ReactElement => {
             boardId: board.id,
             userId,
             roles: role,
-            schemeEditor: minimumRole === MemberRole.Editor,
-            schemeCommenter: minimumRole === MemberRole.Editor || minimumRole === MemberRole.Commenter,
-            schemeViewer: minimumRole === MemberRole.Editor || minimumRole === MemberRole.Commenter || minimumRole === MemberRole.Viewer,
+            schemeAdmin: minimumRole === MemberRole.Admin,
+            schemeEditor: minimumRole === MemberRole.Admin || MemberRole.Editor,
+            schemeCommenter: minimumRole === MemberRole.Admin || MemberRole.Editor || minimumRole === MemberRole.Commenter,
+            schemeViewer: minimumRole === MemberRole.Admin || MemberRole.Editor || minimumRole === MemberRole.Commenter || minimumRole === MemberRole.Viewer,
         } as BoardMember
 
         setConfirmAddUser(null)

--- a/webapp/src/components/markdownEditorInput/markdownEditorInput.tsx
+++ b/webapp/src/components/markdownEditorInput/markdownEditorInput.tsx
@@ -120,15 +120,15 @@ const MarkdownEditorInput = (props: Props): ReactElement => {
     const [editorState, setEditorState] = useState(() => generateEditorState(initialText))
 
     const addUser = useCallback(async (userId: string, role: string) => {
-        const minimumRole = role || MemberRole.Viewer
+        const newRole = role || MemberRole.Viewer
         const newMember = {
             boardId: board.id,
             userId,
             roles: role,
-            schemeAdmin: minimumRole === MemberRole.Admin,
-            schemeEditor: minimumRole === MemberRole.Admin || MemberRole.Editor,
-            schemeCommenter: minimumRole === MemberRole.Admin || MemberRole.Editor || minimumRole === MemberRole.Commenter,
-            schemeViewer: minimumRole === MemberRole.Admin || MemberRole.Editor || minimumRole === MemberRole.Commenter || minimumRole === MemberRole.Viewer,
+            schemeAdmin: newRole === MemberRole.Admin,
+            schemeEditor: newRole === MemberRole.Admin || MemberRole.Editor,
+            schemeCommenter: newRole === MemberRole.Admin || MemberRole.Editor || newRole === MemberRole.Commenter,
+            schemeViewer: newRole === MemberRole.Admin || MemberRole.Editor || newRole === MemberRole.Commenter || newRole === MemberRole.Viewer,
         } as BoardMember
 
         setConfirmAddUser(null)

--- a/webapp/src/properties/multiperson/multiperson.tsx
+++ b/webapp/src/properties/multiperson/multiperson.tsx
@@ -110,15 +110,15 @@ const MultiPerson = (props: PropertyProps): JSX.Element => {
     }
 
     const addUser = useCallback(async (userId: string, role: string) => {
-        const minimumRole = role || MemberRole.Viewer
+        const newRole = role || MemberRole.Viewer
         const newMember = {
             boardId: board.id,
             userId,
             roles: role,
-            schemeAdmin: minimumRole === MemberRole.Admin,
-            schemeEditor: minimumRole === MemberRole.Admin || MemberRole.Editor,
-            schemeCommenter: minimumRole === MemberRole.Admin || MemberRole.Editor || minimumRole === MemberRole.Commenter,
-            schemeViewer: minimumRole === MemberRole.Admin || MemberRole.Editor || minimumRole === MemberRole.Commenter || minimumRole === MemberRole.Viewer,
+            schemeAdmin: newRole === MemberRole.Admin,
+            schemeEditor: newRole === MemberRole.Admin || MemberRole.Editor,
+            schemeCommenter: newRole === MemberRole.Admin || MemberRole.Editor || newRole === MemberRole.Commenter,
+            schemeViewer: newRole === MemberRole.Admin || MemberRole.Editor || newRole === MemberRole.Commenter || newRole === MemberRole.Viewer,
         } as BoardMember
 
         setConfirmAddUser(null)

--- a/webapp/src/properties/multiperson/multiperson.tsx
+++ b/webapp/src/properties/multiperson/multiperson.tsx
@@ -115,9 +115,10 @@ const MultiPerson = (props: PropertyProps): JSX.Element => {
             boardId: board.id,
             userId,
             roles: role,
-            schemeEditor: minimumRole === MemberRole.Editor,
-            schemeCommenter: minimumRole === MemberRole.Editor || minimumRole === MemberRole.Commenter,
-            schemeViewer: minimumRole === MemberRole.Editor || minimumRole === MemberRole.Commenter || minimumRole === MemberRole.Viewer,
+            schemeAdmin: minimumRole === MemberRole.Admin,
+            schemeEditor: minimumRole === MemberRole.Admin || MemberRole.Editor,
+            schemeCommenter: minimumRole === MemberRole.Admin || MemberRole.Editor || minimumRole === MemberRole.Commenter,
+            schemeViewer: minimumRole === MemberRole.Admin || MemberRole.Editor || minimumRole === MemberRole.Commenter || minimumRole === MemberRole.Viewer,
         } as BoardMember
 
         setConfirmAddUser(null)

--- a/webapp/src/properties/person/person.tsx
+++ b/webapp/src/properties/person/person.tsx
@@ -94,15 +94,15 @@ const Person = (props: PropertyProps): JSX.Element => {
     }
 
     const addUser = useCallback(async (userId: string, role: string) => {
-        const minimumRole = role || MemberRole.Viewer
+        const newRole = role || MemberRole.Viewer
         const newMember = {
             boardId: board.id,
             userId,
             roles: role,
-            schemeAdmin: minimumRole === MemberRole.Admin,
-            schemeEditor: minimumRole === MemberRole.Admin || MemberRole.Editor,
-            schemeCommenter: minimumRole === MemberRole.Admin || MemberRole.Editor || minimumRole === MemberRole.Commenter,
-            schemeViewer: minimumRole === MemberRole.Admin || MemberRole.Editor || minimumRole === MemberRole.Commenter || minimumRole === MemberRole.Viewer,
+            schemeAdmin: newRole === MemberRole.Admin,
+            schemeEditor: newRole === MemberRole.Admin || MemberRole.Editor,
+            schemeCommenter: newRole === MemberRole.Admin || MemberRole.Editor || newRole === MemberRole.Commenter,
+            schemeViewer: newRole === MemberRole.Admin || MemberRole.Editor || newRole === MemberRole.Commenter || newRole === MemberRole.Viewer,
         } as BoardMember
 
         setConfirmAddUser(null)

--- a/webapp/src/properties/person/person.tsx
+++ b/webapp/src/properties/person/person.tsx
@@ -99,9 +99,10 @@ const Person = (props: PropertyProps): JSX.Element => {
             boardId: board.id,
             userId,
             roles: role,
-            schemeEditor: minimumRole === MemberRole.Editor,
-            schemeCommenter: minimumRole === MemberRole.Editor || minimumRole === MemberRole.Commenter,
-            schemeViewer: minimumRole === MemberRole.Editor || minimumRole === MemberRole.Commenter || minimumRole === MemberRole.Viewer,
+            schemeAdmin: minimumRole === MemberRole.Admin,
+            schemeEditor: minimumRole === MemberRole.Admin || MemberRole.Editor,
+            schemeCommenter: minimumRole === MemberRole.Admin || MemberRole.Editor || minimumRole === MemberRole.Commenter,
+            schemeViewer: minimumRole === MemberRole.Admin || MemberRole.Editor || minimumRole === MemberRole.Commenter || minimumRole === MemberRole.Viewer,
         } as BoardMember
 
         setConfirmAddUser(null)


### PR DESCRIPTION

#### Summary
Renamed variable to avoid confusion and included setting the user as Admin, since admin users can be set by other admins.

#### Ticket Link

  Fixes #3957 