### PR TITLE
fix: convert `multiSelect` prop value to [] if required

### DIFF
--- a/webapp/src/store/cards.ts
+++ b/webapp/src/store/cards.ts
@@ -354,7 +354,7 @@ function searchFilterCards(cards: Card[], board: Board, searchTextRaw: string): 
                     }
                 } else if (propertyTemplate.type === 'multiSelect') {
                     // Look up the value of the select option
-                    const options = (propertyValue as string[]).map((value) => propertyTemplate.options.find((o) => o.id === value)?.value.toLowerCase())
+                    const options = (Array.isArray(propertyValue) ? propertyValue : [propertyValue]).map((value) => propertyTemplate.options.find((o) => o.id === value)?.value.toLowerCase())
                     if (options?.includes(searchText)) {
                         return true
                     }


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute

Assign two reviewers for this pull request from the names suggested. If no names are suggested or you are not sure who to assign, set `Core Focalboard` as the reviewer.
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the ticket).
-->
@michaelgamble reported a bug where searching in a specific board was crashing the frontend. There was an instance of trying to call `.map` on a _string_ for the property value of a `multiSelect` type and it was expecting an array of strings.

My concern is I'm not sure _why_ the property value was a string and not an array of strings in the first place. I'd rather fix the root cause and not a symptom.

#### Ticket Link
<!--
If this pull request addresses a Github issue, please link the relevant issue, e.g.

  Fixes https://github.com/mattermost/focalboard/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
fixes #4092 
