### PR TITLE
MM-47238 Add MM_BOARDS_DEV_SERVER_URL environment variable for MPA

### DIFF
--- a/mattermost-plugin/webapp/webpack.config.js
+++ b/mattermost-plugin/webapp/webpack.config.js
@@ -116,7 +116,7 @@ const config = {
                 type: 'asset/resource',
                 generator: {
                     filename: '[name][ext]',
-                    publicPath: TARGET_IS_PRODUCT ? 'http://localhost:9006/static/' : '/static/',
+                    publicPath: '/static/',
                 }
             },
         ],
@@ -203,8 +203,18 @@ config.plugins.push(new webpack.DefinePlugin({
 }));
 
 if (NPM_TARGET === 'start:product') {
+    const url = new URL(process.env.MM_BOARDS_DEV_SERVER_URL ?? 'http://localhost:9006');
+
+    for (const rule of config.module.rules) {
+        if (rule.type === 'asset/resource' && rule.generator) {
+            rule.generator.publicPath = url.toString() + 'static/';
+        }
+    }
+
     config.devServer = {
-        port: 9006,
+        https: url.protocol === 'https',
+        host: url.hostname,
+        port: url.port,
         devMiddleware: {
             writeToDisk: false,
         },

--- a/mattermost-plugin/webapp/webpack.config.js
+++ b/mattermost-plugin/webapp/webpack.config.js
@@ -212,7 +212,11 @@ if (NPM_TARGET === 'start:product') {
     }
 
     config.devServer = {
-        https: url.protocol === 'https',
+        https: url.protocol === 'https:' && {
+            minVersion: process.env.MM_SERVICESETTINGS_TLSMINVER,
+            key: process.env.MM_SERVICESETTINGS_TLSKEYFILE,
+            cert: process.env.MM_SERVICESETTINGS_TLSCERTFILE,
+        },
         host: url.hostname,
         port: url.port,
         devMiddleware: {


### PR DESCRIPTION
This makes it so that people who develop MM on a URL other than `http://localhost` can redefine the URL, port, and protocol that the Boards Webpack dev server runs on for MPA development. Without it sets, it still defaults to running the dev server on `http://localhost:9006`

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-47238

#### Related Pull Requests
https://github.com/mattermost/mattermost-server/pull/21435
https://github.com/mattermost/mattermost-webapp/pull/11381

#### Release Note
```release-note
NONE
```
