### PR TITLE
Fix collation and charset after migrations (every run)

### DIFF
--- a/mattermost-plugin/server/manifest.go
+++ b/mattermost-plugin/server/manifest.go
@@ -45,8 +45,7 @@ const manifestStr = `
         "type": "bool",
         "help_text": "This allows board editors to share boards that can be accessed by anyone with the link.",
         "placeholder": "",
-        "default": false,
-        "hosting": ""
+        "default": false
       }
     ]
   }

--- a/server/services/store/sqlstore/data_migrations_test.go
+++ b/server/services/store/sqlstore/data_migrations_test.go
@@ -249,7 +249,7 @@ func TestCheckForMismatchedCollation(t *testing.T) {
 	tableNames, err := sqlStore.getFocalBoardTableNames()
 	require.NoError(t, err)
 
-	sqlCollation := "SELECT table_collation FROM information_schema.tables WHERE table_name=?"
+	sqlCollation := "SELECT table_collation FROM information_schema.tables WHERE table_name=? and table_schema=(SELECT DATABASE())"
 	stmtCollation, err := sqlStore.db.Prepare(sqlCollation)
 	require.NoError(t, err)
 	defer stmtCollation.Close()
@@ -257,7 +257,7 @@ func TestCheckForMismatchedCollation(t *testing.T) {
 	var collation string
 
 	// make sure the correct charset is applied to each table.
-	for _, name := range tableNames {
+	for i, name := range tableNames {
 		row := stmtCollation.QueryRow(name)
 
 		var actualCollation string
@@ -268,6 +268,6 @@ func TestCheckForMismatchedCollation(t *testing.T) {
 			collation = actualCollation
 		}
 
-		assert.Equal(t, collation, actualCollation)
+		assert.Equalf(t, collation, actualCollation, "for table_name='%s', index=%d", name, i)
 	}
 }

--- a/server/services/store/sqlstore/data_migrations_test.go
+++ b/server/services/store/sqlstore/data_migrations_test.go
@@ -245,9 +245,7 @@ func TestCheckForMismatchedCollation(t *testing.T) {
 		return
 	}
 
-	collation, _, err := sqlStore.getCollationAndCharset()
-	require.NoError(t, err)
-
+	// make sure all collations are consistent.
 	tableNames, err := sqlStore.getFocalBoardTableNames()
 	require.NoError(t, err)
 
@@ -256,6 +254,8 @@ func TestCheckForMismatchedCollation(t *testing.T) {
 	require.NoError(t, err)
 	defer stmtCollation.Close()
 
+	var collation string
+
 	// make sure the correct charset is applied to each table.
 	for _, name := range tableNames {
 		row := stmtCollation.QueryRow(name)
@@ -263,6 +263,10 @@ func TestCheckForMismatchedCollation(t *testing.T) {
 		var actualCollation string
 		err = row.Scan(&actualCollation)
 		require.NoError(t, err)
+
+		if collation == "" {
+			collation = actualCollation
+		}
 
 		assert.Equal(t, collation, actualCollation)
 	}

--- a/server/services/store/sqlstore/helpers_test.go
+++ b/server/services/store/sqlstore/helpers_test.go
@@ -12,6 +12,9 @@ import (
 )
 
 func SetupTests(t *testing.T) (store.Store, func()) {
+	origUnitTesting := os.Getenv("FOCALBOARD_UNIT_TESTING")
+	os.Setenv("FOCALBOARD_UNIT_TESTING", "1")
+
 	dbType, connectionString, err := PrepareNewTestDatabase()
 	require.NoError(t, err)
 
@@ -40,6 +43,7 @@ func SetupTests(t *testing.T) (store.Store, func()) {
 		if err = os.Remove(connectionString); err == nil {
 			logger.Debug("Removed test database", mlog.String("file", connectionString))
 		}
+		os.Setenv("FOCALBOARD_UNIT_TESTING", origUnitTesting)
 	}
 
 	return store, tearDown

--- a/server/services/store/sqlstore/migrate.go
+++ b/server/services/store/sqlstore/migrate.go
@@ -236,6 +236,10 @@ func (s *SQLStore) runMigrationSequence(engine *morph.Morph, driver drivers.Driv
 		return fmt.Errorf("error running categoryID migration: %w", mErr)
 	}
 
+	if mErr := s.RunFixCollationsAndCharsetsMigration(); mErr != nil {
+		return fmt.Errorf("error running fix collations and charsets migration: %w", mErr)
+	}
+
 	appliedMigrations, err := driver.AppliedMigrations()
 	if err != nil {
 		return err


### PR DESCRIPTION
#### Summary
This PR ensures that all FocalBoard tables have the correct collation and charset settings for existing tables and any added in the future.  This is done via a final migration step that applies these settings in an idempotent fashion on every run.  

#### Ticket Link
fixes https://github.com/mattermost/focalboard/issues/3871