### PR TITLE
Remove margin on hover if table readonly

### DIFF
--- a/webapp/src/components/__snapshots__/centerPanel.test.tsx.snap
+++ b/webapp/src/components/__snapshots__/centerPanel.test.tsx.snap
@@ -2153,7 +2153,7 @@ exports[`components/centerPanel return centerPanel and press touch 1 with readon
               </button>
             </div>
             <div
-              class="TableRow octo-table-row"
+              class="TableRow octo-table-row readonly"
               draggable="true"
               style="opacity: 1;"
             >
@@ -2194,7 +2194,7 @@ exports[`components/centerPanel return centerPanel and press touch 1 with readon
               </div>
             </div>
             <div
-              class="TableRow octo-table-row"
+              class="TableRow octo-table-row readonly"
               draggable="true"
               style="opacity: 1;"
             >

--- a/webapp/src/components/table/__snapshots__/table.test.tsx.snap
+++ b/webapp/src/components/table/__snapshots__/table.test.tsx.snap
@@ -1876,7 +1876,7 @@ exports[`components/table/Table limited card in table view 1`] = `
         class="table-row-container"
       >
         <div
-          class="TableRow octo-table-row"
+          class="TableRow octo-table-row readonly"
           draggable="true"
           style="opacity: 1;"
         >
@@ -1955,7 +1955,7 @@ exports[`components/table/Table limited card in table view 1`] = `
           </div>
         </div>
         <div
-          class="TableRow octo-table-row"
+          class="TableRow octo-table-row readonly"
           draggable="true"
           style="opacity: 1;"
         >
@@ -2710,7 +2710,7 @@ exports[`components/table/Table should match snapshot without permissions 1`] = 
         class="table-row-container"
       >
         <div
-          class="TableRow octo-table-row"
+          class="TableRow octo-table-row readonly"
           draggable="true"
           style="opacity: 1;"
         >
@@ -2945,7 +2945,7 @@ exports[`components/table/Table should match snapshot, read-only 1`] = `
         class="table-row-container"
       >
         <div
-          class="TableRow octo-table-row"
+          class="TableRow octo-table-row readonly"
           draggable="true"
           style="opacity: 1;"
         >

--- a/webapp/src/components/table/__snapshots__/tableRow.test.tsx.snap
+++ b/webapp/src/components/table/__snapshots__/tableRow.test.tsx.snap
@@ -333,7 +333,7 @@ exports[`components/table/TableRow should match snapshot, isSelected 1`] = `
 exports[`components/table/TableRow should match snapshot, read-only 1`] = `
 <div>
   <div
-    class="TableRow octo-table-row"
+    class="TableRow octo-table-row readonly"
     draggable="true"
     style="opacity: 1;"
   >

--- a/webapp/src/components/table/tableRow.scss
+++ b/webapp/src/components/table/tableRow.scss
@@ -53,6 +53,10 @@
         }
     }
 
+    &.readonly:hover {
+        margin-left: unset;
+    }
+
     .action-cell {
         display: none;
         margin-left: 20px;

--- a/webapp/src/components/table/tableRow.tsx
+++ b/webapp/src/components/table/tableRow.tsx
@@ -100,6 +100,9 @@ const TableRow = (props: Props) => {
             className += ' hidden'
         }
     }
+    if (props.readonly) {
+        className += ' readonly'
+    }
 
     const handleDeleteCard = useCallback(async () => {
         if (!card) {


### PR DESCRIPTION
#### Summary
The problem was we were always adding `margin-left: -60px`. We should not apply this property when we're not showing the delete menu.

#### Ticket Link
Fixes https://github.com/mattermost/focalboard/issues/3915#event-7516604347
