### PR TITLE
Fix GetMemberForBoard from returning a null member

### DIFF
--- a/server/services/permissions/mmpermissions/mmpermissions.go
+++ b/server/services/permissions/mmpermissions/mmpermissions.go
@@ -24,8 +24,9 @@ type Service struct {
 
 func New(store permissions.Store, api APIInterface, logger mlog.LoggerIFace) *Service {
 	return &Service{
-		store: store,
-		api:   api,
+		store:  store,
+		api:    api,
+		logger: logger,
 	}
 }
 

--- a/server/services/store/mattermostauthlayer/mattermostauthlayer.go
+++ b/server/services/store/mattermostauthlayer/mattermostauthlayer.go
@@ -800,9 +800,9 @@ func (s *MattermostAuthLayer) implicitBoardMembershipsFromRows(rows *sql.Rows) (
 }
 
 func (s *MattermostAuthLayer) GetMemberForBoard(boardID, userID string) (*model.BoardMember, error) {
-	bm, original_error := s.Store.GetMemberForBoard(boardID, userID)
+	bm, originalErr := s.Store.GetMemberForBoard(boardID, userID)
 	// Explicit membership not found
-	if model.IsErrNotFound(original_error) {
+	if model.IsErrNotFound(originalErr) {
 		if userID == model.SystemUserID {
 			return nil, model.NewErrNotFound(userID)
 		}
@@ -867,8 +867,8 @@ func (s *MattermostAuthLayer) GetMemberForBoard(boardID, userID string) (*model.
 			}, nil
 		}
 	}
-	if original_error != nil {
-		return nil, original_error
+	if originalErr != nil {
+		return nil, originalErr
 	}
 	return bm, nil
 }

--- a/server/services/store/mattermostauthlayer/mattermostauthlayer.go
+++ b/server/services/store/mattermostauthlayer/mattermostauthlayer.go
@@ -800,15 +800,15 @@ func (s *MattermostAuthLayer) implicitBoardMembershipsFromRows(rows *sql.Rows) (
 }
 
 func (s *MattermostAuthLayer) GetMemberForBoard(boardID, userID string) (*model.BoardMember, error) {
-	bm, err := s.Store.GetMemberForBoard(boardID, userID)
+	bm, original_error := s.Store.GetMemberForBoard(boardID, userID)
 	// Explicit membership not found
-	if model.IsErrNotFound(err) {
+	if model.IsErrNotFound(original_error) {
 		if userID == model.SystemUserID {
 			return nil, model.NewErrNotFound(userID)
 		}
 		var user *model.User
 		// No synthetic memberships for guests
-		user, err = s.GetUserByID(userID)
+		user, err := s.GetUserByID(userID)
 		if err != nil {
 			return nil, err
 		}
@@ -867,8 +867,8 @@ func (s *MattermostAuthLayer) GetMemberForBoard(boardID, userID string) (*model.
 			}, nil
 		}
 	}
-	if err != nil {
-		return nil, err
+	if original_error != nil {
+		return nil, original_error
 	}
 	return bm, nil
 }


### PR DESCRIPTION
#### Summary
GetMemberForBoard can return a nil member if the member is not found and it meets no other membership criteria. This is due to the `err` variable being reset within the `if()` clause, but no member being created.

Updated to a more specific error variable, so it will hopefully not be overwritten in the future. The function is fragile and should be rewritten.

#### Ticket Link

  Fixes https://github.com/mattermost/focalboard/issues/4059
  Fixes https://mattermost.atlassian.net/browse/MM-47528
