### PR TITLE
Fixed server lint issue about not using deprecated package io.ioutils

### DIFF
--- a/mattermost-plugin/build/manifest/main.go
+++ b/mattermost-plugin/build/manifest/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/pkg/errors"
@@ -115,7 +114,7 @@ func applyManifest(manifest *model.Manifest) error {
 		manifestStr := string(manifestBytes)
 
 		// write generated code to file by using Go file template.
-		if err := ioutil.WriteFile(
+		if err := os.WriteFile(
 			"server/manifest.go",
 			[]byte(fmt.Sprintf(pluginIDGoFileTemplate, manifestStr)),
 			0600,

--- a/mattermost-plugin/build/sync/main.go
+++ b/mattermost-plugin/build/sync/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -70,7 +69,7 @@ func main() {
 }
 
 func readPlan(path string) (*plan.Plan, error) {
-	raw, err := ioutil.ReadFile(path)
+	raw, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read plan file %q: %v", path, err)
 	}

--- a/mattermost-plugin/build/sync/plan/actions_test.go
+++ b/mattermost-plugin/build/sync/plan/actions_test.go
@@ -1,7 +1,6 @@
 package plan_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -15,7 +14,7 @@ func TestCopyDirectory(t *testing.T) {
 	assert := assert.New(t)
 
 	// Create a temporary directory to copy to.
-	dir, err := ioutil.TempDir("", "test")
+	dir, err := os.TempDir("", "test")
 	assert.Nil(err)
 	defer os.RemoveAll(dir)
 
@@ -33,7 +32,7 @@ func TestOverwriteFileAction(t *testing.T) {
 	assert := assert.New(t)
 
 	// Create a temporary directory to copy to.
-	dir, err := ioutil.TempDir("", "test")
+	dir, err := os.TempDir("", "test")
 	assert.Nil(err)
 	defer os.RemoveAll(dir)
 
@@ -62,7 +61,7 @@ func TestOverwriteDirectoryAction(t *testing.T) {
 	assert := assert.New(t)
 
 	// Create a temporary directory to copy to.
-	dir, err := ioutil.TempDir("", "test")
+	dir, err := os.TempDir("", "test")
 	assert.Nil(err)
 	defer os.RemoveAll(dir)
 
@@ -93,9 +92,9 @@ func compareDirectories(t *testing.T, pathA, pathB string) {
 	assert := assert.New(t)
 	t.Helper()
 
-	aContents, err := ioutil.ReadDir(pathA)
+	aContents, err := os.ReadDir(pathA)
 	assert.Nil(err)
-	bContents, err := ioutil.ReadDir(pathB)
+	bContents, err := os.ReadDir(pathB)
 	assert.Nil(err)
 	assert.Len(aContents, len(bContents))
 

--- a/mattermost-plugin/build/sync/plan/checks_test.go
+++ b/mattermost-plugin/build/sync/plan/checks_test.go
@@ -2,7 +2,6 @@ package plan_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -21,7 +20,7 @@ func TestRepoIsCleanChecker(t *testing.T) {
 	assert := assert.New(t)
 
 	// Create a git repository in a temporary dir.
-	dir, err := ioutil.TempDir("", "test")
+	dir, err := os.TempDir("", "test")
 	assert.Nil(err)
 	defer os.RemoveAll(dir)
 	repo, err := git.PlainInit(dir, false)
@@ -40,7 +39,7 @@ func TestRepoIsCleanChecker(t *testing.T) {
 	assert.Nil(checker.Check("", ctx))
 
 	// Create a file in the repository.
-	err = ioutil.WriteFile(path.Join(dir, "data.txt"), []byte("lorem ipsum"), 0600)
+	err = os.WriteFile(path.Join(dir, "data.txt"), []byte("lorem ipsum"), 0600)
 	assert.Nil(err)
 	err = checker.Check("", ctx)
 	assert.EqualError(err, "\"target\" repository is not clean")
@@ -51,12 +50,12 @@ func TestPathExistsChecker(t *testing.T) {
 	assert := assert.New(t)
 
 	// Set up a working directory.
-	wd, err := ioutil.TempDir("", "repo")
+	wd, err := os.TempDir("", "repo")
 	assert.Nil(err)
 	defer os.RemoveAll(wd)
 	err = os.Mkdir(filepath.Join(wd, "t"), 0755)
 	assert.Nil(err)
-	err = ioutil.WriteFile(filepath.Join(wd, "t", "test"), []byte("lorem ipsum"), 0644)
+	err = os.WriteFile(filepath.Join(wd, "t", "test"), []byte("lorem ipsum"), 0644)
 	assert.Nil(err)
 
 	checker := plan.PathExistsChecker{}
@@ -81,7 +80,7 @@ func TestPathExistsChecker(t *testing.T) {
 
 func tempGitRepo(assert *assert.Assertions) (string, *git.Repository, func()) {
 	// Setup repository.
-	wd, err := ioutil.TempDir("", "repo")
+	wd, err := os.TempDir("", "repo")
 	assert.Nil(err)
 
 	// Initialize a repository.
@@ -90,7 +89,7 @@ func tempGitRepo(assert *assert.Assertions) (string, *git.Repository, func()) {
 	w, err := repo.Worktree()
 	assert.Nil(err)
 	// Create repository files.
-	err = ioutil.WriteFile(filepath.Join(wd, "test"),
+	err = os.WriteFile(filepath.Join(wd, "test"),
 		[]byte("lorem ipsum"), 0644)
 	assert.Nil(err)
 	sig := &object.Signature{
@@ -101,7 +100,7 @@ func tempGitRepo(assert *assert.Assertions) (string, *git.Repository, func()) {
 	_, err = w.Commit("initial commit", &git.CommitOptions{Author: sig})
 	assert.Nil(err)
 	pathA := "a.txt"
-	err = ioutil.WriteFile(filepath.Join(wd, pathA),
+	err = os.WriteFile(filepath.Join(wd, pathA),
 		[]byte("lorem ipsum"), 0644)
 	assert.Nil(err)
 	_, err = w.Add(pathA)
@@ -160,10 +159,10 @@ func TestUnalteredCheckerDifferentContents(t *testing.T) {
 	checker.Params.TargetRepo = plan.TargetRepo
 
 	// Create a file with the same suffix path, but different contents.
-	tmpDir, err := ioutil.TempDir("", "test")
+	tmpDir, err := os.TempDir("", "test")
 	assert.Nil(err)
 	defer os.RemoveAll(tmpDir)
-	err = ioutil.WriteFile(filepath.Join(tmpDir, "a.txt"),
+	err = os.WriteFile(filepath.Join(tmpDir, "a.txt"),
 		[]byte("not lorem ipsum"), 0644)
 	assert.Nil(err)
 
@@ -186,7 +185,7 @@ func TestUnalteredCheckerNonExistant(t *testing.T) {
 	defer cleanup()
 
 	// Temporary repo.
-	tmpDir, err := ioutil.TempDir("", "test")
+	tmpDir, err := os.TempDir("", "test")
 	assert.Nil(err)
 	defer os.RemoveAll(tmpDir)
 

--- a/mattermost-plugin/build/sync/plan/git/file_history_test.go
+++ b/mattermost-plugin/build/sync/plan/git/file_history_test.go
@@ -1,7 +1,6 @@
 package git_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -19,7 +18,7 @@ var fileContents = []byte("abcdefg")
 func TestFileHistory(t *testing.T) {
 	assert := assert.New(t)
 
-	dir, err := ioutil.TempDir("", "repo")
+	dir, err := os.TempDir("", "repo")
 	assert.Nil(err)
 	defer os.RemoveAll(dir)
 
@@ -29,7 +28,7 @@ func TestFileHistory(t *testing.T) {
 	w, err := repo.Worktree()
 	assert.Nil(err)
 	// Create repository files.
-	err = ioutil.WriteFile(filepath.Join(dir, "test"), fileContents, 0644)
+	err = os.WriteFile(filepath.Join(dir, "test"), fileContents, 0644)
 	assert.Nil(err)
 	_, err = w.Add("test")
 	assert.Nil(err)
@@ -41,10 +40,10 @@ func TestFileHistory(t *testing.T) {
 	_, err = w.Commit("initial commit", &git.CommitOptions{Author: sig})
 	assert.Nil(err)
 	pathA := "a.txt"
-	err = ioutil.WriteFile(filepath.Join(dir, pathA), fileContents, 0644)
+	err = os.WriteFile(filepath.Join(dir, pathA), fileContents, 0644)
 	assert.Nil(err)
 	pathB := "b.txt"
-	err = ioutil.WriteFile(filepath.Join(dir, pathB), fileContents, 0644)
+	err = os.WriteFile(filepath.Join(dir, pathB), fileContents, 0644)
 	assert.Nil(err)
 	_, err = w.Add(pathA)
 	assert.Nil(err)

--- a/server/assets/build-template-archive/main.go
+++ b/server/assets/build-template-archive/main.go
@@ -6,7 +6,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 )
@@ -89,7 +88,7 @@ func build(cfg appConfig) (err error) {
 	}
 
 	// each board is a subdirectory; write each to the archive
-	files, err := ioutil.ReadDir(cfg.dir)
+	files, err := os.ReadDir(cfg.dir)
 	if err != nil {
 		return fmt.Errorf("error reading directory %s: %w", cfg.dir, err)
 	}
@@ -109,7 +108,7 @@ func build(cfg appConfig) (err error) {
 
 func getVersionFile(cfg appConfig) ([]byte, error) {
 	path := filepath.Join(cfg.dir, versionFilename)
-	buf, err := ioutil.ReadFile(path)
+	buf, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("cannot read %s: %w", path, err)
 	}
@@ -135,7 +134,7 @@ func writeBoard(w *zip.Writer, boardID string, cfg appConfig) error {
 	}
 
 	boardPath := filepath.Join(cfg.dir, boardID)
-	files, err := ioutil.ReadDir(boardPath)
+	files, err := os.ReadDir(boardPath)
 	if err != nil {
 		return fmt.Errorf("error reading board directory %s: %w", cfg.dir, err)
 	}

--- a/server/services/store/generators/main.go
+++ b/server/services/store/generators/main.go
@@ -11,7 +11,6 @@ import (
 	"go/parser"
 	"go/token"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"path"
@@ -61,7 +60,7 @@ func buildTransactionalStore() error {
 		return err
 	}
 
-	return ioutil.WriteFile(path.Join("sqlstore/public_methods.go"), formatedCode, 0644) //nolint:gosec
+	return os.WriteFile(path.Join("sqlstore/public_methods.go"), formatedCode, 0644) //nolint:gosec
 }
 
 type methodParam struct {

--- a/server/services/store/sqlstore/util.go
+++ b/server/services/store/sqlstore/util.go
@@ -4,7 +4,6 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -50,7 +49,7 @@ func PrepareNewTestDatabase() (dbType string, connectionString string, err error
 	var rootUser string
 
 	if dbType == model.SqliteDBType {
-		file, err := ioutil.TempFile("", "fbtest_*.db")
+		file, err := os.CreateTemp("", "fbtest_*.db")
 		if err != nil {
 			return "", "", err
 		}


### PR DESCRIPTION
Reference - https://github.com/go-critic/go-critic/issues/1019

`io/ioutils` functions have been moved to the packages `os` or `io`.
`make server-lint` was failing for me on latest `main`.