### PR TITLE
Automated cherry pick of #4145

### DIFF
--- a/mattermost-plugin/server/manifest.go
+++ b/mattermost-plugin/server/manifest.go
@@ -45,7 +45,8 @@ const manifestStr = `
         "type": "bool",
         "help_text": "This allows board editors to share boards that can be accessed by anyone with the link.",
         "placeholder": "",
-        "default": false
+        "default": false,
+        "hosting": ""
       }
     ]
   }


### PR DESCRIPTION
Cherry pick of #4145 on release-7.5.

/cc  @sbishel

```release-note
NONE
```