### PR TITLE
Personal Server - remove same function on disconnect as added on reconnect.

### DIFF
--- a/webapp/src/pages/boardPage/boardPage.tsx
+++ b/webapp/src/pages/boardPage/boardPage.tsx
@@ -141,15 +141,15 @@ const BoardPage = (props: Props): JSX.Element => {
             }
         }
 
+        const dispatchLoadAction = () => {
+            dispatch(loadAction(match.params.boardId))
+        }
+
         Utils.log('useWEbsocket adding onChange handler')
         wsClient.addOnChange(incrementalBlockUpdate, 'block')
         wsClient.addOnChange(incrementalBoardUpdate, 'board')
         wsClient.addOnChange(incrementalBoardMemberUpdate, 'boardMembers')
-        wsClient.addOnReconnect(() => {
-            if (me) {
-                dispatch(loadAction(match.params.boardId))
-            }
-        })
+        wsClient.addOnReconnect(dispatchLoadAction)
 
         wsClient.setOnFollowBlock((_: WSClient, subscription: Subscription): void => {
             if (subscription.subscriberId === me?.id) {
@@ -167,11 +167,7 @@ const BoardPage = (props: Props): JSX.Element => {
             wsClient.removeOnChange(incrementalBlockUpdate, 'block')
             wsClient.removeOnChange(incrementalBoardUpdate, 'board')
             wsClient.removeOnChange(incrementalBoardMemberUpdate, 'boardMembers')
-            wsClient.removeOnReconnect(() => {
-                if (me) {
-                    dispatch(loadAction(match.params.boardId))
-                }
-            })
+            wsClient.removeOnReconnect(dispatchLoadAction)
         }
     }, [me?.id, activeBoardId])
 

--- a/webapp/src/pages/boardPage/boardPage.tsx
+++ b/webapp/src/pages/boardPage/boardPage.tsx
@@ -145,7 +145,11 @@ const BoardPage = (props: Props): JSX.Element => {
         wsClient.addOnChange(incrementalBlockUpdate, 'block')
         wsClient.addOnChange(incrementalBoardUpdate, 'board')
         wsClient.addOnChange(incrementalBoardMemberUpdate, 'boardMembers')
-        wsClient.addOnReconnect(() => dispatch(loadAction(match.params.boardId)))
+        wsClient.addOnReconnect(() => {
+            if (me) {
+                dispatch(loadAction(match.params.boardId))
+            }
+        })
 
         wsClient.setOnFollowBlock((_: WSClient, subscription: Subscription): void => {
             if (subscription.subscriberId === me?.id) {
@@ -163,7 +167,11 @@ const BoardPage = (props: Props): JSX.Element => {
             wsClient.removeOnChange(incrementalBlockUpdate, 'block')
             wsClient.removeOnChange(incrementalBoardUpdate, 'board')
             wsClient.removeOnChange(incrementalBoardMemberUpdate, 'boardMembers')
-            wsClient.removeOnReconnect(() => dispatch(loadAction(match.params.boardId)))
+            wsClient.removeOnReconnect(() => {
+                if (me) {
+                    dispatch(loadAction(match.params.boardId))
+                }
+            })
         }
     }, [me?.id, activeBoardId])
 


### PR DESCRIPTION
#### Summary
Fixes an issue where the webapp gets into a loop calling `initialLoad`. And the first user cannot log in. As shortly after being redirected to `/register` and error occurs and redirects back to `/login`

When a new Personal Server installation is accessed, no one is logged in an error is thrown [here](https://github.com/mattermost/focalboard/blob/main/webapp/src/store/initialLoad.ts#L27).

This results in the errorPage redirecting automatically back to `/login` - https://github.com/mattermost/focalboard/blob/main/webapp/src/errors.ts#L73

~By only calling `initialLoad`, if me is defined, stops the cycle.~

New fix is to ensure we disconnect the same function as connected.

#### Ticket Link

  Fixes https://github.com/mattermost/focalboard/issues/4000
