### PR TITLE
MM-47562 Serve images from the correct URL in product mode

### DIFF
--- a/mattermost-plugin/webapp/webpack.config.js
+++ b/mattermost-plugin/webapp/webpack.config.js
@@ -116,7 +116,7 @@ const config = {
                 type: 'asset/resource',
                 generator: {
                     filename: '[name][ext]',
-                    publicPath: TARGET_IS_PRODUCT ? 'http://localhost:9006/static/' : '/static/',
+                    publicPath: TARGET_IS_PRODUCT ? '/static/products/boards/' : '/static/',
                 }
             },
         ],
@@ -203,8 +203,17 @@ config.plugins.push(new webpack.DefinePlugin({
 }));
 
 if (NPM_TARGET === 'start:product') {
+    const url = new URL('http://localhost:9006');
+
+    for (const rule of config.module.rules) {
+        if (rule.type === 'asset/resource' && rule.generator) {
+            rule.generator.publicPath = url.toString() + 'static/';
+        }
+    }
+
     config.devServer = {
-        port: 9006,
+        host: url.hostname,
+        port: url.port,
         devMiddleware: {
             writeToDisk: false,
         },


### PR DESCRIPTION
This conflicts with https://github.com/mattermost/focalboard/pull/4026, but I didn't want it to have to depend on that one since this one's needed for 7.5 and the other one isn't.

The gist of this change is that line 119 sets the path for static images in product and non-product modes, and then line 206 overrides that only if we're serving the product for development. I would've liked to not set it and then override it below, but I couldn't come up with a better way to keep the webpack dev server setup stuff all together that I was happy with.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-47562