### PR TITLE
GH-4007 Fix for welcome screen flashing

### DIFF
--- a/webapp/src/store/users.ts
+++ b/webapp/src/store/users.ts
@@ -26,7 +26,7 @@ export const fetchMe = createAsyncThunk(
             client.getMyConfig(),
         ])
         return {me, myConfig}
-    }
+    },
 )
 
 export const versionProperty = 'version72MessageCanceled'

--- a/webapp/src/store/users.ts
+++ b/webapp/src/store/users.ts
@@ -20,7 +20,13 @@ import {RootState} from './index'
 
 export const fetchMe = createAsyncThunk(
     'users/fetchMe',
-    async () => client.getMe(),
+    async () => {
+        const [me, myConfig] = await Promise.all([
+            client.getMe(),
+            client.getMyConfig(),
+        ])
+        return {me, myConfig}
+    }
 )
 
 export const versionProperty = 'version72MessageCanceled'
@@ -84,12 +90,16 @@ const usersSlice = createSlice({
     },
     extraReducers: (builder) => {
         builder.addCase(fetchMe.fulfilled, (state, action) => {
-            state.me = action.payload || null
+            state.me = action.payload.me || null
             state.loggedIn = Boolean(state.me)
+            if (action.payload.myConfig) {
+                state.myConfig = parseUserProps(action.payload.myConfig)
+            }
         })
         builder.addCase(fetchMe.rejected, (state) => {
             state.me = null
             state.loggedIn = false
+            state.myConfig = {}
         })
 
         // TODO: change this when the initial load is complete


### PR DESCRIPTION

#### Summary
Fixes issue where the "Welcome Screen" flashes when accessing a board using the `boards/team/xx` endpoint. Also fixes issue with "Welcome Screen" always being displayed when accessing the old `boards/workspaces/xxx` endpoint.

The issue is that the users configuration settings are now retrieved as part of "InitialLoad". So when we are initially checking `!myConfig[UserSettingKey.WelcomePageViewed]`, myConfig has not been loaded resulting in the welcome page being displayed.

This PR retrieves `getMyConfig()` as part of `fetchMe`, which is called from the App element, much earlier in the lifecycle. I initially created a separate `fetchMyConfig`, but decided on changing `fetchMe`, since I would have to call `fetchMyConfig` everywhere `fetchMe` is called.

#### Ticket Link

  Fixes #4007 
