### PR TITLE
Added logic for system board category to show last

### DIFF
--- a/webapp/src/store/sidebar.ts
+++ b/webapp/src/store/sidebar.ts
@@ -38,8 +38,13 @@ export const DefaultCategory: CategoryBoards = {
 export const fetchSidebarCategories = createAsyncThunk(
     'sidebarCategories/fetch',
     async (teamID: string) => {
-        const categories = await client.getSidebarCategories(teamID)
-        return categories.sort((a, b) => a.name.localeCompare(b.name))
+        const allCategories = await client.getSidebarCategories(teamID)
+        const boardSystemCategoies = allCategories.filter((board) => board.name === 'Boards' && board.type === 'system')
+        const categoriesWithoutSystemBoard = allCategories.filter((board) => board.name !== 'Boards' && board.type !== 'system')
+        const categories = categoriesWithoutSystemBoard
+        categories.sort((a, b) => a.name.localeCompare(b.name))
+        categories.push(boardSystemCategoies[0])
+        return categories
     },
 )
 
@@ -74,8 +79,13 @@ const sidebarSlice = createSlice({
                 }
             })
 
-            // sort categories alphabetically
-            state.categoryAttributes.sort((a, b) => a.name.localeCompare(b.name))
+            // sort categories alphabetically only keeping board system category at the end
+            const boardsSystemCategories = state.categoryAttributes.filter((board) => board.name === 'Boards' && board.type === 'system')
+            const categoriesWithoutSystemBoard = state.categoryAttributes.filter((board) => board.name !== 'Baords' && board.type !== 'system')
+            const categories = categoriesWithoutSystemBoard
+            categories.sort((a, b) => a.name.localeCompare(b.name))
+            categories.push(boardsSystemCategories[0])
+            state.categoryAttributes = categories
         },
         updateBoardCategories: (state, action: PayloadAction<BoardCategoryWebsocketData[]>) => {
             action.payload.forEach((boardCategory) => {

--- a/webapp/src/store/sidebar.ts
+++ b/webapp/src/store/sidebar.ts
@@ -38,9 +38,10 @@ export const DefaultCategory: CategoryBoards = {
 export const fetchSidebarCategories = createAsyncThunk(
     'sidebarCategories/fetch',
     async (teamID: string) => {
+        // TODO All this logic should remove once LHS DND PR gets merged
         const allCategories = await client.getSidebarCategories(teamID)
-        const boardSystemCategoies = allCategories.filter((board) => board.name === 'Boards' && board.type === 'system')
-        const categoriesWithoutSystemBoard = allCategories.filter((board) => board.name !== 'Boards' && board.type !== 'system')
+        const boardSystemCategoies = allCategories.filter((category) => category.name === 'Boards' && category.type === 'system')
+        const categoriesWithoutSystemBoard = allCategories.filter((category) => category.name !== 'Boards' && category.type !== 'system')
         const categories = categoriesWithoutSystemBoard
         categories.sort((a, b) => a.name.localeCompare(b.name))
         categories.push(boardSystemCategoies[0])
@@ -80,8 +81,9 @@ const sidebarSlice = createSlice({
             })
 
             // sort categories alphabetically only keeping board system category at the end
-            const boardsSystemCategories = state.categoryAttributes.filter((board) => board.name === 'Boards' && board.type === 'system')
-            const categoriesWithoutSystemBoard = state.categoryAttributes.filter((board) => board.name !== 'Baords' && board.type !== 'system')
+            // TODO All this logic should remove once LHS DND PR gets merged
+            const boardsSystemCategories = state.categoryAttributes.filter((category) => category.name === 'Boards' && category.type === 'system')
+            const categoriesWithoutSystemBoard = state.categoryAttributes.filter((category) => category.name !== 'Baords' && category.type !== 'system')
             const categories = categoriesWithoutSystemBoard
             categories.sort((a, b) => a.name.localeCompare(b.name))
             categories.push(boardsSystemCategories[0])


### PR DESCRIPTION
#### Summary
The PR adds the logic to sort all the board categories but append the system board category at the end.

#### Ticket Link
Fixes https://github.com/mattermost/focalboard/issues/4138
