### PR TITLE
Update URL to docs page for migrating and reference `.boardarchive`

### DIFF
--- a/import/asana/README.md
+++ b/import/asana/README.md
@@ -5,8 +5,8 @@ This node app converts an Asana json archive into a Focalboard archive. To use:
 2. Save it locally, e.g. to `asana.json`
 3. Run `npm install` from within `focalboard/webapp`
 4. Run `npm install` from within `focalboard/import/asana`
-5. Run `npx ts-node importAsana.ts -i <asana.json> -o archive.focalboard`
-6. In Focalboard, click `Settings`, then `Import archive` and select `archive.focalboard`
+5. Run `npx ts-node importAsana.ts -i <asana.json> -o archive.boardarchive`
+6. In Focalboard, click `Settings`, then `Import archive` and select `archive.boardarchive`
 
 ## Import scope
 

--- a/import/asana/importAsana.ts
+++ b/import/asana/importAsana.ts
@@ -34,7 +34,7 @@ function main() {
     const args: minimist.ParsedArgs = minimist(process.argv.slice(2))
 
     const inputFile = args['i']
-    const outputFile = args['o'] || 'archive.focalboard'
+    const outputFile = args['o'] || 'archive.boardarchive'
 
     if (!inputFile) {
         showHelp()
@@ -184,7 +184,7 @@ function convert(input: Asana): [Board[], Block[]] {
 }
 
 function showHelp() {
-    console.log('import -i <input.json> -o [output.focalboard]')
+    console.log('import -i <input.json> -o [output.boardarchive]')
     exit(1)
 }
 

--- a/import/jira/README.md
+++ b/import/jira/README.md
@@ -6,8 +6,8 @@ This node app converts a Jira xml export into a Focalboard archive. To use:
 3. Save it locally, e.g. to `jira_export.xml`
 4. Run `npm install` from within `focalboard/webapp`
 5. Run `npm install` from within `focalboard/import/jira`
-6. Run `npx ts-node importJira.ts -i <path-to-jira.xml> -o archive.focalboard` (also from within `focalboard/import/jira`)
-7. In Focalboard, click `Settings`, then `Import archive` and select `archive.focalboard`
+6. Run `npx ts-node importJira.ts -i <path-to-jira.xml> -o archive.boardarchive` (also from within `focalboard/import/jira`)
+7. In Focalboard, click `Settings`, then `Import archive` and select `archive.boardarchive`
 
 ## Import scope and known limitations
 

--- a/import/jira/importJira.ts
+++ b/import/jira/importJira.ts
@@ -8,7 +8,7 @@ async function main() {
     const args: minimist.ParsedArgs = minimist(process.argv.slice(2))
 
     const inputFile = args['i']
-    const outputFile = args['o'] || 'archive.focalboard'
+    const outputFile = args['o'] || 'archive.boardarchive'
 
     return run(inputFile, outputFile)
 }

--- a/import/jira/jiraImporter.ts
+++ b/import/jira/jiraImporter.ts
@@ -237,7 +237,7 @@ function optionForPropertyValue(cardProperty: IPropertyTemplate, propertyValue: 
 }
 
 function showHelp() {
-    console.log('import -i <input.xml> -o [output.focalboard]')
+    console.log('import -i <input.xml> -o [output.boardarchive]')
     exit(1)
 }
 

--- a/import/nextcloud-deck/README.md
+++ b/import/nextcloud-deck/README.md
@@ -4,10 +4,10 @@ This node app converts data from a Nextcloud Server with the [app Deck](https://
 
 1. Run `npm install` from within `focalboard/webapp`
 2. Run `npm install` from within `focalboard/import/nextcloud-deck`
-3. Run `npx ts-node importDeck.ts -o archive.focalboard` (also from within `focalboard/import/nextcloud-deck`)
+3. Run `npx ts-node importDeck.ts -o archive.boardarchive` (also from within `focalboard/import/nextcloud-deck`)
    1. Enter URL and credentials (can also be provided via cli arguments)
    2. Enter ID of the board to convert
-4. In Focalboard, click `Settings`, then `Import archive` and select `archive.focalboard`
+4. In Focalboard, click `Settings`, then `Import archive` and select `archive.boardarchive`
 
 ## Import scope
 

--- a/import/nextcloud-deck/importDeck.ts
+++ b/import/nextcloud-deck/importDeck.ts
@@ -47,7 +47,7 @@ async function main() {
     const password = args['p'] ?? readline.question('Password: ', {hideEchoBack: true})
     const boardIdString = args['b']
 
-    const outputFile = args['o'] || 'archive.focalboard'
+    const outputFile = args['o'] || 'archive.boardarchive'
 
     // Create Client
     const deckClient = new NextcloudDeckClient({auth: {username, password}, url})

--- a/import/notion/README.md
+++ b/import/notion/README.md
@@ -6,8 +6,8 @@ This node app converts a Notion CSV and markdown export into a Focalboard archiv
 3. Save it locally, and unzip the folder e.g. to `notion-export`
 4. Run `npm install` from within `focalboard/webapp`
 5. Run `npm install` from within `focalboard/import/notion`
-6. Run `npx ts-node importNotion.ts -i <path to the notion-export folder> -o archive.focalboard`
-7. In Focalboard, click `Settings`, then `Import archive` and select `archive.focalboard`
+6. Run `npx ts-node importNotion.ts -i <path to the notion-export folder> -o archive.boardarchive`
+7. In Focalboard, click `Settings`, then `Import archive` and select `archive.boardarchive`
 
 ## Import scope
 

--- a/import/notion/importNotion.ts
+++ b/import/notion/importNotion.ts
@@ -35,7 +35,7 @@ async function main() {
     const args: minimist.ParsedArgs = minimist(process.argv.slice(2))
 
     const inputFolder = args['i']
-    const outputFile = args['o'] || 'archive.focalboard'
+    const outputFile = args['o'] || 'archive.boardarchive'
 
     if (!inputFolder) {
         showHelp()
@@ -217,7 +217,7 @@ function convert(input: any[], title: string): [Board[], Block[]] {
 }
 
 function showHelp() {
-    console.log('import -i <input.json> -o [output.focalboard]')
+    console.log('import -i <input.json> -o [output.boardarchive]')
     exit(1)
 }
 

--- a/import/todoist/README.md
+++ b/import/todoist/README.md
@@ -8,5 +8,5 @@ This node app converts a Todoist json archive into a Focalboard archive. To use:
 1. Note the name and location of the downloaded *json* file.
 3. Run `npm install` from within `focalboard/webapp`
 4. Run `npm install` from within `focalboard/import/todoist`
-5. Run `npx ts-node importTodoist.ts -i <path-to-todoist.json> -o archive.focalboard` (also from within `focalboard/import/todoist`)
-6. In Focalboard, click `Settings`, then `Import archive` and select `archive.focalboard`
+5. Run `npx ts-node importTodoist.ts -i <path-to-todoist.json> -o archive.boardarchive` (also from within `focalboard/import/todoist`)
+6. In Focalboard, click `Settings`, then `Import archive` and select `archive.boardarchive`

--- a/import/todoist/importTodoist.ts
+++ b/import/todoist/importTodoist.ts
@@ -42,7 +42,7 @@ function main() {
     const args: minimist.ParsedArgs = minimist(process.argv.slice(2))
 
     const inputFile = args['i']
-    const outputFile = args['o'] || 'archive.focalboard'
+    const outputFile = args['o'] || 'archive.boardarchive'
 
     if (!inputFile) {
         showHelp()

--- a/import/trello/README.md
+++ b/import/trello/README.md
@@ -6,8 +6,8 @@ This node app converts a Trello json archive into a Focalboard archive. To use:
 3. Save it locally, e.g. to `trello.json`
 4. Run `npm install` from within `focalboard/webapp`
 5. Run `npm install` from within `focalboard/import/trello`
-6. Run `npx ts-node importTrello.ts -i <path-to-trello.json> -o archive.focalboard` (also from within `focalboard/import/trello`)
-7. In Focalboard, click `Settings`, then `Import archive` and select `archive.focalboard`
+6. Run `npx ts-node importTrello.ts -i <path-to-trello.json> -o archive.boardarchive` (also from within `focalboard/import/trello`)
+7. In Focalboard, click `Settings`, then `Import archive` and select `archive.boardarchive`
 
 ## Import scope
 

--- a/import/trello/importTrello.ts
+++ b/import/trello/importTrello.ts
@@ -35,7 +35,7 @@ function main() {
     const args: minimist.ParsedArgs = minimist(process.argv.slice(2))
 
     const inputFile = args['i']
-    const outputFile = args['o'] || 'archive.focalboard'
+    const outputFile = args['o'] || 'archive.boardarchive'
 
     if (!inputFile) {
         showHelp()
@@ -169,7 +169,7 @@ function convert(input: Trello): [Board[], Block[]] {
 }
 
 function showHelp() {
-    console.log('import -i <input.json> -o [output.focalboard]')
+    console.log('import -i <input.json> -o [output.boardarchive]')
     exit(1)
 }
 

--- a/webapp/src/constants.ts
+++ b/webapp/src/constants.ts
@@ -39,7 +39,7 @@ class Constants {
     static readonly versionString = '7.5.0'
     static readonly versionDisplayString = 'Nov 2022'
 
-    static readonly archiveHelpPage = 'https://docs.mattermost.com/boards/data-and-archives.html'
+    static readonly archiveHelpPage = 'https://docs.mattermost.com/boards/migrate-to-boards.html'
     static readonly imports = [
         {
             id: 'trello',


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute

Assign two reviewers for this pull request from the names suggested. If no names are suggested or you are not sure who to assign, set `Core Focalboard` as the reviewer.
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the ticket).
-->
Noticed the URL to the [docs page for migrating](https://docs.mattermost.com/boards/migrate-to-boards.html) is referencing an old one. This properly redirects, but in that redirect the hash e.g. `#import-from-jira` is lost so the specific section isn't actually linked, just the page as a whole.

Also noticed that the READMEs for the import scripts along with the help text were still referencing the older `.focalboard` extension, so I updated those to the shiny `.boardarchive`. This was correct on the docs site so change necessary there.

cc @justinegeffen 

#### Ticket Link
<!--
If this pull request addresses a Github issue, please link the relevant issue, e.g.

  Fixes https://github.com/mattermost/focalboard/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
n/a
