### PR TITLE
Fix collation for personal server

### DIFF
--- a/server/services/store/sqlstore/data_migrations.go
+++ b/server/services/store/sqlstore/data_migrations.go
@@ -655,11 +655,11 @@ func (s *SQLStore) RunFixCollationsAndCharsetsMigration() error {
 	}
 
 	// get collation and charSet setting that Channels is using.
-	// when unit testing, no channels tables exist so just set to a default.
+	// when personal server or unit testing, no channels tables exist so just set to a default.
 	var collation string
 	var charSet string
 	var err error
-	if os.Getenv("FOCALBOARD_UNIT_TESTING") == "1" {
+	if !s.isPlugin || os.Getenv("FOCALBOARD_UNIT_TESTING") == "1" {
 		collation = "utf8mb4_general_ci"
 		charSet = "utf8mb4"
 	} else {


### PR DESCRIPTION
#### Summary
As of 7.4.3 the plugin fixes up any inconsistent collation or charset settings in the database (MySQL only).  It uses the Channels table to determine the current collation setting.  In the case of personal server there is no Channels table so this would fail. TBH I did not know personal server could use MySQL - I thought it was Sqlite only.  

The fix is to use a sensible default for personal server.

#### Ticket Link
fixes https://github.com/mattermost/focalboard/issues/4067