### PR TITLE
GH-3992 fix for missing templates, error when 'system' not found as user.

### DIFF
--- a/server/services/store/mattermostauthlayer/mattermostauthlayer.go
+++ b/server/services/store/mattermostauthlayer/mattermostauthlayer.go
@@ -803,6 +803,9 @@ func (s *MattermostAuthLayer) GetMemberForBoard(boardID, userID string) (*model.
 	bm, err := s.Store.GetMemberForBoard(boardID, userID)
 	// Explicit membership not found
 	if model.IsErrNotFound(err) {
+		if userID != model.SystemUserID {
+			return nil, model.NewErrNotFound(userID)
+		}
 		var user *model.User
 		// No synthetic memberships for guests
 		user, err = s.GetUserByID(userID)

--- a/server/services/store/mattermostauthlayer/mattermostauthlayer.go
+++ b/server/services/store/mattermostauthlayer/mattermostauthlayer.go
@@ -803,7 +803,7 @@ func (s *MattermostAuthLayer) GetMemberForBoard(boardID, userID string) (*model.
 	bm, err := s.Store.GetMemberForBoard(boardID, userID)
 	// Explicit membership not found
 	if model.IsErrNotFound(err) {
-		if userID != model.SystemUserID {
+		if userID == model.SystemUserID {
 			return nil, model.NewErrNotFound(userID)
 		}
 		var user *model.User


### PR DESCRIPTION
#### Summary
When guest users was implemented, we included a check for guest users. In order to perform that check, the user is retrieved. If the user didn't exist, an error is thrown.

When importing templates, the user 'system' is added to the board. However, because it doesn't exist as a user, it fails this check and templates are not imported.

Issue #3993 fails because of missing templates, this will fix both.

#### Ticket Link
  Fixes #3992
  Fixes #3993 

