### PR TITLE
Fix double encoding

### DIFF
--- a/mattermost-plugin/server/manifest.go
+++ b/mattermost-plugin/server/manifest.go
@@ -45,8 +45,7 @@ const manifestStr = `
         "type": "bool",
         "help_text": "This allows board editors to share boards that can be accessed by anyone with the link.",
         "placeholder": "",
-        "default": false,
-        "hosting": ""
+        "default": false
       }
     ]
   }

--- a/mattermost-plugin/server/manifest.go
+++ b/mattermost-plugin/server/manifest.go
@@ -45,7 +45,8 @@ const manifestStr = `
         "type": "bool",
         "help_text": "This allows board editors to share boards that can be accessed by anyone with the link.",
         "placeholder": "",
-        "default": false
+        "default": false,
+        "hosting": ""
       }
     ]
   }

--- a/webapp/src/utils.test.ts
+++ b/webapp/src/utils.test.ts
@@ -58,6 +58,10 @@ describe('utils', () => {
             expect(Utils.htmlFromMarkdown('[]("xss-attack="true"other="whatever)')).toBe(expectedHtml)
             window.openInNewBrowser = null
         })
+
+        test('should not double encode links href on the webapp', () => {
+            expect(Utils.htmlFromMarkdown('https://example.com?title=August%201%20-%202022')).toBe('<p><a target="_blank" rel="noreferrer" href="https://example.com?title=August%201%20-%202022" title="" onclick="">https://example.com?title=August%201%20-%202022</a></p>')
+        })
     })
 
     describe('countCheckboxesInMarkdown', () => {

--- a/webapp/src/utils.test.ts
+++ b/webapp/src/utils.test.ts
@@ -59,7 +59,7 @@ describe('utils', () => {
             window.openInNewBrowser = null
         })
 
-        test('should encode title', () => {
+        test('should encode links', () => {
             expect(Utils.htmlFromMarkdown('https://example.com?title=August<1>2022')).toBe('<p><a target="_blank" rel="noreferrer" href="https://example.com?title=August&lt;1&gt;2022" title="" onclick="">https://example.com?title=August&lt;1&gt;2022</a></p>')
             expect(Utils.htmlFromMarkdown('[Duck Duck Go](https://duckduckgo.com "The best search engine\'s for <privacy>")')).toBe('<p><a target="_blank" rel="noreferrer" href="https://duckduckgo.com" title="The best search engine&#39;s for &lt;privacy&gt;" onclick="">Duck Duck Go</a></p>')
         })

--- a/webapp/src/utils.test.ts
+++ b/webapp/src/utils.test.ts
@@ -61,12 +61,12 @@ describe('utils', () => {
 
         test('should encode title', () => {
             expect(Utils.htmlFromMarkdown('https://example.com?title=August<1>2022')).toBe('<p><a target="_blank" rel="noreferrer" href="https://example.com?title=August&lt;1&gt;2022" title="" onclick="">https://example.com?title=August&lt;1&gt;2022</a></p>')
-            expect(Utils.htmlFromMarkdown('[Duck Duck Go](https://duckduckgo.com "The best search engine\'s for <privacy>")')).toBe('<p><a target="_blank" rel="noreferrer" href="https://duckduckgo.com" title="The best search engine&amp;#39;s for &lt;privacy&gt;" onclick="">Duck Duck Go</a></p>')
+            expect(Utils.htmlFromMarkdown('[Duck Duck Go](https://duckduckgo.com "The best search engine\'s for <privacy>")')).toBe('<p><a target="_blank" rel="noreferrer" href="https://duckduckgo.com" title="The best search engine&#39;s for &lt;privacy&gt;" onclick="">Duck Duck Go</a></p>')
         })
 
         test('should not double encode title and href', () => {
             expect(Utils.htmlFromMarkdown('https://example.com?title=August%201%20-%202022')).toBe('<p><a target="_blank" rel="noreferrer" href="https://example.com?title=August%201%20-%202022" title="" onclick="">https://example.com?title=August%201%20-%202022</a></p>')
-            expect(Utils.htmlFromMarkdown('[Duck Duck Go](https://duckduckgo.com "The best search engine&amp;#39;s for &lt;privacy&gt;")')).toBe('<p><a target="_blank" rel="noreferrer" href="https://duckduckgo.com" title="The best search engine&amp;#39;s for &lt;privacy&gt;" onclick="">Duck Duck Go</a></p>')
+            expect(Utils.htmlFromMarkdown('[Duck Duck Go](https://duckduckgo.com "The best search engine#39;s for &lt;privacy&gt;")')).toBe('<p><a target="_blank" rel="noreferrer" href="https://duckduckgo.com" title="The best search engine#39;s for &lt;privacy&gt;" onclick="">Duck Duck Go</a></p>')
         })
     })
 

--- a/webapp/src/utils.test.ts
+++ b/webapp/src/utils.test.ts
@@ -59,8 +59,14 @@ describe('utils', () => {
             window.openInNewBrowser = null
         })
 
-        test('should not double encode links href on the webapp', () => {
+        test('should encode title', () => {
+            expect(Utils.htmlFromMarkdown('https://example.com?title=August<1>2022')).toBe('<p><a target="_blank" rel="noreferrer" href="https://example.com?title=August&lt;1&gt;2022" title="" onclick="">https://example.com?title=August&lt;1&gt;2022</a></p>')
+            expect(Utils.htmlFromMarkdown('[Duck Duck Go](https://duckduckgo.com "The best search engine\'s for <privacy>")')).toBe('<p><a target="_blank" rel="noreferrer" href="https://duckduckgo.com" title="The best search engine&amp;#39;s for &lt;privacy&gt;" onclick="">Duck Duck Go</a></p>')
+        })
+
+        test('should not double encode title and href', () => {
             expect(Utils.htmlFromMarkdown('https://example.com?title=August%201%20-%202022')).toBe('<p><a target="_blank" rel="noreferrer" href="https://example.com?title=August%201%20-%202022" title="" onclick="">https://example.com?title=August%201%20-%202022</a></p>')
+            expect(Utils.htmlFromMarkdown('[Duck Duck Go](https://duckduckgo.com "The best search engine&amp;#39;s for &lt;privacy&gt;")')).toBe('<p><a target="_blank" rel="noreferrer" href="https://duckduckgo.com" title="The best search engine&amp;#39;s for &lt;privacy&gt;" onclick="">Duck Duck Go</a></p>')
         })
     })
 

--- a/webapp/src/utils.ts
+++ b/webapp/src/utils.ts
@@ -294,8 +294,8 @@ class Utils {
             return '<a ' +
                 'target="_blank" ' +
                 'rel="noreferrer" ' +
-                `href="${encodeURI(href || '')}" ` +
-                `title="${title ? encodeURI(title) : ''}" ` +
+                `href="${encodeURI(decodeURI(href || ''))}" ` +
+                `title="${title ? encodeURI(decodeURI(title)) : ''}" ` +
                 `onclick="${(window.openInNewBrowser ? ' openInNewBrowser && openInNewBrowser(event.target.href);' : '')}"` +
             '>' + contents + '</a>'
         }

--- a/webapp/src/utils.ts
+++ b/webapp/src/utils.ts
@@ -295,7 +295,7 @@ class Utils {
                 'target="_blank" ' +
                 'rel="noreferrer" ' +
                 `href="${encodeURI(decodeURI(href || ''))}" ` +
-                `title="${Utils.htmlEncode(Utils.htmlDecode(title || ''))}" ` +
+                `title="${title || ''}" ` +
                 `onclick="${(window.openInNewBrowser ? ' openInNewBrowser && openInNewBrowser(event.target.href);' : '')}"` +
             '>' + contents + '</a>'
         }

--- a/webapp/src/utils.ts
+++ b/webapp/src/utils.ts
@@ -295,7 +295,7 @@ class Utils {
                 'target="_blank" ' +
                 'rel="noreferrer" ' +
                 `href="${encodeURI(decodeURI(href || ''))}" ` +
-                `title="${title ? encodeURI(decodeURI(title)) : ''}" ` +
+                `title="${Utils.htmlEncode(Utils.htmlDecode(title || ''))}" ` +
                 `onclick="${(window.openInNewBrowser ? ' openInNewBrowser && openInNewBrowser(event.target.href);' : '')}"` +
             '>' + contents + '</a>'
         }


### PR DESCRIPTION
#### Summary
Fixes issue where links are encoded even thought they may already be encoded. Fix is simply decode prior to encoding. 

#### Ticket Link

  Fixes https://github.com/mattermost/focalboard/issues/3496
