### PR TITLE
MM-47793 Change product dev server to not use deprecated options

### DIFF
--- a/mattermost-plugin/webapp/webpack.config.js
+++ b/mattermost-plugin/webapp/webpack.config.js
@@ -206,10 +206,13 @@ if (NPM_TARGET === 'start:product') {
     const url = new URL(process.env.MM_BOARDS_DEV_SERVER_URL ?? 'http://localhost:9006');
 
     config.devServer = {
-        https: url.protocol === 'https:' && {
-            minVersion: process.env.MM_SERVICESETTINGS_TLSMINVER,
-            key: process.env.MM_SERVICESETTINGS_TLSKEYFILE,
-            cert: process.env.MM_SERVICESETTINGS_TLSCERTFILE,
+        server: {
+            type: url.protocol.substring(0, url.protocol.length - 1),
+            options: {
+                minVersion: process.env.MM_SERVICESETTINGS_TLSMINVER ?? 'TLSv1.2',
+                key: process.env.MM_SERVICESETTINGS_TLSKEYFILE,
+                cert: process.env.MM_SERVICESETTINGS_TLSCERTFILE,
+            },
         },
         host: url.hostname,
         port: url.port,


### PR DESCRIPTION
Webpack complains about using the `https` option instead of the `server` one, so I changed that.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-47793
