### PR TITLE
[GH-4086] Doc: Personal server setup guide out of date

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,9 @@ coverage
 # Compiled binary addons (http://nodejs.org/api/addons.html)
 build/Release
 
+# Environment files 
+.env
+
 # Dependency directory
 # https://docs.npmjs.com/misc/faq#should-i-check-my-node-modules-folder-into-git
 node_modules

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Our [developer guide](https://developers.mattermost.com/contribute/focalboard/pe
 
 Clone [mattermost-server](https://github.com/mattermost/mattermost-server) into sibling directory.
 
-Create a .env file in the focalboard directory that contains:
+Create an `.env` file in the focalboard directory that contains:
 
 ```
 EXCLUDE_ENTERPRISE="1"

--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ Like what you see? :eyes: Give us a GitHub Star! :star:
 
 It helps define, organize, track and manage work across individuals and teams. Focalboard comes in two main editions:
 
-- **[Mattermost Boards](https://www.focalboard.com/download/mattermost/)**: A self-hosted or **[free cloud server](https://mattermost.com/sign-up/?utm_source=focalboard&utm_campaign=focalboard)** for your team to plan and collaborate.
+* **[Mattermost Boards](https://www.focalboard.com/download/mattermost/)**: A self-hosted or **[free cloud server](https://mattermost.com/sign-up/?utm_source=focalboard&utm_campaign=focalboard)** for your team to plan and collaborate.
 
-- **[Personal Desktop](https://www.focalboard.com/download/personal-edition/desktop/)**: A standalone, single-user [Mac](https://apps.apple.com/app/apple-store/id1556908618?pt=2114704&ct=website&mt=8), [Windows](https://www.microsoft.com/store/apps/9NLN2T0SX9VF?cid=website), or [Linux](https://www.focalboard.com/download/personal-edition/desktop/#linux-desktop) desktop app for your own todos and personal projects.
+* **[Personal Desktop](https://www.focalboard.com/download/personal-edition/desktop/)**: A standalone, single-user [Mac](https://apps.apple.com/app/apple-store/id1556908618?pt=2114704&ct=website&mt=8), [Windows](https://www.microsoft.com/store/apps/9NLN2T0SX9VF?cid=website), or [Linux](https://www.focalboard.com/download/personal-edition/desktop/#linux-desktop) desktop app for your own todos and personal projects.
 
 Focalboard can also be installed as a standalone **[Personal Server](https://www.focalboard.com/download/personal-edition/ubuntu/)** for development and personal use.
 
@@ -28,15 +28,15 @@ Focalboard can also be installed as a standalone **[Personal Server](https://www
 
 **Mattermost Boards** combines project management tools with messaging and collaboration for teams of all sizes. To access and use **Mattermost Boards**, install or upgrade to Mattermost v6.0 or later as a [self-hosted server](https://docs.mattermost.com/guides/deployment.html?utm_source=focalboard&utm_campaign=focalboard) or [Cloud server](https://mattermost.com/sign-up/?utm_source=focalboard&utm_campaign=focalboard). After logging into Mattermost, select the menu in the top left corner and select **Boards**.
 
-**\*Mattermost Boards** is installed and enabled by default in Mattermost v6.0 and later.\*
+***Mattermost Boards** is installed and enabled by default in Mattermost v6.0 and later.*
 
 See the [plugin setup guide](https://www.focalboard.com/download/mattermost/) for more details.
 
 ### Personal Desktop (Windows, Mac or Linux Desktop)
 
-- **Windows**: Download from the [Windows App Store](https://www.microsoft.com/store/productId/9NLN2T0SX9VF) or download `focalboard-win.zip` from the [latest release](https://github.com/mattermost/focalboard/releases), unpack, and run `Focalboard.exe`.
-- **Mac**: Download from the [Mac App Store](https://apps.apple.com/us/app/focalboard-insiders/id1556908618?mt=12).
-- **Linux Desktop**: Download `focalboard-linux.tar.gz` from the [latest release](https://github.com/mattermost/focalboard/releases), unpack, and open `focalboard-app`.
+* **Windows**: Download from the [Windows App Store](https://www.microsoft.com/store/productId/9NLN2T0SX9VF) or download `focalboard-win.zip` from the [latest release](https://github.com/mattermost/focalboard/releases), unpack, and run `Focalboard.exe`.
+* **Mac**: Download from the [Mac App Store](https://apps.apple.com/us/app/focalboard-insiders/id1556908618?mt=12).
+* **Linux Desktop**: Download `focalboard-linux.tar.gz` from the [latest release](https://github.com/mattermost/focalboard/releases), unpack, and open `focalboard-app`.
 
 ### Personal Server
 
@@ -79,39 +79,39 @@ Once the server is running, you can rebuild just the web app via `make webapp` i
 
 You can build standalone apps that package the server to run locally against SQLite:
 
-- **Windows**:
-  - _Requires Windows 10, [Windows 10 SDK](https://developer.microsoft.com/en-us/windows/downloads/sdk-archive/) 10.0.19041.0, and .NET 4.8 developer pack_
-  - Open a `git-bash` prompt.
-  - Run `make prebuild`
-  - The above prebuild step needs to be run only when you make changes to or want to install your npm dependencies, etc.
-  - Once the prebuild is completed, you can keep repeating the below steps to build the app & see the changes.
-  - Run `make win-wpf-app`
-  - Run `cd win-wpf/msix && focalboard.exe`
-- **Mac**:
-  - _Requires macOS 11.3+ and Xcode 13.2.1+_
-  - Run `make prebuild`
-  - The above prebuild step needs to be run only when you make changes to or want to install your npm dependencies, etc.
-  - Once the prebuild is completed, you can keep repeating the below steps to build the app & see the changes.
-  - Run `make mac-app`
-  - Run `open mac/dist/Focalboard.app`
-- **Linux**:
-  - _Tested on Ubuntu 18.04_
-  - Install `webgtk` dependencies
-    - Run `sudo apt-get install libgtk-3-dev`
-    - Run `sudo apt-get install libwebkit2gtk-4.0-dev`
-  - Run `make prebuild`
-  - The above prebuild step needs to be run only when you make changes to or want to install your npm dependencies, etc.
-  - Once the prebuild is completed, you can keep repeating the below steps to build the app & see the changes.
-  - Run `make linux-app`
-  - Uncompress `linux/dist/focalboard-linux.tar.gz` to a directory of your choice
-  - Run `focalboard-app` from the directory you have chosen
-- **Docker**:
-  - To run it locally from offical image:
-    - `docker run -it -p 80:8000 mattermost/focalboard`
-  - To build it for your current architecture:
-    - `docker build -f docker/Dockerfile .`
-  - To build it for a custom architecture (experimental):
-    - `docker build -f docker/Dockerfile --platform linux/arm64 .`
+* **Windows**:
+    * *Requires Windows 10, [Windows 10 SDK](https://developer.microsoft.com/en-us/windows/downloads/sdk-archive/) 10.0.19041.0, and .NET 4.8 developer pack*
+    * Open a `git-bash` prompt.
+    * Run `make prebuild`
+    * The above prebuild step needs to be run only when you make changes to or want to install your npm dependencies, etc.
+    * Once the prebuild is completed, you can keep repeating the below steps to build the app & see the changes.
+    * Run `make win-wpf-app`
+    * Run `cd win-wpf/msix && focalboard.exe`
+* **Mac**:
+    * *Requires macOS 11.3+ and Xcode 13.2.1+*
+    * Run `make prebuild`
+    * The above prebuild step needs to be run only when you make changes to or want to install your npm dependencies, etc.
+    * Once the prebuild is completed, you can keep repeating the below steps to build the app & see the changes.
+    * Run `make mac-app`
+    * Run `open mac/dist/Focalboard.app`
+* **Linux**:
+    * *Tested on Ubuntu 18.04*
+    * Install `webgtk` dependencies
+        * Run `sudo apt-get install libgtk-3-dev`
+        * Run `sudo apt-get install libwebkit2gtk-4.0-dev`
+    * Run `make prebuild`
+    * The above prebuild step needs to be run only when you make changes to or want to install your npm dependencies, etc.
+    * Once the prebuild is completed, you can keep repeating the below steps to build the app & see the changes.
+    * Run `make linux-app`
+    * Uncompress `linux/dist/focalboard-linux.tar.gz` to a directory of your choice
+    * Run `focalboard-app` from the directory you have chosen
+* **Docker**:
+    * To run it locally from offical image:
+        * `docker run -it -p 80:8000 mattermost/focalboard`
+    * To build it for your current architecture:
+        * `docker build -f docker/Dockerfile .`
+    * To build it for a custom architecture (experimental):
+        * `docker build -f docker/Dockerfile --platform linux/arm64 .`
 
 Cross-compilation currently isn't fully supported, so please build on the appropriate platform. Refer to the GitHub Actions workflows (`build-mac.yml`, `build-win.yml`, `build-ubuntu.yml`) for the detailed list of steps on each platform.
 
@@ -119,10 +119,10 @@ Cross-compilation currently isn't fully supported, so please build on the approp
 
 Before checking in commits, run `make ci`, which is similar to the `.gitlab-ci.yml` workflow and includes:
 
-- **Server unit tests**: `make server-test`
-- **Web app ESLint**: `cd webapp; npm run check`
-- **Web app unit tests**: `cd webapp; npm run test`
-- **Web app UI tests**: `cd webapp; npm run cypress:ci`
+* **Server unit tests**: `make server-test`
+* **Web app ESLint**: `cd webapp; npm run check`
+* **Web app unit tests**: `cd webapp; npm run test`
+* **Web app UI tests**: `cd webapp; npm run cypress:ci`
 
 ### Translating
 
@@ -132,7 +132,7 @@ Help translate Focalboard! The app is already translated into several languages.
 
 Are you interested in influencing the future of the Focalboard open source project? Here's how you can get involved:
 
-- **Changes**: See the [CHANGELOG](CHANGELOG.md) for the latest updates
-- **GitHub Discussions**: Join the [Developer Discussion](https://github.com/mattermost/focalboard/discussions) board
-- **Bug Reports**: [File a bug report](https://github.com/mattermost/focalboard/issues/new?assignees=&labels=bug&template=bug_report.md&title=)
-- **Chat**: Join the [Focalboard community channel](https://community.mattermost.com/core/channels/focalboard)
+* **Changes**: See the [CHANGELOG](CHANGELOG.md) for the latest updates
+* **GitHub Discussions**: Join the [Developer Discussion](https://github.com/mattermost/focalboard/discussions) board
+* **Bug Reports**: [File a bug report](https://github.com/mattermost/focalboard/issues/new?assignees=&labels=bug&template=bug_report.md&title=)
+* **Chat**: Join the [Focalboard community channel](https://community.mattermost.com/core/channels/focalboard)

--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ Like what you see? :eyes: Give us a GitHub Star! :star:
 
 It helps define, organize, track and manage work across individuals and teams. Focalboard comes in two main editions:
 
-* **[Mattermost Boards](https://www.focalboard.com/download/mattermost/)**: A self-hosted or **[free cloud server](https://mattermost.com/sign-up/?utm_source=focalboard&utm_campaign=focalboard)** for your team to plan and collaborate.
+- **[Mattermost Boards](https://www.focalboard.com/download/mattermost/)**: A self-hosted or **[free cloud server](https://mattermost.com/sign-up/?utm_source=focalboard&utm_campaign=focalboard)** for your team to plan and collaborate.
 
-* **[Personal Desktop](https://www.focalboard.com/download/personal-edition/desktop/)**: A standalone, single-user [Mac](https://apps.apple.com/app/apple-store/id1556908618?pt=2114704&ct=website&mt=8), [Windows](https://www.microsoft.com/store/apps/9NLN2T0SX9VF?cid=website), or [Linux](https://www.focalboard.com/download/personal-edition/desktop/#linux-desktop) desktop app for your own todos and personal projects.
+- **[Personal Desktop](https://www.focalboard.com/download/personal-edition/desktop/)**: A standalone, single-user [Mac](https://apps.apple.com/app/apple-store/id1556908618?pt=2114704&ct=website&mt=8), [Windows](https://www.microsoft.com/store/apps/9NLN2T0SX9VF?cid=website), or [Linux](https://www.focalboard.com/download/personal-edition/desktop/#linux-desktop) desktop app for your own todos and personal projects.
 
 Focalboard can also be installed as a standalone **[Personal Server](https://www.focalboard.com/download/personal-edition/ubuntu/)** for development and personal use.
 
@@ -28,15 +28,15 @@ Focalboard can also be installed as a standalone **[Personal Server](https://www
 
 **Mattermost Boards** combines project management tools with messaging and collaboration for teams of all sizes. To access and use **Mattermost Boards**, install or upgrade to Mattermost v6.0 or later as a [self-hosted server](https://docs.mattermost.com/guides/deployment.html?utm_source=focalboard&utm_campaign=focalboard) or [Cloud server](https://mattermost.com/sign-up/?utm_source=focalboard&utm_campaign=focalboard). After logging into Mattermost, select the menu in the top left corner and select **Boards**.
 
-***Mattermost Boards** is installed and enabled by default in Mattermost v6.0 and later.*
+**\*Mattermost Boards** is installed and enabled by default in Mattermost v6.0 and later.\*
 
 See the [plugin setup guide](https://www.focalboard.com/download/mattermost/) for more details.
 
 ### Personal Desktop (Windows, Mac or Linux Desktop)
 
-* **Windows**: Download from the [Windows App Store](https://www.microsoft.com/store/productId/9NLN2T0SX9VF) or download `focalboard-win.zip` from the [latest release](https://github.com/mattermost/focalboard/releases), unpack, and run `Focalboard.exe`.
-* **Mac**: Download from the [Mac App Store](https://apps.apple.com/us/app/focalboard-insiders/id1556908618?mt=12).
-* **Linux Desktop**: Download `focalboard-linux.tar.gz` from the [latest release](https://github.com/mattermost/focalboard/releases), unpack, and open `focalboard-app`.
+- **Windows**: Download from the [Windows App Store](https://www.microsoft.com/store/productId/9NLN2T0SX9VF) or download `focalboard-win.zip` from the [latest release](https://github.com/mattermost/focalboard/releases), unpack, and run `Focalboard.exe`.
+- **Mac**: Download from the [Mac App Store](https://apps.apple.com/us/app/focalboard-insiders/id1556908618?mt=12).
+- **Linux Desktop**: Download `focalboard-linux.tar.gz` from the [latest release](https://github.com/mattermost/focalboard/releases), unpack, and open `focalboard-app`.
 
 ### Personal Server
 
@@ -49,6 +49,14 @@ Contribute code, bug reports, and ideas to the future of the Focalboard project.
 ### Getting started
 
 Our [developer guide](https://developers.mattermost.com/contribute/focalboard/personal-server-setup-guide) has detailed instructions on how to set up your development environment for the **Personal Server**. It also provides more information about contributing to our open source community.
+
+Clone [mattermost-server](https://github.com/mattermost/mattermost-server) into sibling directory.
+
+Create a .env file in the focalboard directory that contains:
+
+```
+EXCLUDE_ENTERPRISE="1"
+```
 
 To build the server:
 
@@ -71,39 +79,39 @@ Once the server is running, you can rebuild just the web app via `make webapp` i
 
 You can build standalone apps that package the server to run locally against SQLite:
 
-* **Windows**:
-    * *Requires Windows 10, [Windows 10 SDK](https://developer.microsoft.com/en-us/windows/downloads/sdk-archive/) 10.0.19041.0, and .NET 4.8 developer pack*
-    * Open a `git-bash` prompt.
-    * Run `make prebuild`
-    * The above prebuild step needs to be run only when you make changes to or want to install your npm dependencies, etc.
-    * Once the prebuild is completed, you can keep repeating the below steps to build the app & see the changes.
-    * Run `make win-wpf-app`
-    * Run `cd win-wpf/msix && focalboard.exe`
-* **Mac**:
-    * *Requires macOS 11.3+ and Xcode 13.2.1+*
-    * Run `make prebuild`
-    * The above prebuild step needs to be run only when you make changes to or want to install your npm dependencies, etc.
-    * Once the prebuild is completed, you can keep repeating the below steps to build the app & see the changes.
-    * Run `make mac-app`
-    * Run `open mac/dist/Focalboard.app`
-* **Linux**:
-    * *Tested on Ubuntu 18.04*
-    * Install `webgtk` dependencies
-        * Run `sudo apt-get install libgtk-3-dev`
-        * Run `sudo apt-get install libwebkit2gtk-4.0-dev`
-    * Run `make prebuild`
-    * The above prebuild step needs to be run only when you make changes to or want to install your npm dependencies, etc.
-    * Once the prebuild is completed, you can keep repeating the below steps to build the app & see the changes.
-    * Run `make linux-app`
-    * Uncompress `linux/dist/focalboard-linux.tar.gz` to a directory of your choice
-    * Run `focalboard-app` from the directory you have chosen
-* **Docker**:
-    * To run it locally from offical image:
-        * `docker run -it -p 80:8000 mattermost/focalboard`
-    * To build it for your current architecture:
-        * `docker build -f docker/Dockerfile .`
-    * To build it for a custom architecture (experimental):
-        * `docker build -f docker/Dockerfile --platform linux/arm64 .`
+- **Windows**:
+  - _Requires Windows 10, [Windows 10 SDK](https://developer.microsoft.com/en-us/windows/downloads/sdk-archive/) 10.0.19041.0, and .NET 4.8 developer pack_
+  - Open a `git-bash` prompt.
+  - Run `make prebuild`
+  - The above prebuild step needs to be run only when you make changes to or want to install your npm dependencies, etc.
+  - Once the prebuild is completed, you can keep repeating the below steps to build the app & see the changes.
+  - Run `make win-wpf-app`
+  - Run `cd win-wpf/msix && focalboard.exe`
+- **Mac**:
+  - _Requires macOS 11.3+ and Xcode 13.2.1+_
+  - Run `make prebuild`
+  - The above prebuild step needs to be run only when you make changes to or want to install your npm dependencies, etc.
+  - Once the prebuild is completed, you can keep repeating the below steps to build the app & see the changes.
+  - Run `make mac-app`
+  - Run `open mac/dist/Focalboard.app`
+- **Linux**:
+  - _Tested on Ubuntu 18.04_
+  - Install `webgtk` dependencies
+    - Run `sudo apt-get install libgtk-3-dev`
+    - Run `sudo apt-get install libwebkit2gtk-4.0-dev`
+  - Run `make prebuild`
+  - The above prebuild step needs to be run only when you make changes to or want to install your npm dependencies, etc.
+  - Once the prebuild is completed, you can keep repeating the below steps to build the app & see the changes.
+  - Run `make linux-app`
+  - Uncompress `linux/dist/focalboard-linux.tar.gz` to a directory of your choice
+  - Run `focalboard-app` from the directory you have chosen
+- **Docker**:
+  - To run it locally from offical image:
+    - `docker run -it -p 80:8000 mattermost/focalboard`
+  - To build it for your current architecture:
+    - `docker build -f docker/Dockerfile .`
+  - To build it for a custom architecture (experimental):
+    - `docker build -f docker/Dockerfile --platform linux/arm64 .`
 
 Cross-compilation currently isn't fully supported, so please build on the appropriate platform. Refer to the GitHub Actions workflows (`build-mac.yml`, `build-win.yml`, `build-ubuntu.yml`) for the detailed list of steps on each platform.
 
@@ -111,10 +119,10 @@ Cross-compilation currently isn't fully supported, so please build on the approp
 
 Before checking in commits, run `make ci`, which is similar to the `.gitlab-ci.yml` workflow and includes:
 
-* **Server unit tests**: `make server-test`
-* **Web app ESLint**: `cd webapp; npm run check`
-* **Web app unit tests**: `cd webapp; npm run test`
-* **Web app UI tests**: `cd webapp; npm run cypress:ci`
+- **Server unit tests**: `make server-test`
+- **Web app ESLint**: `cd webapp; npm run check`
+- **Web app unit tests**: `cd webapp; npm run test`
+- **Web app UI tests**: `cd webapp; npm run cypress:ci`
 
 ### Translating
 
@@ -124,7 +132,7 @@ Help translate Focalboard! The app is already translated into several languages.
 
 Are you interested in influencing the future of the Focalboard open source project? Here's how you can get involved:
 
-* **Changes**: See the [CHANGELOG](CHANGELOG.md) for the latest updates
-* **GitHub Discussions**: Join the [Developer Discussion](https://github.com/mattermost/focalboard/discussions) board
-* **Bug Reports**: [File a bug report](https://github.com/mattermost/focalboard/issues/new?assignees=&labels=bug&template=bug_report.md&title=)
-* **Chat**: Join the [Focalboard community channel](https://community.mattermost.com/core/channels/focalboard)
+- **Changes**: See the [CHANGELOG](CHANGELOG.md) for the latest updates
+- **GitHub Discussions**: Join the [Developer Discussion](https://github.com/mattermost/focalboard/discussions) board
+- **Bug Reports**: [File a bug report](https://github.com/mattermost/focalboard/issues/new?assignees=&labels=bug&template=bug_report.md&title=)
+- **Chat**: Join the [Focalboard community channel](https://community.mattermost.com/core/channels/focalboard)


### PR DESCRIPTION
#### Summary

Updated the readme to reflect how to actually setup the environment locally. Also updated .gitignore to ignore the .env file that now needs to be created. 

#### Ticket Link

Fixes https://github.com/mattermost/focalboard/issues/4086
