### PR TITLE
fix: don't send multiple `viewBoard` telemetries

### DIFF
--- a/webapp/src/components/centerPanel.tsx
+++ b/webapp/src/components/centerPanel.tsx
@@ -86,6 +86,8 @@ const CenterPanel = (props: Props) => {
     const currentCard = useAppSelector(getCurrentCard)
     const dispatch = useAppDispatch()
 
+    // empty dependency array yields behavior like `componentDidMount`, it only runs _once_
+    // https://stackoverflow.com/a/58579462
     useEffect(() => {
         TelemetryClient.trackEvent(TelemetryCategory, TelemetryActions.ViewBoard, {board: props.board.id, view: props.activeView.id, viewType: props.activeView.fields.viewType})
     }, [])
@@ -247,7 +249,6 @@ const CenterPanel = (props: Props) => {
     }, [prepareBoardsTour, shouldStartBoardsTour])
 
     useEffect(() => {
-        TelemetryClient.trackEvent(TelemetryCategory, TelemetryActions.ViewBoard, {board: props.board.id, view: props.activeView.id, viewType: props.activeView.fields.viewType})
         startBoardsTour()
     })
 


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute

Assign two reviewers for this pull request from the names suggested. If no names are suggested or you are not sure who to assign, set `Core Focalboard` as the reviewer.
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the ticket).
-->
There was 2 instances of the `viewBoard` telemetry event being emitted. One of them was _also_ in a `useEffect` with _no_ dependency array so it was being called upon mounting _plus_ after every render.

This fixes the behavior so the telemetry event is only emitted _once_ per viewing the board.

#### Ticket Link
<!--
If this pull request addresses a Github issue, please link the relevant issue, e.g.

  Fixes https://github.com/mattermost/focalboard/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
fixes #4111
