### PR TITLE
When importing boards, don't add user to board if system user

### DIFF
--- a/server/app/import.go
+++ b/server/app/import.go
@@ -225,15 +225,17 @@ func (a *App) ImportBoardJSONL(r io.Reader, opt model.ImportArchiveOptions) (str
 		return "", fmt.Errorf("error inserting archive blocks: %w", err)
 	}
 
-	// add user to all the new boards.
-	for _, board := range boardsAndBlocks.Boards {
-		boardMember := &model.BoardMember{
-			BoardID:     board.ID,
-			UserID:      opt.ModifiedBy,
-			SchemeAdmin: true,
-		}
-		if _, err := a.AddMemberToBoard(boardMember); err != nil {
-			return "", fmt.Errorf("cannot add member to board: %w", err)
+	// add user to all the new boards (if not the fake system user).
+	if opt.ModifiedBy != model.SystemUserID {
+		for _, board := range boardsAndBlocks.Boards {
+			boardMember := &model.BoardMember{
+				BoardID:     board.ID,
+				UserID:      opt.ModifiedBy,
+				SchemeAdmin: true,
+			}
+			if _, err := a.AddMemberToBoard(boardMember); err != nil {
+				return "", fmt.Errorf("cannot add member to board: %w", err)
+			}
 		}
 	}
 


### PR DESCRIPTION
#### Summary
Fixes a bug where the (fake) system user is added to board membership when importing default templates.  The userID is invalid and the import fails.

#### Ticket Link
NONE