### PR TITLE
Fix issues when retrieving boards

### DIFF
--- a/mattermost-plugin/server/manifest.go
+++ b/mattermost-plugin/server/manifest.go
@@ -45,7 +45,8 @@ const manifestStr = `
         "type": "bool",
         "help_text": "This allows board editors to share boards that can be accessed by anyone with the link.",
         "placeholder": "",
-        "default": false
+        "default": false,
+        "hosting": ""
       }
     ]
   }

--- a/server/services/store/mattermostauthlayer/mattermostauthlayer.go
+++ b/server/services/store/mattermostauthlayer/mattermostauthlayer.go
@@ -984,31 +984,25 @@ func (s *MattermostAuthLayer) GetMembersForBoard(boardID string) ([]*model.Board
 }
 
 func (s *MattermostAuthLayer) GetBoardsForUserAndTeam(userID, teamID string, includePublicBoards bool) ([]*model.Board, error) {
+	if includePublicBoards {
+		boards, err := s.SearchBoardsForUserInTeam(teamID, "", userID)
+		if err != nil {
+			return nil, err
+		}
+		return boards, nil
+	}
+
+	// retreive only
+	boardIDs := []string{}
 	members, err := s.GetMembersForUser(userID)
 	if err != nil {
 		return nil, err
 	}
-
-	boardIDs := []string{}
 	for _, m := range members {
 		boardIDs = append(boardIDs, m.BoardID)
 	}
 
-	if includePublicBoards {
-		var boards []*model.Board
-		boards, err = s.SearchBoardsForUserInTeam(teamID, "", userID)
-		if err != nil {
-			return nil, err
-		}
-		for _, b := range boards {
-			boardIDs = append(boardIDs, b.ID)
-		}
-	}
-
 	boards, err := s.Store.GetBoardsInTeamByIds(boardIDs, teamID)
-	// ToDo: check if the query is being used appropriately from the
-	//       interface, as we're getting ID sets on request that
-	//       return partial results that seem to be valid
 	if model.IsErrNotFound(err) {
 		if boards == nil {
 			boards = []*model.Board{}

--- a/server/services/store/mattermostauthlayer/mattermostauthlayer.go
+++ b/server/services/store/mattermostauthlayer/mattermostauthlayer.go
@@ -992,7 +992,7 @@ func (s *MattermostAuthLayer) GetBoardsForUserAndTeam(userID, teamID string, inc
 		return boards, nil
 	}
 
-	// retreive only direct memberships for user
+	// retrieve only direct memberships for user
 	// this is usually done for guests.
 	members, err := s.GetMembersForUser(userID)
 	if err != nil {

--- a/server/services/store/mattermostauthlayer/mattermostauthlayer.go
+++ b/server/services/store/mattermostauthlayer/mattermostauthlayer.go
@@ -992,12 +992,13 @@ func (s *MattermostAuthLayer) GetBoardsForUserAndTeam(userID, teamID string, inc
 		return boards, nil
 	}
 
-	// retreive only
-	boardIDs := []string{}
+	// retreive only direct memberships for user
+	// this is usually done for guests.
 	members, err := s.GetMembersForUser(userID)
 	if err != nil {
 		return nil, err
 	}
+	boardIDs := []string{}
 	for _, m := range members {
 		boardIDs = append(boardIDs, m.BoardID)
 	}


### PR DESCRIPTION
#### Summary

The symptoms were that templates were not being updated via websockets. However, that was because the templates were being added to both `state.templates` and `state.boards`. This was due to `GetMembersForUser` returning templates, which is has to to support permissions for templates properly. 

First solution was to add a boolean and only return the templates when retrieving for member permissions. However, upon further investigation, I noticed that the function `searchBoardForUserInTeam` is all that needs to be called if public boards are requested. We only need to retrieve via direct memberships if public boards are not requested. 

This also saves an additional call, since `searchBoardForUserInTeam` already returns board objects, this removes a database call in those instances. 

Also because the board IDs were being duplicate here, this will fix the WARNING 
```
{"timestamp":"2022-11-03 15:40:39.528 -06:00","level":"warn","msg":"getBoardsInTeamByIds mismatched number of boards found","caller":"sqlstore/board.go:301","product":"boards","len(boards)":2,"len(boardIDs)":4}
```

#### Ticket Link
  Fixes #4125 
  Fixes #4127
  Fixes #4137 
  Fixes #4103
  
