### PR TITLE
[GH-3939] - Updated Margin for GuestBadge

### DIFF
--- a/webapp/src/widgets/guestBadge.scss
+++ b/webapp/src/widgets/guestBadge.scss
@@ -1,7 +1,7 @@
 .GuestBadge {
     display: inline-flex;
     align-items: center;
-    margin: 0 0 0 4px;
+    margin: 0 10px 0 4px;
 }
 
 .GuestBadge__box {


### PR DESCRIPTION
Signed-off-by: Adithya Krishna <adikrish@redhat.com>

#### Summary

Added a margin-right to the guest badge to prevent text being attached or overlapped to the badge itself

#### Ticket Link

Fixes https://github.com/mattermost/focalboard/issues/3939