### PR TITLE
MM-46725 Add build-product target to compile the Boards product

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -186,6 +186,10 @@ watch-plugin: modd-precheck ## Run and upload the plugin to a development server
 live-watch-plugin: modd-precheck ## Run and update locally the plugin in the development server
 	cd mattermost-plugin; make live-watch
 
+.PHONY: build-product
+build-product: ## Builds the product as something the Mattermost server will pull files from when packaging a release
+	cd mattermost-plugin; make build-product
+
 .PHONY: watch-product
 watch-product: ## Run the product as something the Mattermost web app will watch for
 	cd mattermost-plugin; make watch-product

--- a/mattermost-plugin/Makefile
+++ b/mattermost-plugin/Makefile
@@ -174,6 +174,10 @@ endif
 deploy-from-watch: bundle
 	./build/bin/pluginctl deploy $(PLUGIN_ID) dist/$(BUNDLE_NAME)
 
+.PHONY: build-product
+build-product: apply
+	cd webapp && npm run build:product
+
 .PHONY: watch-product
 watch-product: apply
 	cd webapp && npm run start:product

--- a/mattermost-plugin/webapp/package.json
+++ b/mattermost-plugin/webapp/package.json
@@ -12,6 +12,7 @@
     "test:watch": "jest --watch",
     "test-ci": "jest --forceExit --detectOpenHandles --maxWorkers=2",
     "check-types": "tsc",
+    "build:product": "webpack --mode=production",
     "start:product": "webpack serve --mode=development"
   },
   "devDependencies": {

--- a/mattermost-plugin/webapp/webpack.config.js
+++ b/mattermost-plugin/webapp/webpack.config.js
@@ -12,7 +12,7 @@ const tsTransformer = require('@formatjs/ts-transformer');
 const PLUGIN_ID = require('../plugin.json').id;
 
 const NPM_TARGET = process.env.npm_lifecycle_event; //eslint-disable-line no-process-env
-const TARGET_IS_PRODUCT = NPM_TARGET === 'start:product' || NPM_TARGET === 'build:product';
+const TARGET_IS_PRODUCT = NPM_TARGET?.endsWith(':product');
 
 let mode = 'production';
 let devtool;
@@ -169,6 +169,10 @@ if (TARGET_IS_PRODUCT) {
     config.plugins.push(new webpack.DefinePlugin({
         'process.env.TARGET_IS_PRODUCT': TARGET_IS_PRODUCT, // TODO We might want a better name for this
     }));
+
+    config.output = {
+        path: path.join(__dirname, '/dist'),
+    };
 } else {
     config.resolve.alias['react-intl'] = path.resolve(__dirname, '../../webapp/node_modules/react-intl/');
 


### PR DESCRIPTION
Straightforward enough. One small change other than adding the new target is a slight change to the webpack config when building as a product because the JS code was being output to the wrong place previously for a product.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-46275