### PR TITLE
[GH-4070] Fix focus on new table row

### DIFF
--- a/webapp/src/components/centerPanel.tsx
+++ b/webapp/src/components/centerPanel.tsx
@@ -197,6 +197,7 @@ const CenterPanel = (props: Props) => {
                     } else {
                         // Focus on this card's title inline on next render
                         setCardIdToFocusOnRender(block.id)
+                        setTimeout(() => setCardIdToFocusOnRender(''), 300)
                     }
                 },
                 async () => {

--- a/webapp/src/components/centerPanel.tsx
+++ b/webapp/src/components/centerPanel.tsx
@@ -197,7 +197,6 @@ const CenterPanel = (props: Props) => {
                     } else {
                         // Focus on this card's title inline on next render
                         setCardIdToFocusOnRender(block.id)
-                        setTimeout(() => setCardIdToFocusOnRender(''), 100)
                     }
                 },
                 async () => {


### PR DESCRIPTION
#### Summary
##### What
Creating a new table row should focus on the new row's title so that the user can edit it right away.

##### How
The problem is that we reset the `cardIdToFocusOnRender` state too fast, so the new card doesn't see the value anymore when mounted and therefore doesn't focus. That's why I increased the timeout from 100ms to 300ms.

#### Ticket Link
Fixes https://github.com/mattermost/focalboard/issues/4070
