### PR TITLE
MM-46275 Rename product container to 'boards' for consistency

### DIFF
--- a/mattermost-plugin/webapp/webpack.config.js
+++ b/mattermost-plugin/webapp/webpack.config.js
@@ -144,7 +144,7 @@ if (TARGET_IS_PRODUCT) {
     }
 
     config.plugins.push(new ModuleFederationPlugin({
-        name: PLUGIN_ID,
+        name: 'boards',
         filename: 'remote_entry.js',
         exposes: {
             '.': './src/index',


### PR DESCRIPTION
Since we're referring to this as "boards" in the API requests when it's running as a product, I've renamed the module container to "boards" to match that

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-46275
