### PR TITLE
Fix Bug #533 - Filter menu does not disappear when clicked for a second time (Board > Filter)

### DIFF
--- a/webapp/src/components/viewHeader/viewHeader.tsx
+++ b/webapp/src/components/viewHeader/viewHeader.tsx
@@ -65,6 +65,7 @@ type Props = {
 
 const ViewHeader = (props: Props) => {
     const [showFilter, setShowFilter] = useState(false)
+    const [lockFilterOnClose, setLockFilterOnClose] = useState(false)
     const intl = useIntl()
     const canEditBoardProperties = useHasCurrentBoardPermissions([Permission.ManageBoardProperties])
 
@@ -197,7 +198,9 @@ const ViewHeader = (props: Props) => {
                 <ModalWrapper>
                     <Button
                         active={hasFilter}
-                        onClick={() => setShowFilter(true)}
+                        onClick={() => setShowFilter(!showFilter)}
+                        onMouseOver={() => setLockFilterOnClose(true)}
+                        onMouseLeave={() => setLockFilterOnClose(false)}
                     >
                         <FormattedMessage
                             id='ViewHeader.filter'
@@ -208,7 +211,11 @@ const ViewHeader = (props: Props) => {
                     <FilterComponent
                         board={board}
                         activeView={activeView}
-                        onClose={() => setShowFilter(false)}
+                        onClose={() => {
+                            if (!lockFilterOnClose) {
+                                setShowFilter(false)
+                            }
+                        }}
                     />}
                 </ModalWrapper>
 

--- a/webapp/src/widgets/buttons/button.tsx
+++ b/webapp/src/widgets/buttons/button.tsx
@@ -7,6 +7,8 @@ import {Utils} from '../../utils'
 
 type Props = {
     onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void
+    onMouseOver?: (e: React.MouseEvent<HTMLButtonElement>) => void
+    onMouseLeave?: (e: React.MouseEvent<HTMLButtonElement>) => void
     onBlur?: (e: React.FocusEvent<HTMLButtonElement>) => void
     children?: React.ReactNode
     title?: string
@@ -37,6 +39,8 @@ function Button(props: Props): JSX.Element {
         <button
             type={props.submit ? 'submit' : 'button'}
             onClick={props.onClick}
+            onMouseOver={props.onMouseOver}
+            onMouseLeave={props.onMouseLeave}
             className={Utils.generateClassName(classNames)}
             title={props.title}
             onBlur={props.onBlur}


### PR DESCRIPTION
This's the PR to fix the Bug [#533](https://github.com/mattermost/focalboard/issues/533) - Filter menu does not disappear when clicked for a second time (Board > Filter)

The revisions and considerations are:

1. In the file "\webapp\src\components\viewHeader\viewHeader.tsx", among the button of <ModalWrapper>, it sets the onClick event to always set setShowFilter(true) . This's why even though we click the filter button again, the filter menu will never disappear.
2. In order to fix it, to revise the function into setShowFilter(!showFilter)
3. However it'll still have problem, because there's the onClose event below to always set setShowFilter(false). 
4. We cannot move out the onClose with setShowFilter(false), because it's triggered when the user clicks other places in the webpage to move out the focus of the Filter button to close the Filter menu, which means that we should only avoid to fire onClose when the cursor is on the Filter button.
5. Therefore, in the Button component, there're two properties added as onMouseOver and onMouseLeave. It'll enable and disable a lock to fire onClose event when the cursor in and out the Filter button, which means that there's only the onClick event controlling the display or disappear when the user is clicking the Filter button in the Header.

Please kindly suggest and feedback. Thank you very much. 