### PR TITLE
Gh 3942 - fix bug with Boards bot, update link text

### DIFF
--- a/server/app/boards.go
+++ b/server/app/boards.go
@@ -18,8 +18,8 @@ var (
 	ErrNewBoardCannotHaveID = errors.New("new board cannot have an ID")
 )
 
-const linkBoardMessage = "@%s linked Board [%s](%s) with this channel"
-const unlinkBoardMessage = "@%s unlinked Board [%s](%s) with this channel"
+const linkBoardMessage = "@%s linked the board [%s](%s) with this channel"
+const unlinkBoardMessage = "@%s unlinked the board [%s](%s) with this channel"
 
 func (a *App) GetBoard(boardID string) (*model.Board, error) {
 	board, err := a.store.GetBoard(boardID)

--- a/server/services/store/mattermostauthlayer/mattermostauthlayer.go
+++ b/server/services/store/mattermostauthlayer/mattermostauthlayer.go
@@ -1036,8 +1036,10 @@ func (s *MattermostAuthLayer) getBoardsBotID() (string, error) {
 	if boardsBotID == "" {
 		var err error
 		boardsBotID, err = s.servicesAPI.EnsureBot(model.FocalboardBot)
-		s.logger.Error("failed to ensure boards bot", mlog.Err(err))
-		return "", err
+		if err != nil {
+			s.logger.Error("failed to ensure boards bot", mlog.Err(err))
+			return "", err
+		}
 	}
 	return boardsBotID, nil
 }

--- a/server/services/store/mattermostauthlayer/mattermostauthlayer_test.go
+++ b/server/services/store/mattermostauthlayer/mattermostauthlayer_test.go
@@ -13,25 +13,27 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var errTest = errors.New("failed to patch bot")
+
 func TestGetBoardsBotID(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	servicesAPI := mockservicesapi.NewMockServicesAPI(ctrl)
 
 	mmAuthLayer, _ := New("test", nil, nil, mlog.CreateConsoleTestLogger(true, mlog.LvlError), servicesAPI, "")
 
-	servicesAPI.EXPECT().EnsureBot(model.FocalboardBot).Return("", errors.New("failed to patch bot"))
+	servicesAPI.EXPECT().EnsureBot(model.FocalboardBot).Return("", errTest)
 	_, err := mmAuthLayer.getBoardsBotID()
 	require.NotEmpty(t, err)
 
 	servicesAPI.EXPECT().EnsureBot(model.FocalboardBot).Return("TestBotID", nil).Times(1)
-	botId, err := mmAuthLayer.getBoardsBotID()
+	botID, err := mmAuthLayer.getBoardsBotID()
 	require.Empty(t, err)
-	require.NotEmpty(t, botId)
-	require.Equal(t, "TestBotID", botId)
+	require.NotEmpty(t, botID)
+	require.Equal(t, "TestBotID", botID)
 
 	// Call again, should not call "EnsureBot"
-	botId, err = mmAuthLayer.getBoardsBotID()
+	botID, err = mmAuthLayer.getBoardsBotID()
 	require.Empty(t, err)
-	require.NotEmpty(t, botId)
-	require.Equal(t, "TestBotID", botId)
+	require.NotEmpty(t, botID)
+	require.Equal(t, "TestBotID", botID)
 }

--- a/server/services/store/mattermostauthlayer/mattermostauthlayer_test.go
+++ b/server/services/store/mattermostauthlayer/mattermostauthlayer_test.go
@@ -1,0 +1,37 @@
+package mattermostauthlayer
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+
+	"github.com/mattermost/focalboard/server/model"
+	mockservicesapi "github.com/mattermost/focalboard/server/model/mocks"
+	"github.com/mattermost/mattermost-server/v6/shared/mlog"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetBoardsBotID(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	servicesAPI := mockservicesapi.NewMockServicesAPI(ctrl)
+
+	mmAuthLayer, _ := New("test", nil, nil, mlog.CreateConsoleTestLogger(true, mlog.LvlError), servicesAPI, "")
+
+	servicesAPI.EXPECT().EnsureBot(model.FocalboardBot).Return("", errors.New("failed to patch bot"))
+	_, err := mmAuthLayer.getBoardsBotID()
+	require.NotEmpty(t, err)
+
+	servicesAPI.EXPECT().EnsureBot(model.FocalboardBot).Return("TestBotID", nil).Times(1)
+	botId, err := mmAuthLayer.getBoardsBotID()
+	require.Empty(t, err)
+	require.NotEmpty(t, botId)
+	require.Equal(t, "TestBotID", botId)
+
+	// Call again, should not call "EnsureBot"
+	botId, err = mmAuthLayer.getBoardsBotID()
+	require.Empty(t, err)
+	require.NotEmpty(t, botId)
+	require.Equal(t, "TestBotID", botId)
+}


### PR DESCRIPTION
#### Summary
Updates the text displayed when linking a board to a channel.

Second fixes a bug (and adds tests) where the Boards bot would initially fail "EnsureBot", which was the reason for the card, it was implemented, but there was a but. 

#### Ticket Link

  Fixes https://github.com/mattermost/focalboard/issues/3941

Fixes https://community.mattermost.com/boards/team/qghzt68dq7bopgqamcnziq69ao/b4ctmm917q3rzdfi451qtuxjzcw/vn3tt1q8ndj87frb4uyu4936yfh/c9jwpnzupn3yw5kmbpzyhedunwo