### PR TITLE
Fix tooltip cutoff

### DIFF
--- a/webapp/src/widgets/tooltip.scss
+++ b/webapp/src/widgets/tooltip.scss
@@ -54,15 +54,14 @@ $tooltop-vertical-offset: 2px;
 
     // Top tooltip arrow style
     &.tooltip-top:hover::before {
-        left: 50%;
+        left: 0;
         bottom: calc(100% - 2px);
-        transform: translate(-50%, #{$tooltop-horizontal-offset});
     }
     // Top tooltip body style
     &.tooltip-top:hover::after {
         bottom: calc(100% + 10px);
-        left: 50%;
-        transform: translate(-10%, #{$tooltop-horizontal-offset});
+        left: -20%;
+        transform: translate(0, #{$tooltop-horizontal-offset});
     }
 
     // Right tooltip arrow style

--- a/webapp/src/widgets/tooltip.scss
+++ b/webapp/src/widgets/tooltip.scss
@@ -62,7 +62,7 @@ $tooltop-vertical-offset: 2px;
     &.tooltip-top:hover::after {
         bottom: calc(100% + 10px);
         left: 50%;
-        transform: translate(-50%, #{$tooltop-horizontal-offset});
+        transform: translate(-10%, #{$tooltop-horizontal-offset});
     }
 
     // Right tooltip arrow style


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute

Assign two reviewers for this pull request from the names suggested. If no names are suggested or you are not sure who to assign, set `Core Focalboard` as the reviewer.
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the ticket).
-->

Fix the kanban card tooltip that cutting off. I consider the both tooltip with short text and long text.

<table>
<tr>
	<td>Before</td>
	<td>After</td>
<tr>
	<td>
	    <img width="400" alt="Screen Shot 2021-10-23 at 13 14 38" src="https://user-images.githubusercontent.com/1910192/198553197-f3cae100-57d7-4df8-814d-9e77bd48fa2c.png">
	</td>
        <td>
            <img width="400" alt="Screen Shot 2021-10-23 at 13 15 58" src="https://user-images.githubusercontent.com/1910192/198553234-88b14d94-e2ff-4d30-9189-dbada404ce82.png">
        </td>    
</table>

#### Ticket Link
<!--
If this pull request addresses a Github issue, please link the relevant issue, e.g.

  Fixes https://github.com/mattermost/focalboard/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

Fix https://github.com/mattermost/focalboard/issues/3246.
