### PR TITLE
MM-47562/MM-47631 Just rely on Webpack for image paths in product mode

### DIFF
--- a/mattermost-plugin/webapp/webpack.config.js
+++ b/mattermost-plugin/webapp/webpack.config.js
@@ -116,7 +116,7 @@ const config = {
                 type: 'asset/resource',
                 generator: {
                     filename: '[name][ext]',
-                    publicPath: TARGET_IS_PRODUCT ? '/static/products/boards/' : '/static/',
+                    publicPath: TARGET_IS_PRODUCT ? undefined : '/static/',
                 }
             },
         ],
@@ -204,12 +204,6 @@ config.plugins.push(new webpack.DefinePlugin({
 
 if (NPM_TARGET === 'start:product') {
     const url = new URL('http://localhost:9006');
-
-    for (const rule of config.module.rules) {
-        if (rule.type === 'asset/resource' && rule.generator) {
-            rule.generator.publicPath = url.toString() + 'static/';
-        }
-    }
 
     config.devServer = {
         host: url.hostname,


### PR DESCRIPTION
Okay, so I know this is reverting my previous PR (https://mattermost.atlassian.net/browse/MM-47562) and conflicts with previous ones as well, but I think I've finally sorted out this asset path thing for products once and for all.

Instead of telling Webpack what the final URL of images will be, we're just letting Webpack figure it out entirely by itself. It does that by using `document.currentScript` (supported on all major browsers) to find where a JS file to find where the images are located. Because of the changes I made in https://github.com/mattermost/focalboard/pull/3748/commits/b9e2263cb519376574f099c06614bcff90f4dc63, JS and images are always located in the same folder.

Because this has been a pain to get working in all cases, I went through and tested a production build with product and plugin mode, both with and without subpaths. For my own sake, I took screenshots of each modes running off the same binary with slightly different configurations with the URLs of an image visible to confirm that it's loading from the right place:
| |Product|Plugin|
|-|-|-|
|Normal|![product](https://user-images.githubusercontent.com/3277310/196826358-9a22b1cf-03f9-424c-a405-6d44e620789e.png)|![plugin](https://user-images.githubusercontent.com/3277310/196826369-d07e264a-0420-4772-a6fd-a8421f9a29b6.png)
|Subpath|![product with subpath](https://user-images.githubusercontent.com/3277310/196826384-5fbb47b2-89c4-4dd8-b151-03415426121b.png)|![plugin with subpath](https://user-images.githubusercontent.com/3277310/196826387-89d6c25d-6db1-4105-ae38-67145e783073.png)|

Something neat with that though is that it was the same binary and just changing environment variables to change the site URL and feature flags between the screenshots, so that's pretty cool.

As a followup, I think we could also change this for the plugin version of Boards as well and get rid of the [`buildURL`](https://github.com/mattermost/focalboard/blob/main/webapp/src/utils.ts#L584) utility function, but I've spent enough time myself trying to wrap my head around this one to try to figure out how to change that. There's also a bit of weirdness where the Focalboard plugin loads JS files from `/static/plugins/focalboard` and images from `/plugins/focalboard/static`, but images are additionally available from `/static/plugins/focalboard`, so I don't know what's up with that.

![static files paths](https://user-images.githubusercontent.com/3277310/196827142-642bc6a4-6121-401d-8004-af4b05096997.png)

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-47562
https://mattermost.atlassian.net/browse/MM-47631