### PR TITLE
[GH-2068] [text] doesn't directly enter edit mode when adding

### DIFF
--- a/webapp/src/components/__snapshots__/addContentMenuItem.test.tsx.snap
+++ b/webapp/src/components/__snapshots__/addContentMenuItem.test.tsx.snap
@@ -40,6 +40,46 @@ exports[`components/addContentMenuItem return a checkbox menu item 1`] = `
 </div>
 `;
 
+exports[`components/addContentMenuItem return a checkbox menu item 2`] = `
+<div>
+  <div
+    aria-label="checkbox"
+    class="MenuOption TextOption menu-option"
+    role="button"
+  >
+    <div
+      class="d-flex"
+    >
+      <div
+        class="menu-option__icon"
+      >
+        <svg
+          class="CheckIcon Icon"
+          viewBox="0 0 100 100"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <polyline
+            points="20,60 40,80 80,40"
+          />
+        </svg>
+      </div>
+    </div>
+    <div
+      class="menu-option__content"
+    >
+      <div
+        class="menu-name"
+      >
+        checkbox
+      </div>
+    </div>
+    <div
+      class="noicon"
+    />
+  </div>
+</div>
+`;
+
 exports[`components/addContentMenuItem return a divider menu item 1`] = `
 <div>
   <div
@@ -80,7 +120,87 @@ exports[`components/addContentMenuItem return a divider menu item 1`] = `
 </div>
 `;
 
+exports[`components/addContentMenuItem return a divider menu item 2`] = `
+<div>
+  <div
+    aria-label="divider"
+    class="MenuOption TextOption menu-option"
+    role="button"
+  >
+    <div
+      class="d-flex"
+    >
+      <div
+        class="menu-option__icon"
+      >
+        <svg
+          class="DividerIcon Icon"
+          viewBox="0 0 448 512"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M 432,224 H 16 c -8.836556,0 -16,7.16344 -16,16 v 32 c 0,8.83656 7.163444,16 16,16 h 416 c 8.83656,0 16,-7.16344 16,-16 v -32 c 0,-8.83656 -7.16344,-16 -16,-16 z"
+          />
+        </svg>
+      </div>
+    </div>
+    <div
+      class="menu-option__content"
+    >
+      <div
+        class="menu-name"
+      >
+        divider
+      </div>
+    </div>
+    <div
+      class="noicon"
+    />
+  </div>
+</div>
+`;
+
 exports[`components/addContentMenuItem return a text menu item 1`] = `
+<div>
+  <div
+    aria-label="text"
+    class="MenuOption TextOption menu-option"
+    role="button"
+  >
+    <div
+      class="d-flex"
+    >
+      <div
+        class="menu-option__icon"
+      >
+        <svg
+          class="TextIcon Icon"
+          viewBox="0 0 448 512"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M432 416H16a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h416a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16zm0-128H16a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h416a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16zm0-128H16a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h416a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16zm0-128H16A16 16 0 0 0 0 48v32a16 16 0 0 0 16 16h416a16 16 0 0 0 16-16V48a16 16 0 0 0-16-16z"
+          />
+        </svg>
+      </div>
+    </div>
+    <div
+      class="menu-option__content"
+    >
+      <div
+        class="menu-name"
+      >
+        text
+      </div>
+    </div>
+    <div
+      class="noicon"
+    />
+  </div>
+</div>
+`;
+
+exports[`components/addContentMenuItem return a text menu item 2`] = `
 <div>
   <div
     aria-label="text"

--- a/webapp/src/components/__snapshots__/contentBlock.test.tsx.snap
+++ b/webapp/src/components/__snapshots__/contentBlock.test.tsx.snap
@@ -476,12 +476,55 @@ exports[`components/contentBlock should match snapshot with textBlock 1`] = `
         style="flex: 0 0 auto; height: 100%;"
       />
       <div
-        class="MarkdownEditor octo-editor  "
+        class="MarkdownEditor octo-editor  active"
       >
         <div
-          class="octo-editor-preview"
-          data-testid="preview-element"
-        />
+          class="MarkdownEditorInput"
+        >
+          <div
+            class="DraftEditor-root"
+          >
+            <div
+              class="DraftEditor-editorContainer"
+            >
+              <div
+                aria-autocomplete="list"
+                aria-expanded="false"
+                class="notranslate public-DraftEditor-content"
+                contenteditable="true"
+                role="combobox"
+                spellcheck="false"
+                style="outline: none; user-select: text; white-space: pre-wrap; word-wrap: break-word;"
+              >
+                <div
+                  data-contents="true"
+                >
+                  <div
+                    class=""
+                    data-block="true"
+                    data-editor="123"
+                    data-offset-key="123-0-0"
+                  >
+                    <div
+                      class="public-DraftStyleDefault-block public-DraftStyleDefault-ltr"
+                      data-offset-key="123-0-0"
+                    >
+                      <span
+                        data-offset-key="123-0-0"
+                      >
+                        <span
+                          data-text="true"
+                        >
+                          title
+                        </span>
+                      </span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
     <div

--- a/webapp/src/components/addContentMenuItem.test.tsx
+++ b/webapp/src/components/addContentMenuItem.test.tsx
@@ -2,15 +2,13 @@
 // See LICENSE.txt for license information.
 
 import React, {ReactElement, ReactNode} from 'react'
-import {render, screen, waitFor} from '@testing-library/react'
+import {render, screen} from '@testing-library/react'
 
 import '@testing-library/jest-dom'
 
-import {mocked} from 'jest-mock'
-
 import userEvent from '@testing-library/user-event'
 
-import mutator from '../mutator'
+import {act} from 'react-dom/test-utils'
 
 import {TestBlockFactory} from '../test/testBlockFactory'
 
@@ -35,7 +33,6 @@ const wrap = (child: ReactNode): ReactElement => (
 )
 
 jest.mock('../mutator')
-const mockedMutator = mocked(mutator, true)
 
 describe('components/addContentMenuItem', () => {
     beforeEach(() => {
@@ -46,7 +43,6 @@ describe('components/addContentMenuItem', () => {
             wrap(
                 <AddContentMenuItem
                     type={'image'}
-                    card={card}
                     cords={{x: 0}}
                 />,
             ),
@@ -59,15 +55,16 @@ describe('components/addContentMenuItem', () => {
             wrap(
                 <AddContentMenuItem
                     type={'text'}
-                    card={card}
                     cords={{x: 0}}
                 />,
             ),
         )
         expect(container).toMatchSnapshot()
-        const buttonElement = screen.getByRole('button', {name: 'text'})
-        userEvent.click(buttonElement)
-        await waitFor(() => expect(mockedMutator.insertBlock).toBeCalled())
+        await act(async () => {
+            const buttonElement = screen.getByRole('button', {name: 'text'})
+            userEvent.click(buttonElement)
+        })
+        expect(container).toMatchSnapshot()
     })
 
     test('return a checkbox menu item', async () => {
@@ -75,15 +72,16 @@ describe('components/addContentMenuItem', () => {
             wrap(
                 <AddContentMenuItem
                     type={'checkbox'}
-                    card={card}
                     cords={{x: 0}}
                 />,
             ),
         )
         expect(container).toMatchSnapshot()
-        const buttonElement = screen.getByRole('button', {name: 'checkbox'})
-        userEvent.click(buttonElement)
-        await waitFor(() => expect(mockedMutator.insertBlock).toBeCalled())
+        await act(async () => {
+            const buttonElement = screen.getByRole('button', {name: 'checkbox'})
+            userEvent.click(buttonElement)
+        })
+        expect(container).toMatchSnapshot()
     })
 
     test('return a divider menu item', async () => {
@@ -91,15 +89,16 @@ describe('components/addContentMenuItem', () => {
             wrap(
                 <AddContentMenuItem
                     type={'divider'}
-                    card={card}
                     cords={{x: 0}}
                 />,
             ),
         )
         expect(container).toMatchSnapshot()
-        const buttonElement = screen.getByRole('button', {name: 'divider'})
-        userEvent.click(buttonElement)
-        await waitFor(() => expect(mockedMutator.insertBlock).toBeCalled())
+        await act(async () => {
+            const buttonElement = screen.getByRole('button', {name: 'divider'})
+            userEvent.click(buttonElement)
+        })
+        expect(container).toMatchSnapshot()
     })
 
     test('return an error and empty element from unknown type', () => {
@@ -107,7 +106,6 @@ describe('components/addContentMenuItem', () => {
             wrap(
                 <AddContentMenuItem
                     type={'unknown'}
-                    card={card}
                     cords={{x: 0}}
                 />,
             ),

--- a/webapp/src/components/addContentMenuItem.tsx
+++ b/webapp/src/components/addContentMenuItem.tsx
@@ -1,28 +1,26 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React from 'react'
+import React, {useCallback} from 'react'
 import {useIntl} from 'react-intl'
 
-import {BlockTypes, Block} from '../blocks/block'
-import {Card} from '../blocks/card'
-import mutator from '../mutator'
-import octoClient from '../octoClient'
+import {BlockTypes} from '../blocks/block'
 import {Utils} from '../utils'
 import Menu from '../widgets/menu'
 
+import {useCardDetailContext} from './cardDetail/cardDetailContext'
 import {contentRegistry} from './content/contentRegistry'
 
 type Props = {
     type: BlockTypes
-    card: Card
     cords: {x: number, y?: number, z?: number}
 }
 
 const AddContentMenuItem = (props: Props): JSX.Element => {
-    const {card, type, cords} = props
+    const {type, cords} = props
     const index = cords.x
     const intl = useIntl()
+    const cardDetail = useCardDetailContext()
 
     const handler = contentRegistry.getHandler(type)
     if (!handler) {
@@ -30,33 +28,17 @@ const AddContentMenuItem = (props: Props): JSX.Element => {
         return <></>
     }
 
+    const addElement = useCallback(() => {
+        cardDetail.addBlock(handler, index, false)
+    }, [cardDetail, handler, index])
+
     return (
         <Menu.Text
             key={type}
             id={type}
             name={handler.getDisplayText(intl)}
             icon={handler.getIcon()}
-            onClick={async () => {
-                const newBlock = await handler.createBlock(card.boardId, intl)
-                newBlock.parentId = card.id
-                newBlock.boardId = card.boardId
-
-                const typeName = handler.getDisplayText(intl)
-                const description = intl.formatMessage({id: 'ContentBlock.addElement', defaultMessage: 'add {type}'}, {type: typeName})
-
-                const afterRedo = async (nb: Block) => {
-                    const contentOrder = card.fields.contentOrder.slice()
-                    contentOrder.splice(index, 0, nb.id)
-                    await octoClient.patchBlock(card.boardId, card.id, {updatedFields: {contentOrder}})
-                }
-
-                const beforeUndo = async () => {
-                    const contentOrder = card.fields.contentOrder.slice()
-                    await octoClient.patchBlock(card.boardId, card.id, {updatedFields: {contentOrder}})
-                }
-
-                await mutator.insertBlock(newBlock.boardId, newBlock, description, afterRedo, beforeUndo)
-            }}
+            onClick={addElement}
         />
     )
 }

--- a/webapp/src/components/content/textElement.test.tsx
+++ b/webapp/src/components/content/textElement.test.tsx
@@ -9,6 +9,8 @@ import '@testing-library/jest-dom'
 
 import {mocked} from 'jest-mock'
 
+import {CardDetailProvider} from '../cardDetail/cardDetailContext'
+
 import {TextBlock} from '../../blocks/textBlock'
 
 import {mockDOM, wrapDNDIntl, mockStateStore} from '../../testUtils'
@@ -45,6 +47,7 @@ describe('components/content/TextElement', () => {
     })
 
     const board1 = TestBlockFactory.createBoard()
+    const card = TestBlockFactory.createCard(board1)
     board1.id = 'board-id-1'
 
     const state = {
@@ -72,10 +75,12 @@ describe('components/content/TextElement', () => {
     test('return a textElement', async () => {
         const component = wrapDNDIntl(
             <ReduxProvider store={store}>
-                <TextElement
-                    block={defaultBlock}
-                    readonly={false}
-                />
+                <CardDetailProvider card={card}>
+                    <TextElement
+                        block={defaultBlock}
+                        readonly={false}
+                    />
+                </CardDetailProvider>
             </ReduxProvider>,
         )
 

--- a/webapp/src/components/content/textElement.tsx
+++ b/webapp/src/components/content/textElement.tsx
@@ -3,6 +3,8 @@
 import React from 'react'
 import {useIntl} from 'react-intl'
 
+import {useCardDetailContext} from '../cardDetail/cardDetailContext'
+
 import {ContentBlock} from '../../blocks/contentBlock'
 import {createTextBlock} from '../../blocks/textBlock'
 import mutator from '../../mutator'
@@ -19,6 +21,7 @@ type Props = {
 const TextElement = (props: Props): JSX.Element => {
     const {block, readonly} = props
     const intl = useIntl()
+    const {lastAddedBlock} = useCardDetailContext()
 
     return (
         <MarkdownEditor
@@ -30,6 +33,7 @@ const TextElement = (props: Props): JSX.Element => {
                 }
             }}
             readonly={readonly}
+            focus={lastAddedBlock.id === block.id}
         />
     )
 }

--- a/webapp/src/components/contentBlock.tsx
+++ b/webapp/src/components/contentBlock.tsx
@@ -105,7 +105,6 @@ const ContentBlock = (props: Props): JSX.Element => {
                                     <AddContentMenuItem
                                         key={type}
                                         type={type}
-                                        card={card}
                                         cords={cords}
                                     />
                                 ))}

--- a/webapp/src/components/markdownEditor.tsx
+++ b/webapp/src/components/markdownEditor.tsx
@@ -13,6 +13,7 @@ type Props = {
     placeholderText?: string
     className?: string
     readonly?: boolean
+    focus?: boolean
 
     onChange?: (text: string) => void
     onFocus?: () => void
@@ -20,8 +21,8 @@ type Props = {
 }
 
 const MarkdownEditor = (props: Props): JSX.Element => {
-    const {placeholderText, onFocus, onBlur, onChange, text, id} = props
-    const [isEditing, setIsEditing] = useState(false)
+    const {placeholderText, onFocus, onBlur, onChange, text, id, focus = false} = props
+    const [isEditing, setIsEditing] = useState(focus)
     const html: string = Utils.htmlFromMarkdown(text || placeholderText || '')
 
     const previewElement = (


### PR DESCRIPTION
#### Summary

When adding a text block in a card it enters edit-mode straight away instead of having to click on it.


#### Ticket Link

 Fixes https://github.com/mattermost/focalboard/issues/2068

