### PR TITLE
fix code for portuguese to match codes in i18n.tsx

### DIFF
--- a/webapp/src/constants.ts
+++ b/webapp/src/constants.ts
@@ -130,7 +130,7 @@ class Constants {
             displayName: 'Occitan',
         },
         {
-            code: 'pt_BR',
+            code: 'pt-br',
             name: 'portuguese',
             displayName: 'Português (Brasil)',
         },


### PR DESCRIPTION
#### Summary
fixes issue where portuguese code in constants didn't match codes in [i18n.tsx](https://github.com/mattermost/focalboard/blob/main/webapp/src/i18n.tsx)

#### Ticket Link

  Fixes https://github.com/mattermost/focalboard/issues/4065

