### PR TITLE
[GH-3938] Fix: Duplicated board as template should be in the default category

### DIFF
--- a/server/app/boards.go
+++ b/server/app/boards.go
@@ -183,9 +183,11 @@ func (a *App) DuplicateBoard(boardID, userID, toTeam string, asTemplate bool) (*
 		a.logger.Error("Could not copy files while duplicating board", mlog.String("BoardID", boardID), mlog.Err(err))
 	}
 
-	for _, board := range bab.Boards {
-		if categoryErr := a.setBoardCategoryFromSource(boardID, board.ID, userID, board.TeamID); categoryErr != nil {
-			return nil, nil, categoryErr
+	if !asTemplate {
+		for _, board := range bab.Boards {
+			if categoryErr := a.setBoardCategoryFromSource(boardID, board.ID, userID, board.TeamID); categoryErr != nil {
+				return nil, nil, categoryErr
+			}
 		}
 	}
 

--- a/server/integrationtests/board_test.go
+++ b/server/integrationtests/board_test.go
@@ -2090,6 +2090,108 @@ func TestDuplicateBoard(t *testing.T) {
 		}
 		require.Equal(t, createdCategory.ID, duplicateBoardCategoryID)
 	})
+
+	t.Run("create and duplicate public board from a custom category", func(t *testing.T) {
+		th := SetupTestHelper(t).InitBasic()
+		defer th.TearDown()
+
+		me := th.GetUser1()
+		teamID := testTeamID
+
+		category := model.Category{
+			Name:   "My Category",
+			UserID: me.ID,
+			TeamID: teamID,
+		}
+		createdCategory, resp := th.Client.CreateCategory(category)
+		th.CheckOK(resp)
+		require.NoError(t, resp.Error)
+		require.NotNil(t, createdCategory)
+		require.Equal(t, "My Category", createdCategory.Name)
+		require.Equal(t, me.ID, createdCategory.UserID)
+		require.Equal(t, teamID, createdCategory.TeamID)
+
+		title := "Public board"
+		newBoard := &model.Board{
+			Title:  title,
+			Type:   model.BoardTypeOpen,
+			TeamID: teamID,
+		}
+		board, resp := th.Client.CreateBoard(newBoard)
+		th.CheckOK(resp)
+		require.NoError(t, resp.Error)
+		require.NotNil(t, board)
+		require.NotNil(t, board.ID)
+		require.Equal(t, title, board.Title)
+		require.Equal(t, model.BoardTypeOpen, board.Type)
+		require.Equal(t, teamID, board.TeamID)
+		require.Equal(t, me.ID, board.CreatedBy)
+		require.Equal(t, me.ID, board.ModifiedBy)
+
+		// move board to custom category
+		resp = th.Client.UpdateCategoryBoard(teamID, createdCategory.ID, board.ID)
+		th.CheckOK(resp)
+		require.NoError(t, resp.Error)
+
+		newBlocks := []model.Block{
+			{
+				ID:       utils.NewID(utils.IDTypeBlock),
+				BoardID:  board.ID,
+				CreateAt: 1,
+				UpdateAt: 1,
+				Title:    "View 1",
+				Type:     model.TypeView,
+			},
+		}
+
+		newBlocks, resp = th.Client.InsertBlocks(board.ID, newBlocks, false)
+		require.NoError(t, resp.Error)
+		require.Len(t, newBlocks, 1)
+
+		newUserMember := &model.BoardMember{
+			UserID:       th.GetUser2().ID,
+			BoardID:      board.ID,
+			SchemeEditor: true,
+		}
+		th.Client.AddMemberToBoard(newUserMember)
+
+		members, err := th.Server.App().GetMembersForBoard(board.ID)
+		require.NoError(t, err)
+		require.Len(t, members, 2)
+
+		// Duplicate the board
+		rBoardsAndBlock, resp := th.Client.DuplicateBoard(board.ID, false, teamID)
+		th.CheckOK(resp)
+		require.NotNil(t, rBoardsAndBlock)
+		require.Equal(t, len(rBoardsAndBlock.Boards), 1)
+		require.Equal(t, len(rBoardsAndBlock.Blocks), 1)
+
+		duplicateBoard := rBoardsAndBlock.Boards[0]
+		require.Equal(t, duplicateBoard.Type, model.BoardTypePrivate, "Duplicated board should be private")
+		require.Equal(t, "Public board copy", duplicateBoard.Title)
+
+		members, err = th.Server.App().GetMembersForBoard(duplicateBoard.ID)
+		require.NoError(t, err)
+		require.Len(t, members, 1, "Duplicated board should only have one member")
+		require.Equal(t, me.ID, members[0].UserID)
+		require.Equal(t, duplicateBoard.ID, members[0].BoardID)
+		require.True(t, members[0].SchemeAdmin)
+
+		// verify duplicated board is in the same custom category
+		userCategoryBoards, resp := th.Client.GetUserCategoryBoards(teamID)
+		th.CheckOK(resp)
+		require.NotNil(t, rBoardsAndBlock)
+
+		var duplicateBoardCategoryID string
+		for _, categoryBoard := range userCategoryBoards {
+			for _, boardID := range categoryBoard.BoardIDs {
+				if boardID == duplicateBoard.ID {
+					duplicateBoardCategoryID = categoryBoard.Category.ID
+				}
+			}
+		}
+		require.Equal(t, createdCategory.ID, duplicateBoardCategoryID)
+	})
 }
 
 func TestJoinBoard(t *testing.T) {

--- a/server/integrationtests/board_test.go
+++ b/server/integrationtests/board_test.go
@@ -2091,7 +2091,7 @@ func TestDuplicateBoard(t *testing.T) {
 		require.Equal(t, createdCategory.ID, duplicateBoardCategoryID)
 	})
 
-	t.Run("create and duplicate public board from a custom category", func(t *testing.T) {
+	t.Run("create and duplicate public board from a custom category as template", func(t *testing.T) {
 		th := SetupTestHelper(t).InitBasic()
 		defer th.TearDown()
 
@@ -2160,7 +2160,7 @@ func TestDuplicateBoard(t *testing.T) {
 		require.Len(t, members, 2)
 
 		// Duplicate the board
-		rBoardsAndBlock, resp := th.Client.DuplicateBoard(board.ID, false, teamID)
+		rBoardsAndBlock, resp := th.Client.DuplicateBoard(board.ID, true, teamID)
 		th.CheckOK(resp)
 		require.NotNil(t, rBoardsAndBlock)
 		require.Equal(t, len(rBoardsAndBlock.Boards), 1)
@@ -2168,7 +2168,7 @@ func TestDuplicateBoard(t *testing.T) {
 
 		duplicateBoard := rBoardsAndBlock.Boards[0]
 		require.Equal(t, duplicateBoard.Type, model.BoardTypePrivate, "Duplicated board should be private")
-		require.Equal(t, "Public board copy", duplicateBoard.Title)
+		require.Equal(t, "New board template", duplicateBoard.Title)
 
 		members, err = th.Server.App().GetMembersForBoard(duplicateBoard.ID)
 		require.NoError(t, err)
@@ -2177,7 +2177,7 @@ func TestDuplicateBoard(t *testing.T) {
 		require.Equal(t, duplicateBoard.ID, members[0].BoardID)
 		require.True(t, members[0].SchemeAdmin)
 
-		// verify duplicated board is in the same custom category
+		// verify duplicated board is in the default Boards category (i.e. not the same custom category as the source board)
 		userCategoryBoards, resp := th.Client.GetUserCategoryBoards(teamID)
 		th.CheckOK(resp)
 		require.NotNil(t, rBoardsAndBlock)
@@ -2190,7 +2190,7 @@ func TestDuplicateBoard(t *testing.T) {
 				}
 			}
 		}
-		require.Equal(t, createdCategory.ID, duplicateBoardCategoryID)
+		require.Nil(t, duplicateBoardCategoryID)
 	})
 }
 

--- a/server/integrationtests/board_test.go
+++ b/server/integrationtests/board_test.go
@@ -2180,7 +2180,6 @@ func TestDuplicateBoard(t *testing.T) {
 		// verify duplicated board is in the default Boards category (i.e. not the same custom category as the source board)
 		userCategoryBoards, resp := th.Client.GetUserCategoryBoards(teamID)
 		th.CheckOK(resp)
-		require.NotNil(t, rBoardsAndBlock)
 
 		var duplicateBoardCategoryID string
 		for _, categoryBoard := range userCategoryBoards {
@@ -2190,7 +2189,7 @@ func TestDuplicateBoard(t *testing.T) {
 				}
 			}
 		}
-		require.Nil(t, duplicateBoardCategoryID)
+		require.Empty(t, duplicateBoardCategoryID)
 	})
 }
 

--- a/webapp/src/components/sidebar/sidebarBoardItem.tsx
+++ b/webapp/src/components/sidebar/sidebarBoardItem.tsx
@@ -116,8 +116,8 @@ const SidebarBoardItem = (props: Props) => {
 
         const boardId = blocksAndBoards.boards[0].id
 
-        // If the source board is in a custom category, set the new board in
-        // the same category. Even though the server does this as well on its side,
+        // If the source board is in a custom category and is not being duplicated as a template,
+        // set the new board in the same category. Even though the server does this as well on its side,
         // we need to do this to avoid the duplicated board showing up in default "Boards" category first
         // then jumping to the custom category.
         // The jump would happen because when server clones a board from a custom category,
@@ -128,7 +128,7 @@ const SidebarBoardItem = (props: Props) => {
         // to the correct category.
         // By not waiting for the board-category WS event and setting the right category for the board,
         // we avoid the jumping behavior.
-        if (props.categoryBoards.id !== '') {
+        if (!asTemplate && props.categoryBoards.id !== '') {
             await dispatch(updateBoardCategories([{
                 boardID: boardId,
                 categoryID: props.categoryBoards.id,


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

Assign two reviewers for this pull request from the names suggested. If no names are suggested or you are not sure who to assign, set `Core Focalboard` as the reviewer.
-->

#### Summary
##### What
When a board in a custom category is duplicated as a template (e.g. using the "New template from board" menu option), the new template should be in the default Boards category. Currently, it is added to the same category as the source board.

##### How
* Server: Changed to not assign a category if duplicating as a template.
This change is tested via an integration test. I usually prefer to have unit tests in addition, but the current behaviour is integration-tested (and not unit-tested). I'm not sure what the intended testing strategy is for this project, so please let me know if you think a unit test would be useful here.
* Web app: The web app adds the duplicated board to the same category immediately (i.e. before receiving the update from the server), so I changed it to not do that if duplicating as a template.
The existing behaviour here is not tested and I would need some suggestions on how to do that if you think we should test that change.

I tested the change locally with the Mattermost Boards Plugin and it works as expected.

#### Ticket Link
Fixes https://github.com/mattermost/focalboard/issues/3938
