### PR TITLE
Minor CSS fix

### DIFF
--- a/webapp/src/properties/person/person.scss
+++ b/webapp/src/properties/person/person.scss
@@ -14,6 +14,7 @@
         display: flex;
         align-items: center;
         color: rgba(var(--center-channel-color-rgb), 1);
+        margin-left: 10px;
 
         img {
             border-radius: 50px;


### PR DESCRIPTION
#### Summary

Minor UI fixes

Before:

The focus was going behind the person's avatar.

https://user-images.githubusercontent.com/26198062/199473719-f2fe9489-7e0b-4461-a68c-4d27861ef524.mov

After: 

Added some margin for the person's avatar and name.

https://user-images.githubusercontent.com/26198062/199473838-1bea02d9-3113-4a11-be31-a16c85da8cef.mov

#### Reason
The default behaviour for component `Select` in `react-select` is like below. The focus by default will be at the beginning of the `input` field.

https://user-images.githubusercontent.com/26198062/199474499-e7a19729-84ca-48d5-b298-c131fce75557.mov



#### Ticket Link
Fixes https://github.com/mattermost/focalboard/issues/3881
