### PR TITLE
[GH-1007] Fix popup menus visibility

### DIFF
--- a/mattermost-plugin/webapp/src/components/__snapshots__/rhsChannelBoardItem.test.tsx.snap
+++ b/mattermost-plugin/webapp/src/components/__snapshots__/rhsChannelBoardItem.test.tsx.snap
@@ -61,7 +61,7 @@ exports[`components/rhsChannelBoardItem render board with menu open 1`] = `
       </span>
       <div
         aria-label="menuwrapper"
-        class="MenuWrapper"
+        class="MenuWrapper override menuOpened"
         role="button"
       >
         <button

--- a/webapp/src/components/__snapshots__/blockIconSelector.test.tsx.snap
+++ b/webapp/src/components/__snapshots__/blockIconSelector.test.tsx.snap
@@ -29,7 +29,7 @@ exports[`components/blockIconSelector return menu on click 1`] = `
   >
     <div
       aria-label="menuwrapper"
-      class="MenuWrapper"
+      class="MenuWrapper override menuOpened"
       role="button"
     >
       <div

--- a/webapp/src/components/__snapshots__/cardDialog.test.tsx.snap
+++ b/webapp/src/components/__snapshots__/cardDialog.test.tsx.snap
@@ -590,7 +590,7 @@ exports[`components/cardDialog return cardDialog menu content 1`] = `
             </div>
             <div
               aria-label="menuwrapper"
-              class="MenuWrapper"
+              class="MenuWrapper override menuOpened"
               role="button"
             >
               <button

--- a/webapp/src/components/__snapshots__/centerPanel.test.tsx.snap
+++ b/webapp/src/components/__snapshots__/centerPanel.test.tsx.snap
@@ -1167,7 +1167,7 @@ exports[`components/centerPanel return centerPanel and click on card to show car
               role="button"
             >
               <button
-                class="IconButton"
+                class="IconButton CardActionsMenuIcon"
                 type="button"
               >
                 <i
@@ -1201,7 +1201,7 @@ exports[`components/centerPanel return centerPanel and click on card to show car
               role="button"
             >
               <button
-                class="IconButton"
+                class="IconButton CardActionsMenuIcon"
                 type="button"
               >
                 <i
@@ -8393,7 +8393,7 @@ exports[`components/centerPanel should match snapshot for Gallery 1`] = `
           role="button"
         >
           <button
-            class="IconButton"
+            class="IconButton CardActionsMenuIcon"
             type="button"
           >
             <i
@@ -8884,7 +8884,7 @@ exports[`components/centerPanel should match snapshot for Kanban 1`] = `
               role="button"
             >
               <button
-                class="IconButton"
+                class="IconButton CardActionsMenuIcon"
                 type="button"
               >
                 <i
@@ -9403,7 +9403,7 @@ exports[`components/centerPanel should match snapshot for Kanban, not shared 1`]
               role="button"
             >
               <button
-                class="IconButton"
+                class="IconButton CardActionsMenuIcon"
                 type="button"
               >
                 <i

--- a/webapp/src/components/__snapshots__/contentBlock.test.tsx.snap
+++ b/webapp/src/components/__snapshots__/contentBlock.test.tsx.snap
@@ -6,14 +6,14 @@ exports[`components/contentBlock return commentBlock and click on menuwrapper 1`
     class="rowContents"
   >
     <div
-      class="ContentBlock octo-block"
+      class="ContentBlock octo-block menuOpened"
     >
       <div
         class="octo-block-margin"
       >
         <div
           aria-label="menuwrapper"
-          class="MenuWrapper"
+          class="MenuWrapper override menuOpened"
           role="button"
         >
           <button

--- a/webapp/src/components/calendar/__snapshots__/fullCalendar.test.tsx.snap
+++ b/webapp/src/components/calendar/__snapshots__/fullCalendar.test.tsx.snap
@@ -733,7 +733,7 @@ exports[`components/calendar/toolbar return calendar, no date property 1`] = `
                                               role="button"
                                             >
                                               <button
-                                                class="IconButton"
+                                                class="IconButton CardActionsMenuIcon"
                                                 type="button"
                                               >
                                                 <i
@@ -3007,7 +3007,7 @@ exports[`components/calendar/toolbar return calendar, with date property not set
                                               role="button"
                                             >
                                               <button
-                                                class="IconButton"
+                                                class="IconButton CardActionsMenuIcon"
                                                 type="button"
                                               >
                                                 <i
@@ -5979,7 +5979,7 @@ exports[`components/calendar/toolbar return calendar, with date property set 1`]
                                               role="button"
                                             >
                                               <button
-                                                class="IconButton"
+                                                class="IconButton CardActionsMenuIcon"
                                                 type="button"
                                               >
                                                 <i
@@ -7561,7 +7561,7 @@ exports[`components/calendar/toolbar return calendar, without permissions 1`] = 
                                               role="button"
                                             >
                                               <button
-                                                class="IconButton"
+                                                class="IconButton CardActionsMenuIcon"
                                                 type="button"
                                               >
                                                 <i

--- a/webapp/src/components/calendar/fullCalendar.tsx
+++ b/webapp/src/components/calendar/fullCalendar.tsx
@@ -25,10 +25,9 @@ import ConfirmationDialogBox, {ConfirmationDialogBoxProps} from '../confirmation
 
 import './fullcalendar.scss'
 import MenuWrapper from '../../widgets/menuWrapper'
-import IconButton from '../../widgets/buttons/iconButton'
 import CardActionsMenu from '../cardActionsMenu/cardActionsMenu'
-import OptionsIcon from '../../widgets/icons/options'
 import TelemetryClient, {TelemetryActions, TelemetryCategory} from '../../telemetry/telemetryClient'
+import CardActionsMenuIcon from '../cardActionsMenu/cardActionsMenuIcon'
 
 const oneDay = 60 * 60 * 24 * 1000
 
@@ -156,7 +155,7 @@ const CalendarFullView = (props: Props): JSX.Element|null => {
                         className='optionsMenu'
                         stopPropagationOnToggle={true}
                     >
-                        <IconButton icon={<OptionsIcon/>}/>
+                        <CardActionsMenuIcon/>
                         <CardActionsMenu
                             cardId={card.id}
                             onClickDelete={() => openConfirmationDialogBox(card)}

--- a/webapp/src/components/calendar/fullcalendar.scss
+++ b/webapp/src/components/calendar/fullcalendar.scss
@@ -38,10 +38,6 @@
         position: absolute;
         right: 0;
         top: 0;
-
-        .IconButton {
-            background-color: rgba(var(--center-channel-color-rgb), 0.13);
-        }
     }
 
     .octo-tooltip {

--- a/webapp/src/components/cardActionsMenu/cardActionsMenuIcon.scss
+++ b/webapp/src/components/cardActionsMenu/cardActionsMenuIcon.scss
@@ -1,0 +1,12 @@
+.CardActionsMenuIcon {
+    border-radius: 3px;
+    padding: 0;
+    box-shadow: rgba(var(--center-channel-color-rgb), 0.1) 0 0 0 1px,
+        rgba(var(--center-channel-color-rgb), 0.1) 0 2px 4px;
+    height: 24px;
+    width: 24px;
+
+    &:hover {
+        background: rgb(var(--center-channel-color-rgb), 0.1);
+    }
+}

--- a/webapp/src/components/cardActionsMenu/cardActionsMenuIcon.tsx
+++ b/webapp/src/components/cardActionsMenu/cardActionsMenuIcon.tsx
@@ -1,0 +1,20 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react'
+
+import OptionsIcon from '../../widgets/icons/options'
+import IconButton from '../../widgets/buttons/iconButton'
+
+import './cardActionsMenuIcon.scss'
+
+const CardActionsMenuIcon = () => {
+    return (
+        <IconButton
+            className='CardActionsMenuIcon'
+            icon={<OptionsIcon/>}
+        />
+    )
+}
+
+export default CardActionsMenuIcon

--- a/webapp/src/components/cardDetail/__snapshots__/cardDetailContentsMenu.test.tsx.snap
+++ b/webapp/src/components/cardDetail/__snapshots__/cardDetailContentsMenu.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`components/cardDetail/cardDetailContentsMenu return cardDetailContentsM
   >
     <div
       aria-label="menuwrapper"
-      class="MenuWrapper"
+      class="MenuWrapper override menuOpened"
       role="button"
     >
       <button
@@ -222,7 +222,7 @@ exports[`components/cardDetail/cardDetailContentsMenu return cardDetailContentsM
   >
     <div
       aria-label="menuwrapper"
-      class="MenuWrapper"
+      class="MenuWrapper override menuOpened"
       role="button"
     >
       <button
@@ -437,7 +437,7 @@ exports[`components/cardDetail/cardDetailContentsMenu return cardDetailContentsM
   >
     <div
       aria-label="menuwrapper"
-      class="MenuWrapper"
+      class="MenuWrapper override menuOpened"
       role="button"
     >
       <button

--- a/webapp/src/components/cardDetail/__snapshots__/cardDetailProperties.test.tsx.snap
+++ b/webapp/src/components/cardDetail/__snapshots__/cardDetailProperties.test.tsx.snap
@@ -262,7 +262,7 @@ exports[`components/cardDetail/CardDetailProperties should show property types m
     >
       <div
         aria-label="menuwrapper"
-        class="MenuWrapper"
+        class="MenuWrapper override menuOpened"
         role="button"
       >
         <button

--- a/webapp/src/components/cardDetail/__snapshots__/comment.test.tsx.snap
+++ b/webapp/src/components/cardDetail/__snapshots__/comment.test.tsx.snap
@@ -29,7 +29,7 @@ exports[`components/cardDetail/comment return comment 1`] = `
       </div>
       <div
         aria-label="menuwrapper"
-        class="MenuWrapper"
+        class="MenuWrapper override menuOpened"
         role="button"
       >
         <button
@@ -157,7 +157,7 @@ exports[`components/cardDetail/comment return comment and delete comment 1`] = `
       </div>
       <div
         aria-label="menuwrapper"
-        class="MenuWrapper"
+        class="MenuWrapper override menuOpened"
         role="button"
       >
         <button
@@ -333,7 +333,7 @@ exports[`components/cardDetail/comment return guest comment 1`] = `
       </div>
       <div
         aria-label="menuwrapper"
-        class="MenuWrapper"
+        class="MenuWrapper override menuOpened"
         role="button"
       >
         <button
@@ -470,7 +470,7 @@ exports[`components/cardDetail/comment return guest comment and delete comment 1
       </div>
       <div
         aria-label="menuwrapper"
-        class="MenuWrapper"
+        class="MenuWrapper override menuOpened"
         role="button"
       >
         <button

--- a/webapp/src/components/contentBlock.scss
+++ b/webapp/src/components/contentBlock.scss
@@ -1,3 +1,5 @@
+@import '../styles/z-index';
+
 .ContentBlock {
     // HACK: Fixes Chrome drag and drop preview
     transform: translate3d(0, 0, 0);
@@ -7,7 +9,10 @@
         display: none;
     }
 
-    &:hover {
+    &:hover,
+    &.menuOpened {
+        @include z-index(menu);
+
         .MenuWrapper {
             display: flex;
         }

--- a/webapp/src/components/contentBlock.tsx
+++ b/webapp/src/components/contentBlock.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React from 'react'
+import React, {useState} from 'react'
 import {useIntl} from 'react-intl'
 
 import {Card} from '../blocks/card'
@@ -41,6 +41,7 @@ const ContentBlock = (props: Props): JSX.Element => {
     const [, , gripRef, itemRef] = useSortableWithGrip('content', {block, cords}, true, () => {})
     const [, isOver2,, itemRef2] = useSortableWithGrip('content', {block, cords}, true, (src, dst) => props.onDrop(src, dst, 'right'))
     const [, isOver3,, itemRef3] = useSortableWithGrip('content', {block, cords}, true, (src, dst) => props.onDrop(src, dst, 'left'))
+    const [menuOpened, setMenuOpened] = useState(false)
 
     const index = cords.x
     const colIndex = (cords.y || cords.y === 0) && cords.y > -1 ? cords.y : -1
@@ -55,7 +56,11 @@ const ContentBlock = (props: Props): JSX.Element => {
         }
     }
 
-    const className = 'ContentBlock octo-block'
+    let className = 'ContentBlock octo-block'
+    if (menuOpened) {
+        className += ' menuOpened'
+    }
+
     return (
         <div
             className='rowContents'
@@ -67,7 +72,7 @@ const ContentBlock = (props: Props): JSX.Element => {
             >
                 <div className='octo-block-margin'>
                     {!props.readonly &&
-                    <MenuWrapper>
+                    <MenuWrapper onToggle={setMenuOpened}>
                         <IconButton icon={<OptionsIcon/>}/>
                         <Menu>
                             {index > 0 &&
@@ -94,6 +99,7 @@ const ContentBlock = (props: Props): JSX.Element => {
                                 id='insertAbove'
                                 name={intl.formatMessage({id: 'ContentBlock.insertAbove', defaultMessage: 'Insert above'})}
                                 icon={<AddIcon/>}
+                                position='top'
                             >
                                 {contentRegistry.contentTypes.map((type) => (
                                     <AddContentMenuItem

--- a/webapp/src/components/gallery/__snapshots__/gallery.test.tsx.snap
+++ b/webapp/src/components/gallery/__snapshots__/gallery.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`src/components/gallery/Gallery limited card count check 1`] = `
         role="button"
       >
         <button
-          class="IconButton"
+          class="IconButton CardActionsMenuIcon"
           type="button"
         >
           <i
@@ -39,7 +39,7 @@ exports[`src/components/gallery/Gallery limited card count check 1`] = `
         role="button"
       >
         <button
-          class="IconButton"
+          class="IconButton CardActionsMenuIcon"
           type="button"
         >
           <i
@@ -98,7 +98,7 @@ exports[`src/components/gallery/Gallery return Gallery and click new 1`] = `
         role="button"
       >
         <button
-          class="IconButton"
+          class="IconButton CardActionsMenuIcon"
           type="button"
         >
           <i
@@ -128,7 +128,7 @@ exports[`src/components/gallery/Gallery return Gallery and click new 1`] = `
         role="button"
       >
         <button
-          class="IconButton"
+          class="IconButton CardActionsMenuIcon"
           type="button"
         >
           <i
@@ -195,11 +195,11 @@ exports[`src/components/gallery/Gallery should match snapshot 1`] = `
     >
       <div
         aria-label="menuwrapper"
-        class="MenuWrapper optionsMenu"
+        class="MenuWrapper override menuOpened optionsMenu"
         role="button"
       >
         <button
-          class="IconButton"
+          class="IconButton CardActionsMenuIcon"
           type="button"
         >
           <i
@@ -365,7 +365,7 @@ exports[`src/components/gallery/Gallery should match snapshot 1`] = `
         role="button"
       >
         <button
-          class="IconButton"
+          class="IconButton CardActionsMenuIcon"
           type="button"
         >
           <i
@@ -398,11 +398,11 @@ exports[`src/components/gallery/Gallery should match snapshot without permission
     >
       <div
         aria-label="menuwrapper"
-        class="MenuWrapper optionsMenu"
+        class="MenuWrapper override menuOpened optionsMenu"
         role="button"
       >
         <button
-          class="IconButton"
+          class="IconButton CardActionsMenuIcon"
           type="button"
         >
           <i
@@ -509,7 +509,7 @@ exports[`src/components/gallery/Gallery should match snapshot without permission
         role="button"
       >
         <button
-          class="IconButton"
+          class="IconButton CardActionsMenuIcon"
           type="button"
         >
           <i

--- a/webapp/src/components/gallery/__snapshots__/galleryCard.test.tsx.snap
+++ b/webapp/src/components/gallery/__snapshots__/galleryCard.test.tsx.snap
@@ -37,7 +37,7 @@ exports[`src/components/gallery/GalleryCard with a comment content should match 
   >
     <div
       aria-label="menuwrapper"
-      class="MenuWrapper optionsMenu"
+      class="MenuWrapper override menuOpened optionsMenu"
       role="button"
     >
       <button
@@ -214,7 +214,7 @@ exports[`src/components/gallery/GalleryCard with an image content should match s
   >
     <div
       aria-label="menuwrapper"
-      class="MenuWrapper optionsMenu"
+      class="MenuWrapper override menuOpened optionsMenu"
       role="button"
     >
       <button
@@ -429,7 +429,7 @@ exports[`src/components/gallery/GalleryCard with many contents should match snap
   >
     <div
       aria-label="menuwrapper"
-      class="MenuWrapper optionsMenu"
+      class="MenuWrapper override menuOpened optionsMenu"
       role="button"
     >
       <button
@@ -610,7 +610,7 @@ exports[`src/components/gallery/GalleryCard with many images content should matc
   >
     <div
       aria-label="menuwrapper"
-      class="MenuWrapper optionsMenu"
+      class="MenuWrapper override menuOpened optionsMenu"
       role="button"
     >
       <button
@@ -1028,7 +1028,7 @@ exports[`src/components/gallery/GalleryCard without block content should match s
   >
     <div
       aria-label="menuwrapper"
-      class="MenuWrapper optionsMenu"
+      class="MenuWrapper override menuOpened optionsMenu"
       role="button"
     >
       <button

--- a/webapp/src/components/gallery/galleryCard.scss
+++ b/webapp/src/components/gallery/galleryCard.scss
@@ -34,10 +34,6 @@
         position: absolute;
         right: 10px;
         top: 10px;
-
-        .IconButton {
-            background-color: rgba(var(--center-channel-color-rgb), 0.13);
-        }
     }
 
     .gallery-item {

--- a/webapp/src/components/gallery/galleryCard.tsx
+++ b/webapp/src/components/gallery/galleryCard.tsx
@@ -11,8 +11,6 @@ import mutator from '../../mutator'
 import {getCardContents} from '../../store/contents'
 import {useAppSelector} from '../../store/hooks'
 import TelemetryClient, {TelemetryActions, TelemetryCategory} from '../../telemetry/telemetryClient'
-import IconButton from '../../widgets/buttons/iconButton'
-import OptionsIcon from '../../widgets/icons/options'
 import MenuWrapper from '../../widgets/menuWrapper'
 import Tooltip from '../../widgets/tooltip'
 import {CardDetailProvider} from '../cardDetail/cardDetailContext'
@@ -23,6 +21,7 @@ import './galleryCard.scss'
 import CardBadges from '../cardBadges'
 import CardActionsMenu from '../cardActionsMenu/cardActionsMenu'
 import ConfirmationDialogBox, {ConfirmationDialogBoxProps} from '../confirmationDialogBox'
+import CardActionsMenuIcon from '../cardActionsMenu/cardActionsMenuIcon'
 
 type Props = {
     board: Board
@@ -90,7 +89,7 @@ const GalleryCard = (props: Props) => {
                         className='optionsMenu'
                         stopPropagationOnToggle={true}
                     >
-                        <IconButton icon={<OptionsIcon/>}/>
+                        <CardActionsMenuIcon/>
                         <CardActionsMenu
                             cardId={card!.id}
                             onClickDelete={() => setShowConfirmationDialogBox(true)}

--- a/webapp/src/components/globalHeader/__snapshots__/globalHeaderSettingsMenu.test.tsx.snap
+++ b/webapp/src/components/globalHeader/__snapshots__/globalHeaderSettingsMenu.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`components/sidebar/GlobalHeaderSettingsMenu imports menu open should ma
   >
     <div
       aria-label="menuwrapper"
-      class="MenuWrapper"
+      class="MenuWrapper override menuOpened"
       role="button"
     >
       <div
@@ -353,7 +353,7 @@ exports[`components/sidebar/GlobalHeaderSettingsMenu languages menu open should 
   >
     <div
       aria-label="menuwrapper"
-      class="MenuWrapper"
+      class="MenuWrapper override menuOpened"
       role="button"
     >
       <div
@@ -1002,7 +1002,7 @@ exports[`components/sidebar/GlobalHeaderSettingsMenu settings menu open should m
   >
     <div
       aria-label="menuwrapper"
-      class="MenuWrapper"
+      class="MenuWrapper override menuOpened"
       role="button"
     >
       <div

--- a/webapp/src/components/kanban/__snapshots__/kanbanCard.test.tsx.snap
+++ b/webapp/src/components/kanban/__snapshots__/kanbanCard.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`src/components/kanban/kanbanCard return kanbanCard and click on copy li
   >
     <div
       aria-label="menuwrapper"
-      class="MenuWrapper optionsMenu "
+      class="MenuWrapper override menuOpened optionsMenu "
       role="button"
     >
       <button
@@ -191,7 +191,7 @@ exports[`src/components/kanban/kanbanCard return kanbanCard and click on delete 
   >
     <div
       aria-label="menuwrapper"
-      class="MenuWrapper optionsMenu "
+      class="MenuWrapper override menuOpened optionsMenu "
       role="button"
     >
       <button
@@ -373,7 +373,7 @@ exports[`src/components/kanban/kanbanCard return kanbanCard and click on duplica
   >
     <div
       aria-label="menuwrapper"
-      class="MenuWrapper optionsMenu "
+      class="MenuWrapper override menuOpened optionsMenu "
       role="button"
     >
       <button

--- a/webapp/src/components/kanban/__snapshots__/kanbanColumnHeader.test.tsx.snap
+++ b/webapp/src/components/kanban/__snapshots__/kanbanColumnHeader.test.tsx.snap
@@ -36,7 +36,7 @@ exports[`src/components/kanban/kanbanColumnHeader return kanbanColumnHeader and 
     />
     <div
       aria-label="menuwrapper"
-      class="MenuWrapper"
+      class="MenuWrapper override menuOpened"
       role="button"
     >
       <button

--- a/webapp/src/components/kanban/__snapshots__/kanbanHiddenColumnItem.test.tsx.snap
+++ b/webapp/src/components/kanban/__snapshots__/kanbanHiddenColumnItem.test.tsx.snap
@@ -36,7 +36,7 @@ exports[`src/components/kanban/kanbanHiddenColumnItem return kanbanHiddenColumnI
   >
     <div
       aria-label="menuwrapper"
-      class="MenuWrapper"
+      class="MenuWrapper override menuOpened"
       role="button"
     >
       <span
@@ -145,7 +145,7 @@ exports[`src/components/kanban/kanbanHiddenColumnItem return kanbanHiddenColumnI
   >
     <div
       aria-label="menuwrapper"
-      class="MenuWrapper"
+      class="MenuWrapper override menuOpened"
       role="button"
     >
       <span

--- a/webapp/src/components/kanban/kanbanCard.scss
+++ b/webapp/src/components/kanban/kanbanCard.scss
@@ -30,26 +30,13 @@
     }
 
     .optionsMenu {
-        background: rgb(var(--center-channel-bg-rgb), 1);
+        background: rgb(var(--center-channel-bg-rgb));
         display: none;
         position: absolute;
         right: 12px;
 
         &.show {
             display: block;
-        }
-
-        .IconButton {
-            border-radius: 3px;
-            padding: 0;
-            box-shadow: rgba(var(--center-channel-color-rgb), 0.1) 0 0 0 1px,
-                rgba(var(--center-channel-color-rgb), 0.1) 0 2px 4px;
-            height: 24px;
-            width: 24px;
-
-            &:hover {
-                background: rgb(var(--center-channel-color-rgb), 0.1);
-            }
         }
     }
 

--- a/webapp/src/components/kanban/kanbanCard.tsx
+++ b/webapp/src/components/kanban/kanbanCard.tsx
@@ -10,8 +10,6 @@ import {useSortable} from '../../hooks/sortable'
 import mutator from '../../mutator'
 import TelemetryClient, {TelemetryActions, TelemetryCategory} from '../../telemetry/telemetryClient'
 import {Utils} from '../../utils'
-import IconButton from '../../widgets/buttons/iconButton'
-import OptionsIcon from '../../widgets/icons/options'
 import MenuWrapper from '../../widgets/menuWrapper'
 import Tooltip from '../../widgets/tooltip'
 import PropertyValueElement from '../propertyValueElement'
@@ -21,6 +19,7 @@ import CardBadges from '../cardBadges'
 import OpenCardTourStep from '../onboardingTour/openCard/open_card'
 import CopyLinkTourStep from '../onboardingTour/copyLink/copy_link'
 import CardActionsMenu from '../cardActionsMenu/cardActionsMenu'
+import CardActionsMenuIcon from '../cardActionsMenu/cardActionsMenuIcon'
 
 export const OnboardingCardClassName = 'onboardingCard'
 
@@ -103,7 +102,7 @@ const KanbanCard = (props: Props) => {
                     className={`optionsMenu ${showOnboarding ? 'show' : ''}`}
                     stopPropagationOnToggle={true}
                 >
-                    <IconButton icon={<OptionsIcon/>}/>
+                    <CardActionsMenuIcon/>
                     <CardActionsMenu
                         cardId={card!.id}
                         onClickDelete={handleDeleteButtonOnClick}

--- a/webapp/src/components/shareBoard/__snapshots__/channelPermissionsRow.test.tsx.snap
+++ b/webapp/src/components/shareBoard/__snapshots__/channelPermissionsRow.test.tsx.snap
@@ -69,7 +69,7 @@ exports[`src/components/shareBoard/channelPermissionsRow should match snapshot i
     <div>
       <div
         aria-label="menuwrapper"
-        class="MenuWrapper"
+        class="MenuWrapper override menuOpened"
         role="button"
       >
         <button
@@ -187,7 +187,7 @@ exports[`src/components/shareBoard/channelPermissionsRow should match snapshot i
     <div>
       <div
         aria-label="menuwrapper"
-        class="MenuWrapper"
+        class="MenuWrapper override menuOpened"
         role="button"
       >
         <button
@@ -309,7 +309,7 @@ exports[`src/components/shareBoard/channelPermissionsRow should match snapshot w
     <div>
       <div
         aria-label="menuwrapper"
-        class="MenuWrapper"
+        class="MenuWrapper override menuOpened"
         role="button"
       >
         <button

--- a/webapp/src/components/shareBoard/__snapshots__/teamPermissionsRow.test.tsx.snap
+++ b/webapp/src/components/shareBoard/__snapshots__/teamPermissionsRow.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`src/components/shareBoard/teamPermissionsRow should match snapshot 1`] 
     <div>
       <div
         aria-label="menuwrapper"
-        class="MenuWrapper"
+        class="MenuWrapper override menuOpened"
         role="button"
       >
         <button
@@ -232,7 +232,7 @@ exports[`src/components/shareBoard/teamPermissionsRow should match snapshot in p
     <div>
       <div
         aria-label="menuwrapper"
-        class="MenuWrapper"
+        class="MenuWrapper override menuOpened"
         role="button"
       >
         <button
@@ -445,7 +445,7 @@ exports[`src/components/shareBoard/teamPermissionsRow should match snapshot in t
     <div>
       <div
         aria-label="menuwrapper"
-        class="MenuWrapper"
+        class="MenuWrapper override menuOpened"
         role="button"
       >
         <button

--- a/webapp/src/components/shareBoard/__snapshots__/userPermissionsRow.test.tsx.snap
+++ b/webapp/src/components/shareBoard/__snapshots__/userPermissionsRow.test.tsx.snap
@@ -27,7 +27,7 @@ exports[`src/components/shareBoard/userPermissionsRow should match snapshot 1`] 
     <div>
       <div
         aria-label="menuwrapper"
-        class="MenuWrapper"
+        class="MenuWrapper override menuOpened"
         role="button"
       >
         <button
@@ -281,7 +281,7 @@ exports[`src/components/shareBoard/userPermissionsRow should match snapshot in p
     <div>
       <div
         aria-label="menuwrapper"
-        class="MenuWrapper"
+        class="MenuWrapper override menuOpened"
         role="button"
       >
         <button
@@ -535,7 +535,7 @@ exports[`src/components/shareBoard/userPermissionsRow should match snapshot in t
     <div>
       <div
         aria-label="menuwrapper"
-        class="MenuWrapper"
+        class="MenuWrapper override menuOpened"
         role="button"
       >
         <button

--- a/webapp/src/components/sidebar/__snapshots__/sidebarBoardItem.test.tsx.snap
+++ b/webapp/src/components/sidebar/__snapshots__/sidebarBoardItem.test.tsx.snap
@@ -86,7 +86,7 @@ exports[`components/sidebarBoardItem sidebar board item 1`] = `
     <div>
       <div
         aria-label="menuwrapper"
-        class="MenuWrapper menuOpen"
+        class="MenuWrapper override menuOpened menuOpen"
         role="button"
       >
         <button
@@ -373,7 +373,7 @@ exports[`components/sidebarBoardItem sidebar board item for guest 1`] = `
     <div>
       <div
         aria-label="menuwrapper"
-        class="MenuWrapper menuOpen"
+        class="MenuWrapper override menuOpened menuOpen"
         role="button"
       >
         <button

--- a/webapp/src/components/sidebar/__snapshots__/sidebarSettingsMenu.test.tsx.snap
+++ b/webapp/src/components/sidebar/__snapshots__/sidebarSettingsMenu.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`components/sidebar/SidebarSettingsMenu imports menu open should match s
   >
     <div
       aria-label="menuwrapper"
-      class="MenuWrapper"
+      class="MenuWrapper override menuOpened"
       role="button"
     >
       <div
@@ -369,7 +369,7 @@ exports[`components/sidebar/SidebarSettingsMenu languages menu open should match
   >
     <div
       aria-label="menuwrapper"
-      class="MenuWrapper"
+      class="MenuWrapper override menuOpened"
       role="button"
     >
       <div
@@ -1032,7 +1032,7 @@ exports[`components/sidebar/SidebarSettingsMenu settings menu open should match 
   >
     <div
       aria-label="menuwrapper"
-      class="MenuWrapper"
+      class="MenuWrapper override menuOpened"
       role="button"
     >
       <div
@@ -1200,7 +1200,7 @@ exports[`components/sidebar/SidebarSettingsMenu theme menu open should match sna
   >
     <div
       aria-label="menuwrapper"
-      class="MenuWrapper"
+      class="MenuWrapper override menuOpened"
       role="button"
     >
       <div

--- a/webapp/src/components/viewHeader/__snapshots__/emptyCardButton.test.tsx.snap
+++ b/webapp/src/components/viewHeader/__snapshots__/emptyCardButton.test.tsx.snap
@@ -96,7 +96,7 @@ exports[`components/viewHeader/emptyCardButton return EmptyCardButton and Set Te
     </div>
     <div
       aria-label="menuwrapper"
-      class="MenuWrapper"
+      class="MenuWrapper override menuOpened"
       role="button"
     >
       <button

--- a/webapp/src/components/viewHeader/__snapshots__/filterComponent.test.tsx.snap
+++ b/webapp/src/components/viewHeader/__snapshots__/filterComponent.test.tsx.snap
@@ -27,7 +27,7 @@ exports[`components/viewHeader/filterComponent return filterComponent 1`] = `
       >
         <div
           aria-label="menuwrapper"
-          class="MenuWrapper"
+          class="MenuWrapper override menuOpened"
           role="button"
         >
           <button
@@ -299,7 +299,7 @@ exports[`components/viewHeader/filterComponent return filterComponent and add Fi
       >
         <div
           aria-label="menuwrapper"
-          class="MenuWrapper"
+          class="MenuWrapper override menuOpened"
           role="button"
         >
           <button
@@ -585,7 +585,7 @@ exports[`components/viewHeader/filterComponent return filterComponent and click 
         </div>
         <div
           aria-label="menuwrapper"
-          class="MenuWrapper"
+          class="MenuWrapper override menuOpened"
           role="button"
         >
           <button
@@ -812,7 +812,7 @@ exports[`components/viewHeader/filterComponent return filterComponent and filter
       >
         <div
           aria-label="menuwrapper"
-          class="MenuWrapper"
+          class="MenuWrapper override menuOpened"
           role="button"
         >
           <button

--- a/webapp/src/components/viewHeader/__snapshots__/filterEntry.test.tsx.snap
+++ b/webapp/src/components/viewHeader/__snapshots__/filterEntry.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`components/viewHeader/filterEntry return filterEntry 1`] = `
   >
     <div
       aria-label="menuwrapper"
-      class="MenuWrapper"
+      class="MenuWrapper override menuOpened"
       role="button"
     >
       <button
@@ -262,7 +262,7 @@ exports[`components/viewHeader/filterEntry return filterEntry and click on delet
     </div>
     <div
       aria-label="menuwrapper"
-      class="MenuWrapper"
+      class="MenuWrapper override menuOpened"
       role="button"
     >
       <button
@@ -472,7 +472,7 @@ exports[`components/viewHeader/filterEntry return filterEntry and click on doesn
     </div>
     <div
       aria-label="menuwrapper"
-      class="MenuWrapper"
+      class="MenuWrapper override menuOpened"
       role="button"
     >
       <button
@@ -682,7 +682,7 @@ exports[`components/viewHeader/filterEntry return filterEntry and click on inclu
     </div>
     <div
       aria-label="menuwrapper"
-      class="MenuWrapper"
+      class="MenuWrapper override menuOpened"
       role="button"
     >
       <button
@@ -892,7 +892,7 @@ exports[`components/viewHeader/filterEntry return filterEntry and click on is em
     </div>
     <div
       aria-label="menuwrapper"
-      class="MenuWrapper"
+      class="MenuWrapper override menuOpened"
       role="button"
     >
       <button
@@ -1102,7 +1102,7 @@ exports[`components/viewHeader/filterEntry return filterEntry and click on is no
     </div>
     <div
       aria-label="menuwrapper"
-      class="MenuWrapper"
+      class="MenuWrapper override menuOpened"
       role="button"
     >
       <button
@@ -1298,7 +1298,7 @@ exports[`components/viewHeader/filterEntry return filterEntry and click on statu
   >
     <div
       aria-label="menuwrapper"
-      class="MenuWrapper"
+      class="MenuWrapper override menuOpened"
       role="button"
     >
       <button
@@ -1587,7 +1587,7 @@ exports[`components/viewHeader/filterEntry return filterEntry for boolean field 
     </div>
     <div
       aria-label="menuwrapper"
-      class="MenuWrapper"
+      class="MenuWrapper override menuOpened"
       role="button"
     >
       <button
@@ -1787,7 +1787,7 @@ exports[`components/viewHeader/filterEntry return filterEntry for text field 2`]
     </div>
     <div
       aria-label="menuwrapper"
-      class="MenuWrapper"
+      class="MenuWrapper override menuOpened"
       role="button"
     >
       <button

--- a/webapp/src/components/viewHeader/__snapshots__/filterValue.test.tsx.snap
+++ b/webapp/src/components/viewHeader/__snapshots__/filterValue.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`components/viewHeader/filterValue return filterValue 1`] = `
 <div>
   <div
     aria-label="menuwrapper"
-    class="MenuWrapper filterValue"
+    class="MenuWrapper override menuOpened filterValue"
     role="button"
   >
     <button
@@ -90,7 +90,7 @@ exports[`components/viewHeader/filterValue return filterValue and click Status 1
 <div>
   <div
     aria-label="menuwrapper"
-    class="MenuWrapper filterValue"
+    class="MenuWrapper override menuOpened filterValue"
     role="button"
   >
     <button
@@ -176,7 +176,7 @@ exports[`components/viewHeader/filterValue return filterValue and click Status w
 <div>
   <div
     aria-label="menuwrapper"
-    class="MenuWrapper filterValue"
+    class="MenuWrapper override menuOpened filterValue"
     role="button"
   >
     <button

--- a/webapp/src/components/viewHeader/__snapshots__/newCardButton.test.tsx.snap
+++ b/webapp/src/components/viewHeader/__snapshots__/newCardButton.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`components/viewHeader/newCardButton return NewCardButton 1`] = `
     </div>
     <div
       aria-label="menuwrapper"
-      class="MenuWrapper"
+      class="MenuWrapper override menuOpened"
       role="button"
     >
       <div
@@ -168,7 +168,7 @@ exports[`components/viewHeader/newCardButton return NewCardButton and addCard 1`
     </div>
     <div
       aria-label="menuwrapper"
-      class="MenuWrapper"
+      class="MenuWrapper override menuOpened"
       role="button"
     >
       <div
@@ -324,7 +324,7 @@ exports[`components/viewHeader/newCardButton return NewCardButton and addCardTem
     </div>
     <div
       aria-label="menuwrapper"
-      class="MenuWrapper"
+      class="MenuWrapper override menuOpened"
       role="button"
     >
       <div

--- a/webapp/src/components/viewHeader/__snapshots__/newCardButtonTemplateItem.test.tsx.snap
+++ b/webapp/src/components/viewHeader/__snapshots__/newCardButtonTemplateItem.test.tsx.snap
@@ -31,7 +31,7 @@ exports[`components/viewHeader/newCardButtonTemplateItem return NewCardButtonTem
     </div>
     <div
       aria-label="menuwrapper"
-      class="MenuWrapper"
+      class="MenuWrapper override menuOpened"
       role="button"
     >
       <button
@@ -221,7 +221,7 @@ exports[`components/viewHeader/newCardButtonTemplateItem return NewCardButtonTem
     </div>
     <div
       aria-label="menuwrapper"
-      class="MenuWrapper"
+      class="MenuWrapper override menuOpened"
       role="button"
     >
       <button
@@ -458,7 +458,7 @@ exports[`components/viewHeader/newCardButtonTemplateItem return NewCardButtonTem
     </div>
     <div
       aria-label="menuwrapper"
-      class="MenuWrapper"
+      class="MenuWrapper override menuOpened"
       role="button"
     >
       <button
@@ -648,7 +648,7 @@ exports[`components/viewHeader/newCardButtonTemplateItem return NewCardButtonTem
     </div>
     <div
       aria-label="menuwrapper"
-      class="MenuWrapper"
+      class="MenuWrapper override menuOpened"
       role="button"
     >
       <button

--- a/webapp/src/components/viewHeader/__snapshots__/viewHeaderActionsMenu.test.tsx.snap
+++ b/webapp/src/components/viewHeader/__snapshots__/viewHeaderActionsMenu.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`components/viewHeader/viewHeaderActionsMenu return menu 1`] = `
   >
     <div
       aria-label="View header menu"
-      class="MenuWrapper"
+      class="MenuWrapper override menuOpened"
       role="button"
     >
       <button
@@ -128,7 +128,7 @@ exports[`components/viewHeader/viewHeaderActionsMenu return menu and verify call
   >
     <div
       aria-label="View header menu"
-      class="MenuWrapper"
+      class="MenuWrapper override menuOpened"
       role="button"
     >
       <button
@@ -249,7 +249,7 @@ exports[`components/viewHeader/viewHeaderActionsMenu return menu and verify call
   >
     <div
       aria-label="View header menu"
-      class="MenuWrapper"
+      class="MenuWrapper override menuOpened"
       role="button"
     >
       <button

--- a/webapp/src/components/viewHeader/__snapshots__/viewHeaderGroupByMenu.test.tsx.snap
+++ b/webapp/src/components/viewHeader/__snapshots__/viewHeaderGroupByMenu.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`components/viewHeader/viewHeaderGroupByMenu For viewType table render o
 <div>
   <div
     aria-label="menuwrapper"
-    class="MenuWrapper"
+    class="MenuWrapper override menuOpened"
     role="button"
   >
     <button
@@ -247,7 +247,7 @@ exports[`components/viewHeader/viewHeaderGroupByMenu For viewType table render o
 <div>
   <div
     aria-label="menuwrapper"
-    class="MenuWrapper"
+    class="MenuWrapper override menuOpened"
     role="button"
   >
     <button
@@ -490,7 +490,7 @@ exports[`components/viewHeader/viewHeaderGroupByMenu return groupBy menu 1`] = `
 <div>
   <div
     aria-label="menuwrapper"
-    class="MenuWrapper"
+    class="MenuWrapper override menuOpened"
     role="button"
   >
     <button
@@ -697,7 +697,7 @@ exports[`components/viewHeader/viewHeaderGroupByMenu return groupBy menu, hideEm
 <div>
   <div
     aria-label="menuwrapper"
-    class="MenuWrapper"
+    class="MenuWrapper override menuOpened"
     role="button"
   >
     <button

--- a/webapp/src/components/viewHeader/__snapshots__/viewHeaderPropertiesMenu.test.tsx.snap
+++ b/webapp/src/components/viewHeader/__snapshots__/viewHeaderPropertiesMenu.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`components/viewHeader/viewHeaderPropertiesMenu return properties menu 1
 <div>
   <div
     aria-label="Properties menu"
-    class="MenuWrapper"
+    class="MenuWrapper override menuOpened"
     role="button"
   >
     <button
@@ -183,7 +183,7 @@ exports[`components/viewHeader/viewHeaderPropertiesMenu return properties menu w
 <div>
   <div
     aria-label="Properties menu"
-    class="MenuWrapper"
+    class="MenuWrapper override menuOpened"
     role="button"
   >
     <button

--- a/webapp/src/components/viewHeader/__snapshots__/viewHeaderSortMenu.test.tsx.snap
+++ b/webapp/src/components/viewHeader/__snapshots__/viewHeaderSortMenu.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`components/viewHeader/viewHeaderSortMenu return sort menu 1`] = `
 <div>
   <div
     aria-label="menuwrapper"
-    class="MenuWrapper"
+    class="MenuWrapper override menuOpened"
     role="button"
   >
     <button

--- a/webapp/src/widgets/menuWrapper.scss
+++ b/webapp/src/widgets/menuWrapper.scss
@@ -6,6 +6,9 @@
         cursor: default;
     }
 
+    &.override.menuOpened {
+        display: block;
+    }
 
     *:first-child {
         /* stylelint-disable property-no-vendor-prefix*/

--- a/webapp/src/widgets/menuWrapper.tsx
+++ b/webapp/src/widgets/menuWrapper.tsx
@@ -87,6 +87,9 @@ const MenuWrapper = (props: Props) => {
     if (props.disabled) {
         className += ' disabled'
     }
+    if (open) {
+        className += ' override menuOpened'
+    }
     if (props.className) {
         className += ' ' + props.className
     }


### PR DESCRIPTION
#### Summary
Always show popup menu when it is opened:
- applied to popup menus for cards in kanban/gallery/calendar, menus for content block and comment
- add additional class name `menuOpened` and ensure that menu is visible
- new component `CardActionsMenuIcon` introduced and used for kanban/gallery/calendar card actions menu
- increase `z-index` for `ContentBlock` when menu is opened to avoid overlaps
- jest snapshots updated: additional classes added to existing elements

#### Ticket Link
Fixed #1007 