### PR TITLE
Updating board template picker ui

### DIFF
--- a/webapp/i18n/en.json
+++ b/webapp/i18n/en.json
@@ -16,7 +16,7 @@
   "BoardMember.unlinkChannel": "Unlink",
   "BoardPage.newVersion": "A new version of Boards is available, click here to reload.",
   "BoardPage.syncFailed": "Board may be deleted or access revoked.",
-  "BoardTemplateSelector.add-template": "New template",
+  "BoardTemplateSelector.add-template": "Create new template",
   "BoardTemplateSelector.create-empty-board": "Create empty board",
   "BoardTemplateSelector.delete-template": "Delete",
   "BoardTemplateSelector.description": "Add a board to the sidebar using any of the templates defined below or start from scratch.",

--- a/webapp/src/components/boardTemplateSelector/__snapshots__/boardTemplateSelector.test.tsx.snap
+++ b/webapp/src/components/boardTemplateSelector/__snapshots__/boardTemplateSelector.test.tsx.snap
@@ -3,8 +3,11 @@
 exports[`components/boardTemplateSelector/boardTemplateSelector a focalboard Plugin should match snapshot 1`] = `
 <div>
   <div
-    class="BoardTemplateSelector__container"
+    class="BoardTemplateSelector__container "
   >
+    <div
+      class="BoardTemplateSelector__backdrop"
+    />
     <div
       class="BoardTemplateSelector"
     >
@@ -161,7 +164,7 @@ exports[`components/boardTemplateSelector/boardTemplateSelector a focalboard Plu
 exports[`components/boardTemplateSelector/boardTemplateSelector a focalboard Plugin should match snapshot with custom title and description 1`] = `
 <div>
   <div
-    class="BoardTemplateSelector__container"
+    class="BoardTemplateSelector__container BoardTemplateSelector__container--page"
   >
     <div
       class="BoardTemplateSelector"
@@ -309,7 +312,7 @@ exports[`components/boardTemplateSelector/boardTemplateSelector a focalboard Plu
 exports[`components/boardTemplateSelector/boardTemplateSelector a focalboard Plugin should match snapshot without close 1`] = `
 <div>
   <div
-    class="BoardTemplateSelector__container"
+    class="BoardTemplateSelector__container BoardTemplateSelector__container--page"
   >
     <div
       class="BoardTemplateSelector"
@@ -457,8 +460,11 @@ exports[`components/boardTemplateSelector/boardTemplateSelector a focalboard Plu
 exports[`components/boardTemplateSelector/boardTemplateSelector not a focalboard Plugin should match snapshot 1`] = `
 <div>
   <div
-    class="BoardTemplateSelector__container"
+    class="BoardTemplateSelector__container "
   >
+    <div
+      class="BoardTemplateSelector__backdrop"
+    />
     <div
       class="BoardTemplateSelector"
     >

--- a/webapp/src/components/boardTemplateSelector/__snapshots__/boardTemplateSelector.test.tsx.snap
+++ b/webapp/src/components/boardTemplateSelector/__snapshots__/boardTemplateSelector.test.tsx.snap
@@ -138,11 +138,15 @@ exports[`components/boardTemplateSelector/boardTemplateSelector a focalboard Plu
           </div>
         </div>
         <div
-          class="template-preview-box"
+          class="templates-content"
         >
           <div
-            class="BoardTemplateSelectorPreview"
-          />
+            class="template-preview-box"
+          >
+            <div
+              class="BoardTemplateSelectorPreview"
+            />
+          </div>
           <div
             class="buttons"
           >
@@ -286,11 +290,15 @@ exports[`components/boardTemplateSelector/boardTemplateSelector a focalboard Plu
           </div>
         </div>
         <div
-          class="template-preview-box"
+          class="templates-content"
         >
           <div
-            class="BoardTemplateSelectorPreview"
-          />
+            class="template-preview-box"
+          >
+            <div
+              class="BoardTemplateSelectorPreview"
+            />
+          </div>
           <div
             class="buttons"
           >
@@ -434,11 +442,15 @@ exports[`components/boardTemplateSelector/boardTemplateSelector a focalboard Plu
           </div>
         </div>
         <div
-          class="template-preview-box"
+          class="templates-content"
         >
           <div
-            class="BoardTemplateSelectorPreview"
-          />
+            class="template-preview-box"
+          >
+            <div
+              class="BoardTemplateSelectorPreview"
+            />
+          </div>
           <div
             class="buttons"
           >
@@ -595,11 +607,15 @@ exports[`components/boardTemplateSelector/boardTemplateSelector not a focalboard
           </div>
         </div>
         <div
-          class="template-preview-box"
+          class="templates-content"
         >
           <div
-            class="BoardTemplateSelectorPreview"
-          />
+            class="template-preview-box"
+          >
+            <div
+              class="BoardTemplateSelectorPreview"
+            />
+          </div>
           <div
             class="buttons"
           >

--- a/webapp/src/components/boardTemplateSelector/__snapshots__/boardTemplateSelector.test.tsx.snap
+++ b/webapp/src/components/boardTemplateSelector/__snapshots__/boardTemplateSelector.test.tsx.snap
@@ -126,11 +126,12 @@ exports[`components/boardTemplateSelector/boardTemplateSelector a focalboard Plu
           class="templates-sidebar__footer"
         >
           <button
-            type="button"
+            class="templates__empty-board"
           >
-            <span>
-              Create empty board
-            </span>
+            <i
+              class="CompassIcon icon-kanban"
+            />
+            Create empty board
           </button>
         </div>
       </div>
@@ -273,11 +274,12 @@ exports[`components/boardTemplateSelector/boardTemplateSelector a focalboard Plu
           class="templates-sidebar__footer"
         >
           <button
-            type="button"
+            class="templates__empty-board"
           >
-            <span>
-              Create empty board
-            </span>
+            <i
+              class="CompassIcon icon-kanban"
+            />
+            Create empty board
           </button>
         </div>
       </div>
@@ -420,11 +422,12 @@ exports[`components/boardTemplateSelector/boardTemplateSelector a focalboard Plu
           class="templates-sidebar__footer"
         >
           <button
-            type="button"
+            class="templates__empty-board"
           >
-            <span>
-              Create empty board
-            </span>
+            <i
+              class="CompassIcon icon-kanban"
+            />
+            Create empty board
           </button>
         </div>
       </div>
@@ -577,11 +580,12 @@ exports[`components/boardTemplateSelector/boardTemplateSelector not a focalboard
           class="templates-sidebar__footer"
         >
           <button
-            type="button"
+            class="templates__empty-board"
           >
-            <span>
-              Create empty board
-            </span>
+            <i
+              class="CompassIcon icon-kanban"
+            />
+            Create empty board
           </button>
         </div>
       </div>

--- a/webapp/src/components/boardTemplateSelector/__snapshots__/boardTemplateSelector.test.tsx.snap
+++ b/webapp/src/components/boardTemplateSelector/__snapshots__/boardTemplateSelector.test.tsx.snap
@@ -3,154 +3,154 @@
 exports[`components/boardTemplateSelector/boardTemplateSelector a focalboard Plugin should match snapshot 1`] = `
 <div>
   <div
-    class="BoardTemplateSelector"
+    class="BoardTemplateSelector__container"
   >
     <div
-      class="toolbar"
-    >
-      <button
-        aria-label="Close"
-        title="Close"
-        type="button"
-      >
-        <i
-          class="CompassIcon icon-close CloseIcon"
-        />
-      </button>
-    </div>
-    <div
-      class="header"
-    >
-      <h1
-        class="title"
-      >
-        Create a board
-      </h1>
-      <p
-        class="description"
-      >
-        Add a board to the sidebar using any of the templates defined below or start from scratch.
-      </p>
-    </div>
-    <div
-      class="templates"
+      class="BoardTemplateSelector"
     >
       <div
-        class="templates-sidebar"
+        class="toolbar"
+      >
+        <button
+          aria-label="Close"
+          title="Close"
+          type="button"
+        >
+          <i
+            class="CompassIcon icon-close CloseIcon"
+          />
+        </button>
+      </div>
+      <div
+        class="header"
+      >
+        <h1
+          class="title"
+        >
+          Create a board
+        </h1>
+        <p
+          class="description"
+        >
+          Add a board to the sidebar using any of the templates defined below or start from scratch.
+        </p>
+      </div>
+      <div
+        class="templates"
       >
         <div
-          class="templates-list"
+          class="templates-sidebar"
         >
           <div
-            class="BoardTemplateSelectorItem active"
+            class="templates-list"
           >
-            <span
-              class="template-icon"
+            <button
+              type="button"
             >
-              🚴🏻‍♂️
-            </span>
-            <span
-              class="template-name"
-            >
-              Template Global
-            </span>
-          </div>
-          <div
-            class="BoardTemplateSelectorItem"
-          >
-            <span
-              class="template-icon"
-            >
-              🚴🏻‍♂️
-            </span>
-            <span
-              class="template-name"
-            >
-              Template 1
-            </span>
+              <i
+                class="CompassIcon icon-plus"
+              />
+              <span>
+                Create new template
+              </span>
+            </button>
             <div
-              class="actions"
+              class="BoardTemplateSelectorItem active"
             >
-              <button
-                aria-label="Delete"
-                title="Delete"
-                type="button"
+              <span
+                class="template-icon"
               >
-                <i
-                  class="CompassIcon icon-trash-can-outline DeleteIcon trash-can-outline"
-                />
-              </button>
-              <button
-                aria-label="Edit"
-                title="Edit"
-                type="button"
+                🚴🏻‍♂️
+              </span>
+              <span
+                class="template-name"
               >
-                <i
-                  class="CompassIcon icon-pencil-outline EditIcon"
-                />
-              </button>
+                Template Global
+              </span>
+            </div>
+            <div
+              class="BoardTemplateSelectorItem"
+            >
+              <span
+                class="template-icon"
+              >
+                🚴🏻‍♂️
+              </span>
+              <span
+                class="template-name"
+              >
+                Template 1
+              </span>
+              <div
+                class="actions"
+              >
+                <button
+                  aria-label="Delete"
+                  title="Delete"
+                  type="button"
+                >
+                  <i
+                    class="CompassIcon icon-trash-can-outline DeleteIcon trash-can-outline"
+                  />
+                </button>
+                <button
+                  aria-label="Edit"
+                  title="Edit"
+                  type="button"
+                >
+                  <i
+                    class="CompassIcon icon-pencil-outline EditIcon"
+                  />
+                </button>
+              </div>
+            </div>
+            <div
+              class="BoardTemplateSelectorItem"
+            >
+              <span
+                class="template-icon"
+              >
+                ❄️
+              </span>
+              <span
+                class="template-name"
+              >
+                Welcome to Boards!
+              </span>
             </div>
           </div>
           <div
-            class="BoardTemplateSelectorItem"
+            class="templates-sidebar__footer"
           >
-            <span
-              class="template-icon"
-            >
-              ❄️
-            </span>
-            <span
-              class="template-name"
-            >
-              Welcome to Boards!
-            </span>
-          </div>
-          <div
-            class="new-template"
-          >
-            <span
-              class="template-icon"
+            <button
+              type="button"
             >
               <i
-                class="CompassIcon icon-plus AddIcon"
+                class="CompassIcon icon-kanban"
               />
-            </span>
-            <span
-              class="template-name"
-            >
-              New template
-            </span>
+              <span>
+                Create empty board
+              </span>
+            </button>
           </div>
         </div>
         <div
-          class="templates-sidebar__footer"
+          class="template-preview-box"
         >
-          <button
-            class="templates__empty-board"
+          <div
+            class="BoardTemplateSelectorPreview"
+          />
+          <div
+            class="buttons"
           >
-            <i
-              class="CompassIcon icon-kanban"
-            />
-            Create empty board
-          </button>
-        </div>
-      </div>
-      <div
-        class="template-preview-box"
-      >
-        <div
-          class="BoardTemplateSelectorPreview"
-        />
-        <div
-          class="buttons"
-        >
-          <button
-            type="button"
-          >
-            <span>
-              Use this template
-            </span>
-          </button>
+            <button
+              type="button"
+            >
+              <span>
+                Use this template
+              </span>
+            </button>
+          </div>
         </div>
       </div>
     </div>
@@ -161,144 +161,144 @@ exports[`components/boardTemplateSelector/boardTemplateSelector a focalboard Plu
 exports[`components/boardTemplateSelector/boardTemplateSelector a focalboard Plugin should match snapshot with custom title and description 1`] = `
 <div>
   <div
-    class="BoardTemplateSelector"
+    class="BoardTemplateSelector__container"
   >
     <div
-      class="toolbar"
-    />
-    <div
-      class="header"
-    >
-      <h1
-        class="title"
-      >
-        test-title
-      </h1>
-      <p
-        class="description"
-      >
-        test-description
-      </p>
-    </div>
-    <div
-      class="templates"
+      class="BoardTemplateSelector"
     >
       <div
-        class="templates-sidebar"
+        class="toolbar"
+      />
+      <div
+        class="header"
+      >
+        <h1
+          class="title"
+        >
+          test-title
+        </h1>
+        <p
+          class="description"
+        >
+          test-description
+        </p>
+      </div>
+      <div
+        class="templates"
       >
         <div
-          class="templates-list"
+          class="templates-sidebar"
         >
           <div
-            class="BoardTemplateSelectorItem active"
+            class="templates-list"
           >
-            <span
-              class="template-icon"
+            <button
+              type="button"
             >
-              🚴🏻‍♂️
-            </span>
-            <span
-              class="template-name"
-            >
-              Template Global
-            </span>
-          </div>
-          <div
-            class="BoardTemplateSelectorItem"
-          >
-            <span
-              class="template-icon"
-            >
-              🚴🏻‍♂️
-            </span>
-            <span
-              class="template-name"
-            >
-              Template 1
-            </span>
+              <i
+                class="CompassIcon icon-plus"
+              />
+              <span>
+                Create new template
+              </span>
+            </button>
             <div
-              class="actions"
+              class="BoardTemplateSelectorItem active"
             >
-              <button
-                aria-label="Delete"
-                title="Delete"
-                type="button"
+              <span
+                class="template-icon"
               >
-                <i
-                  class="CompassIcon icon-trash-can-outline DeleteIcon trash-can-outline"
-                />
-              </button>
-              <button
-                aria-label="Edit"
-                title="Edit"
-                type="button"
+                🚴🏻‍♂️
+              </span>
+              <span
+                class="template-name"
               >
-                <i
-                  class="CompassIcon icon-pencil-outline EditIcon"
-                />
-              </button>
+                Template Global
+              </span>
+            </div>
+            <div
+              class="BoardTemplateSelectorItem"
+            >
+              <span
+                class="template-icon"
+              >
+                🚴🏻‍♂️
+              </span>
+              <span
+                class="template-name"
+              >
+                Template 1
+              </span>
+              <div
+                class="actions"
+              >
+                <button
+                  aria-label="Delete"
+                  title="Delete"
+                  type="button"
+                >
+                  <i
+                    class="CompassIcon icon-trash-can-outline DeleteIcon trash-can-outline"
+                  />
+                </button>
+                <button
+                  aria-label="Edit"
+                  title="Edit"
+                  type="button"
+                >
+                  <i
+                    class="CompassIcon icon-pencil-outline EditIcon"
+                  />
+                </button>
+              </div>
+            </div>
+            <div
+              class="BoardTemplateSelectorItem"
+            >
+              <span
+                class="template-icon"
+              >
+                ❄️
+              </span>
+              <span
+                class="template-name"
+              >
+                Welcome to Boards!
+              </span>
             </div>
           </div>
           <div
-            class="BoardTemplateSelectorItem"
+            class="templates-sidebar__footer"
           >
-            <span
-              class="template-icon"
-            >
-              ❄️
-            </span>
-            <span
-              class="template-name"
-            >
-              Welcome to Boards!
-            </span>
-          </div>
-          <div
-            class="new-template"
-          >
-            <span
-              class="template-icon"
+            <button
+              type="button"
             >
               <i
-                class="CompassIcon icon-plus AddIcon"
+                class="CompassIcon icon-kanban"
               />
-            </span>
-            <span
-              class="template-name"
-            >
-              New template
-            </span>
+              <span>
+                Create empty board
+              </span>
+            </button>
           </div>
         </div>
         <div
-          class="templates-sidebar__footer"
+          class="template-preview-box"
         >
-          <button
-            class="templates__empty-board"
+          <div
+            class="BoardTemplateSelectorPreview"
+          />
+          <div
+            class="buttons"
           >
-            <i
-              class="CompassIcon icon-kanban"
-            />
-            Create empty board
-          </button>
-        </div>
-      </div>
-      <div
-        class="template-preview-box"
-      >
-        <div
-          class="BoardTemplateSelectorPreview"
-        />
-        <div
-          class="buttons"
-        >
-          <button
-            type="button"
-          >
-            <span>
-              Use this template
-            </span>
-          </button>
+            <button
+              type="button"
+            >
+              <span>
+                Use this template
+              </span>
+            </button>
+          </div>
         </div>
       </div>
     </div>
@@ -309,144 +309,144 @@ exports[`components/boardTemplateSelector/boardTemplateSelector a focalboard Plu
 exports[`components/boardTemplateSelector/boardTemplateSelector a focalboard Plugin should match snapshot without close 1`] = `
 <div>
   <div
-    class="BoardTemplateSelector"
+    class="BoardTemplateSelector__container"
   >
     <div
-      class="toolbar"
-    />
-    <div
-      class="header"
-    >
-      <h1
-        class="title"
-      >
-        Create a board
-      </h1>
-      <p
-        class="description"
-      >
-        Add a board to the sidebar using any of the templates defined below or start from scratch.
-      </p>
-    </div>
-    <div
-      class="templates"
+      class="BoardTemplateSelector"
     >
       <div
-        class="templates-sidebar"
+        class="toolbar"
+      />
+      <div
+        class="header"
+      >
+        <h1
+          class="title"
+        >
+          Create a board
+        </h1>
+        <p
+          class="description"
+        >
+          Add a board to the sidebar using any of the templates defined below or start from scratch.
+        </p>
+      </div>
+      <div
+        class="templates"
       >
         <div
-          class="templates-list"
+          class="templates-sidebar"
         >
           <div
-            class="BoardTemplateSelectorItem active"
+            class="templates-list"
           >
-            <span
-              class="template-icon"
+            <button
+              type="button"
             >
-              🚴🏻‍♂️
-            </span>
-            <span
-              class="template-name"
-            >
-              Template Global
-            </span>
-          </div>
-          <div
-            class="BoardTemplateSelectorItem"
-          >
-            <span
-              class="template-icon"
-            >
-              🚴🏻‍♂️
-            </span>
-            <span
-              class="template-name"
-            >
-              Template 1
-            </span>
+              <i
+                class="CompassIcon icon-plus"
+              />
+              <span>
+                Create new template
+              </span>
+            </button>
             <div
-              class="actions"
+              class="BoardTemplateSelectorItem active"
             >
-              <button
-                aria-label="Delete"
-                title="Delete"
-                type="button"
+              <span
+                class="template-icon"
               >
-                <i
-                  class="CompassIcon icon-trash-can-outline DeleteIcon trash-can-outline"
-                />
-              </button>
-              <button
-                aria-label="Edit"
-                title="Edit"
-                type="button"
+                🚴🏻‍♂️
+              </span>
+              <span
+                class="template-name"
               >
-                <i
-                  class="CompassIcon icon-pencil-outline EditIcon"
-                />
-              </button>
+                Template Global
+              </span>
+            </div>
+            <div
+              class="BoardTemplateSelectorItem"
+            >
+              <span
+                class="template-icon"
+              >
+                🚴🏻‍♂️
+              </span>
+              <span
+                class="template-name"
+              >
+                Template 1
+              </span>
+              <div
+                class="actions"
+              >
+                <button
+                  aria-label="Delete"
+                  title="Delete"
+                  type="button"
+                >
+                  <i
+                    class="CompassIcon icon-trash-can-outline DeleteIcon trash-can-outline"
+                  />
+                </button>
+                <button
+                  aria-label="Edit"
+                  title="Edit"
+                  type="button"
+                >
+                  <i
+                    class="CompassIcon icon-pencil-outline EditIcon"
+                  />
+                </button>
+              </div>
+            </div>
+            <div
+              class="BoardTemplateSelectorItem"
+            >
+              <span
+                class="template-icon"
+              >
+                ❄️
+              </span>
+              <span
+                class="template-name"
+              >
+                Welcome to Boards!
+              </span>
             </div>
           </div>
           <div
-            class="BoardTemplateSelectorItem"
+            class="templates-sidebar__footer"
           >
-            <span
-              class="template-icon"
-            >
-              ❄️
-            </span>
-            <span
-              class="template-name"
-            >
-              Welcome to Boards!
-            </span>
-          </div>
-          <div
-            class="new-template"
-          >
-            <span
-              class="template-icon"
+            <button
+              type="button"
             >
               <i
-                class="CompassIcon icon-plus AddIcon"
+                class="CompassIcon icon-kanban"
               />
-            </span>
-            <span
-              class="template-name"
-            >
-              New template
-            </span>
+              <span>
+                Create empty board
+              </span>
+            </button>
           </div>
         </div>
         <div
-          class="templates-sidebar__footer"
+          class="template-preview-box"
         >
-          <button
-            class="templates__empty-board"
+          <div
+            class="BoardTemplateSelectorPreview"
+          />
+          <div
+            class="buttons"
           >
-            <i
-              class="CompassIcon icon-kanban"
-            />
-            Create empty board
-          </button>
-        </div>
-      </div>
-      <div
-        class="template-preview-box"
-      >
-        <div
-          class="BoardTemplateSelectorPreview"
-        />
-        <div
-          class="buttons"
-        >
-          <button
-            type="button"
-          >
-            <span>
-              Use this template
-            </span>
-          </button>
+            <button
+              type="button"
+            >
+              <span>
+                Use this template
+              </span>
+            </button>
+          </div>
         </div>
       </div>
     </div>
@@ -457,154 +457,154 @@ exports[`components/boardTemplateSelector/boardTemplateSelector a focalboard Plu
 exports[`components/boardTemplateSelector/boardTemplateSelector not a focalboard Plugin should match snapshot 1`] = `
 <div>
   <div
-    class="BoardTemplateSelector"
+    class="BoardTemplateSelector__container"
   >
     <div
-      class="toolbar"
-    >
-      <button
-        aria-label="Close"
-        title="Close"
-        type="button"
-      >
-        <i
-          class="CompassIcon icon-close CloseIcon"
-        />
-      </button>
-    </div>
-    <div
-      class="header"
-    >
-      <h1
-        class="title"
-      >
-        Create a board
-      </h1>
-      <p
-        class="description"
-      >
-        Add a board to the sidebar using any of the templates defined below or start from scratch.
-      </p>
-    </div>
-    <div
-      class="templates"
+      class="BoardTemplateSelector"
     >
       <div
-        class="templates-sidebar"
+        class="toolbar"
+      >
+        <button
+          aria-label="Close"
+          title="Close"
+          type="button"
+        >
+          <i
+            class="CompassIcon icon-close CloseIcon"
+          />
+        </button>
+      </div>
+      <div
+        class="header"
+      >
+        <h1
+          class="title"
+        >
+          Create a board
+        </h1>
+        <p
+          class="description"
+        >
+          Add a board to the sidebar using any of the templates defined below or start from scratch.
+        </p>
+      </div>
+      <div
+        class="templates"
       >
         <div
-          class="templates-list"
+          class="templates-sidebar"
         >
           <div
-            class="BoardTemplateSelectorItem active"
+            class="templates-list"
           >
-            <span
-              class="template-icon"
+            <button
+              type="button"
             >
-              🚴🏻‍♂️
-            </span>
-            <span
-              class="template-name"
-            >
-              Template Global
-            </span>
-          </div>
-          <div
-            class="BoardTemplateSelectorItem"
-          >
-            <span
-              class="template-icon"
-            >
-              🚴🏻‍♂️
-            </span>
-            <span
-              class="template-name"
-            >
-              Template 1
-            </span>
+              <i
+                class="CompassIcon icon-plus"
+              />
+              <span>
+                Create new template
+              </span>
+            </button>
             <div
-              class="actions"
+              class="BoardTemplateSelectorItem active"
             >
-              <button
-                aria-label="Delete"
-                title="Delete"
-                type="button"
+              <span
+                class="template-icon"
               >
-                <i
-                  class="CompassIcon icon-trash-can-outline DeleteIcon trash-can-outline"
-                />
-              </button>
-              <button
-                aria-label="Edit"
-                title="Edit"
-                type="button"
+                🚴🏻‍♂️
+              </span>
+              <span
+                class="template-name"
               >
-                <i
-                  class="CompassIcon icon-pencil-outline EditIcon"
-                />
-              </button>
+                Template Global
+              </span>
+            </div>
+            <div
+              class="BoardTemplateSelectorItem"
+            >
+              <span
+                class="template-icon"
+              >
+                🚴🏻‍♂️
+              </span>
+              <span
+                class="template-name"
+              >
+                Template 1
+              </span>
+              <div
+                class="actions"
+              >
+                <button
+                  aria-label="Delete"
+                  title="Delete"
+                  type="button"
+                >
+                  <i
+                    class="CompassIcon icon-trash-can-outline DeleteIcon trash-can-outline"
+                  />
+                </button>
+                <button
+                  aria-label="Edit"
+                  title="Edit"
+                  type="button"
+                >
+                  <i
+                    class="CompassIcon icon-pencil-outline EditIcon"
+                  />
+                </button>
+              </div>
+            </div>
+            <div
+              class="BoardTemplateSelectorItem"
+            >
+              <span
+                class="template-icon"
+              >
+                ❄️
+              </span>
+              <span
+                class="template-name"
+              >
+                Welcome to Boards!
+              </span>
             </div>
           </div>
           <div
-            class="BoardTemplateSelectorItem"
+            class="templates-sidebar__footer"
           >
-            <span
-              class="template-icon"
-            >
-              ❄️
-            </span>
-            <span
-              class="template-name"
-            >
-              Welcome to Boards!
-            </span>
-          </div>
-          <div
-            class="new-template"
-          >
-            <span
-              class="template-icon"
+            <button
+              type="button"
             >
               <i
-                class="CompassIcon icon-plus AddIcon"
+                class="CompassIcon icon-kanban"
               />
-            </span>
-            <span
-              class="template-name"
-            >
-              New template
-            </span>
+              <span>
+                Create empty board
+              </span>
+            </button>
           </div>
         </div>
         <div
-          class="templates-sidebar__footer"
+          class="template-preview-box"
         >
-          <button
-            class="templates__empty-board"
+          <div
+            class="BoardTemplateSelectorPreview"
+          />
+          <div
+            class="buttons"
           >
-            <i
-              class="CompassIcon icon-kanban"
-            />
-            Create empty board
-          </button>
-        </div>
-      </div>
-      <div
-        class="template-preview-box"
-      >
-        <div
-          class="BoardTemplateSelectorPreview"
-        />
-        <div
-          class="buttons"
-        >
-          <button
-            type="button"
-          >
-            <span>
-              Use this template
-            </span>
-          </button>
+            <button
+              type="button"
+            >
+              <span>
+                Use this template
+              </span>
+            </button>
+          </div>
         </div>
       </div>
     </div>

--- a/webapp/src/components/boardTemplateSelector/__snapshots__/boardTemplateSelector.test.tsx.snap
+++ b/webapp/src/components/boardTemplateSelector/__snapshots__/boardTemplateSelector.test.tsx.snap
@@ -36,87 +36,102 @@ exports[`components/boardTemplateSelector/boardTemplateSelector a focalboard Plu
       class="templates"
     >
       <div
-        class="templates-list"
+        class="templates-sidebar"
       >
         <div
-          class="BoardTemplateSelectorItem active"
+          class="templates-list"
         >
-          <span
-            class="template-icon"
-          >
-            🚴🏻‍♂️
-          </span>
-          <span
-            class="template-name"
-          >
-            Template Global
-          </span>
-        </div>
-        <div
-          class="BoardTemplateSelectorItem"
-        >
-          <span
-            class="template-icon"
-          >
-            🚴🏻‍♂️
-          </span>
-          <span
-            class="template-name"
-          >
-            Template 1
-          </span>
           <div
-            class="actions"
+            class="BoardTemplateSelectorItem active"
           >
-            <button
-              aria-label="Delete"
-              title="Delete"
-              type="button"
+            <span
+              class="template-icon"
+            >
+              🚴🏻‍♂️
+            </span>
+            <span
+              class="template-name"
+            >
+              Template Global
+            </span>
+          </div>
+          <div
+            class="BoardTemplateSelectorItem"
+          >
+            <span
+              class="template-icon"
+            >
+              🚴🏻‍♂️
+            </span>
+            <span
+              class="template-name"
+            >
+              Template 1
+            </span>
+            <div
+              class="actions"
+            >
+              <button
+                aria-label="Delete"
+                title="Delete"
+                type="button"
+              >
+                <i
+                  class="CompassIcon icon-trash-can-outline DeleteIcon trash-can-outline"
+                />
+              </button>
+              <button
+                aria-label="Edit"
+                title="Edit"
+                type="button"
+              >
+                <i
+                  class="CompassIcon icon-pencil-outline EditIcon"
+                />
+              </button>
+            </div>
+          </div>
+          <div
+            class="BoardTemplateSelectorItem"
+          >
+            <span
+              class="template-icon"
+            >
+              ❄️
+            </span>
+            <span
+              class="template-name"
+            >
+              Welcome to Boards!
+            </span>
+          </div>
+          <div
+            class="new-template"
+          >
+            <span
+              class="template-icon"
             >
               <i
-                class="CompassIcon icon-trash-can-outline DeleteIcon trash-can-outline"
+                class="CompassIcon icon-plus AddIcon"
               />
-            </button>
-            <button
-              aria-label="Edit"
-              title="Edit"
-              type="button"
+            </span>
+            <span
+              class="template-name"
             >
-              <i
-                class="CompassIcon icon-pencil-outline EditIcon"
-              />
-            </button>
+              New template
+            </span>
           </div>
         </div>
         <div
-          class="BoardTemplateSelectorItem"
+          class="templates-sidebar__footer"
         >
-          <span
-            class="template-icon"
+          <button
+            type="button"
           >
-            ❄️
-          </span>
-          <span
-            class="template-name"
-          >
-            Welcome to Boards!
-          </span>
-        </div>
-        <div
-          class="new-template"
-        >
-          <span
-            class="template-icon"
-          >
-            <i
-              class="CompassIcon icon-plus AddIcon"
-            />
-          </span>
-          <span
-            class="template-name"
-          >
-            New template
-          </span>
+            <span>
+              Create empty board
+            </span>
+          </button>
         </div>
       </div>
       <div
@@ -133,13 +148,6 @@ exports[`components/boardTemplateSelector/boardTemplateSelector a focalboard Plu
           >
             <span>
               Use this template
-            </span>
-          </button>
-          <button
-            type="button"
-          >
-            <span>
-              Create empty board
             </span>
           </button>
         </div>
@@ -175,87 +183,102 @@ exports[`components/boardTemplateSelector/boardTemplateSelector a focalboard Plu
       class="templates"
     >
       <div
-        class="templates-list"
+        class="templates-sidebar"
       >
         <div
-          class="BoardTemplateSelectorItem active"
+          class="templates-list"
         >
-          <span
-            class="template-icon"
-          >
-            🚴🏻‍♂️
-          </span>
-          <span
-            class="template-name"
-          >
-            Template Global
-          </span>
-        </div>
-        <div
-          class="BoardTemplateSelectorItem"
-        >
-          <span
-            class="template-icon"
-          >
-            🚴🏻‍♂️
-          </span>
-          <span
-            class="template-name"
-          >
-            Template 1
-          </span>
           <div
-            class="actions"
+            class="BoardTemplateSelectorItem active"
           >
-            <button
-              aria-label="Delete"
-              title="Delete"
-              type="button"
+            <span
+              class="template-icon"
+            >
+              🚴🏻‍♂️
+            </span>
+            <span
+              class="template-name"
+            >
+              Template Global
+            </span>
+          </div>
+          <div
+            class="BoardTemplateSelectorItem"
+          >
+            <span
+              class="template-icon"
+            >
+              🚴🏻‍♂️
+            </span>
+            <span
+              class="template-name"
+            >
+              Template 1
+            </span>
+            <div
+              class="actions"
+            >
+              <button
+                aria-label="Delete"
+                title="Delete"
+                type="button"
+              >
+                <i
+                  class="CompassIcon icon-trash-can-outline DeleteIcon trash-can-outline"
+                />
+              </button>
+              <button
+                aria-label="Edit"
+                title="Edit"
+                type="button"
+              >
+                <i
+                  class="CompassIcon icon-pencil-outline EditIcon"
+                />
+              </button>
+            </div>
+          </div>
+          <div
+            class="BoardTemplateSelectorItem"
+          >
+            <span
+              class="template-icon"
+            >
+              ❄️
+            </span>
+            <span
+              class="template-name"
+            >
+              Welcome to Boards!
+            </span>
+          </div>
+          <div
+            class="new-template"
+          >
+            <span
+              class="template-icon"
             >
               <i
-                class="CompassIcon icon-trash-can-outline DeleteIcon trash-can-outline"
+                class="CompassIcon icon-plus AddIcon"
               />
-            </button>
-            <button
-              aria-label="Edit"
-              title="Edit"
-              type="button"
+            </span>
+            <span
+              class="template-name"
             >
-              <i
-                class="CompassIcon icon-pencil-outline EditIcon"
-              />
-            </button>
+              New template
+            </span>
           </div>
         </div>
         <div
-          class="BoardTemplateSelectorItem"
+          class="templates-sidebar__footer"
         >
-          <span
-            class="template-icon"
+          <button
+            type="button"
           >
-            ❄️
-          </span>
-          <span
-            class="template-name"
-          >
-            Welcome to Boards!
-          </span>
-        </div>
-        <div
-          class="new-template"
-        >
-          <span
-            class="template-icon"
-          >
-            <i
-              class="CompassIcon icon-plus AddIcon"
-            />
-          </span>
-          <span
-            class="template-name"
-          >
-            New template
-          </span>
+            <span>
+              Create empty board
+            </span>
+          </button>
         </div>
       </div>
       <div
@@ -272,13 +295,6 @@ exports[`components/boardTemplateSelector/boardTemplateSelector a focalboard Plu
           >
             <span>
               Use this template
-            </span>
-          </button>
-          <button
-            type="button"
-          >
-            <span>
-              Create empty board
             </span>
           </button>
         </div>
@@ -314,87 +330,102 @@ exports[`components/boardTemplateSelector/boardTemplateSelector a focalboard Plu
       class="templates"
     >
       <div
-        class="templates-list"
+        class="templates-sidebar"
       >
         <div
-          class="BoardTemplateSelectorItem active"
+          class="templates-list"
         >
-          <span
-            class="template-icon"
-          >
-            🚴🏻‍♂️
-          </span>
-          <span
-            class="template-name"
-          >
-            Template Global
-          </span>
-        </div>
-        <div
-          class="BoardTemplateSelectorItem"
-        >
-          <span
-            class="template-icon"
-          >
-            🚴🏻‍♂️
-          </span>
-          <span
-            class="template-name"
-          >
-            Template 1
-          </span>
           <div
-            class="actions"
+            class="BoardTemplateSelectorItem active"
           >
-            <button
-              aria-label="Delete"
-              title="Delete"
-              type="button"
+            <span
+              class="template-icon"
+            >
+              🚴🏻‍♂️
+            </span>
+            <span
+              class="template-name"
+            >
+              Template Global
+            </span>
+          </div>
+          <div
+            class="BoardTemplateSelectorItem"
+          >
+            <span
+              class="template-icon"
+            >
+              🚴🏻‍♂️
+            </span>
+            <span
+              class="template-name"
+            >
+              Template 1
+            </span>
+            <div
+              class="actions"
+            >
+              <button
+                aria-label="Delete"
+                title="Delete"
+                type="button"
+              >
+                <i
+                  class="CompassIcon icon-trash-can-outline DeleteIcon trash-can-outline"
+                />
+              </button>
+              <button
+                aria-label="Edit"
+                title="Edit"
+                type="button"
+              >
+                <i
+                  class="CompassIcon icon-pencil-outline EditIcon"
+                />
+              </button>
+            </div>
+          </div>
+          <div
+            class="BoardTemplateSelectorItem"
+          >
+            <span
+              class="template-icon"
+            >
+              ❄️
+            </span>
+            <span
+              class="template-name"
+            >
+              Welcome to Boards!
+            </span>
+          </div>
+          <div
+            class="new-template"
+          >
+            <span
+              class="template-icon"
             >
               <i
-                class="CompassIcon icon-trash-can-outline DeleteIcon trash-can-outline"
+                class="CompassIcon icon-plus AddIcon"
               />
-            </button>
-            <button
-              aria-label="Edit"
-              title="Edit"
-              type="button"
+            </span>
+            <span
+              class="template-name"
             >
-              <i
-                class="CompassIcon icon-pencil-outline EditIcon"
-              />
-            </button>
+              New template
+            </span>
           </div>
         </div>
         <div
-          class="BoardTemplateSelectorItem"
+          class="templates-sidebar__footer"
         >
-          <span
-            class="template-icon"
+          <button
+            type="button"
           >
-            ❄️
-          </span>
-          <span
-            class="template-name"
-          >
-            Welcome to Boards!
-          </span>
-        </div>
-        <div
-          class="new-template"
-        >
-          <span
-            class="template-icon"
-          >
-            <i
-              class="CompassIcon icon-plus AddIcon"
-            />
-          </span>
-          <span
-            class="template-name"
-          >
-            New template
-          </span>
+            <span>
+              Create empty board
+            </span>
+          </button>
         </div>
       </div>
       <div
@@ -411,13 +442,6 @@ exports[`components/boardTemplateSelector/boardTemplateSelector a focalboard Plu
           >
             <span>
               Use this template
-            </span>
-          </button>
-          <button
-            type="button"
-          >
-            <span>
-              Create empty board
             </span>
           </button>
         </div>
@@ -463,87 +487,102 @@ exports[`components/boardTemplateSelector/boardTemplateSelector not a focalboard
       class="templates"
     >
       <div
-        class="templates-list"
+        class="templates-sidebar"
       >
         <div
-          class="BoardTemplateSelectorItem active"
+          class="templates-list"
         >
-          <span
-            class="template-icon"
-          >
-            🚴🏻‍♂️
-          </span>
-          <span
-            class="template-name"
-          >
-            Template Global
-          </span>
-        </div>
-        <div
-          class="BoardTemplateSelectorItem"
-        >
-          <span
-            class="template-icon"
-          >
-            🚴🏻‍♂️
-          </span>
-          <span
-            class="template-name"
-          >
-            Template 1
-          </span>
           <div
-            class="actions"
+            class="BoardTemplateSelectorItem active"
           >
-            <button
-              aria-label="Delete"
-              title="Delete"
-              type="button"
+            <span
+              class="template-icon"
+            >
+              🚴🏻‍♂️
+            </span>
+            <span
+              class="template-name"
+            >
+              Template Global
+            </span>
+          </div>
+          <div
+            class="BoardTemplateSelectorItem"
+          >
+            <span
+              class="template-icon"
+            >
+              🚴🏻‍♂️
+            </span>
+            <span
+              class="template-name"
+            >
+              Template 1
+            </span>
+            <div
+              class="actions"
+            >
+              <button
+                aria-label="Delete"
+                title="Delete"
+                type="button"
+              >
+                <i
+                  class="CompassIcon icon-trash-can-outline DeleteIcon trash-can-outline"
+                />
+              </button>
+              <button
+                aria-label="Edit"
+                title="Edit"
+                type="button"
+              >
+                <i
+                  class="CompassIcon icon-pencil-outline EditIcon"
+                />
+              </button>
+            </div>
+          </div>
+          <div
+            class="BoardTemplateSelectorItem"
+          >
+            <span
+              class="template-icon"
+            >
+              ❄️
+            </span>
+            <span
+              class="template-name"
+            >
+              Welcome to Boards!
+            </span>
+          </div>
+          <div
+            class="new-template"
+          >
+            <span
+              class="template-icon"
             >
               <i
-                class="CompassIcon icon-trash-can-outline DeleteIcon trash-can-outline"
+                class="CompassIcon icon-plus AddIcon"
               />
-            </button>
-            <button
-              aria-label="Edit"
-              title="Edit"
-              type="button"
+            </span>
+            <span
+              class="template-name"
             >
-              <i
-                class="CompassIcon icon-pencil-outline EditIcon"
-              />
-            </button>
+              New template
+            </span>
           </div>
         </div>
         <div
-          class="BoardTemplateSelectorItem"
+          class="templates-sidebar__footer"
         >
-          <span
-            class="template-icon"
+          <button
+            type="button"
           >
-            ❄️
-          </span>
-          <span
-            class="template-name"
-          >
-            Welcome to Boards!
-          </span>
-        </div>
-        <div
-          class="new-template"
-        >
-          <span
-            class="template-icon"
-          >
-            <i
-              class="CompassIcon icon-plus AddIcon"
-            />
-          </span>
-          <span
-            class="template-name"
-          >
-            New template
-          </span>
+            <span>
+              Create empty board
+            </span>
+          </button>
         </div>
       </div>
       <div
@@ -560,13 +599,6 @@ exports[`components/boardTemplateSelector/boardTemplateSelector not a focalboard
           >
             <span>
               Use this template
-            </span>
-          </button>
-          <button
-            type="button"
-          >
-            <span>
-              Create empty board
             </span>
           </button>
         </div>

--- a/webapp/src/components/boardTemplateSelector/boardTemplateSelector.scss
+++ b/webapp/src/components/boardTemplateSelector/boardTemplateSelector.scss
@@ -12,7 +12,7 @@
     align-items: center;
     justify-content: center;
 
-    @media (max-width: 1600px) {
+    @media (max-height: 1024px) {
         padding: 80px;
     }
 }
@@ -142,25 +142,31 @@
         }
     }
 
+    .templates-content {
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        height: 100%;
+        overflow: hidden;
+    }
+
+    .buttons {
+        display: flex;
+        padding: 24px;
+        justify-content: flex-end;
+        height: 89px;
+        border-top: 1px solid rgba(var(--center-channel-color-rgb), 0.16);
+        background-color: rgb(var(--center-channel-bg-rgb));
+    }
+
     .template-preview-box {
-        padding: 32px;
+        padding: 32px 32px 0;
         position: relative;
         background-color: rgb(var(--center-channel-bg-rgb));
-        overflow: hidden;
         width: 100%;
-
-        .buttons {
-            display: flex;
-            position: absolute;
-            left: 0;
-            bottom: 0;
-            width: 100%;
-            padding: 24px;
-            justify-content: flex-end;
-            height: 89px;
-            border-top: 1px solid rgba(var(--center-channel-color-rgb), 0.16);
-            background-color: rgb(var(--center-channel-bg-rgb));
-        }
+        flex: 1;
+        overflow: hidden;
+        overflow-y: auto;
 
         .empty-board {
             background-color: rgb(var(--center-channel-bg-rgb));

--- a/webapp/src/components/boardTemplateSelector/boardTemplateSelector.scss
+++ b/webapp/src/components/boardTemplateSelector/boardTemplateSelector.scss
@@ -105,7 +105,7 @@
             position: absolute;
             right: 0;
             top: 0;
-            padding: 32px;
+            padding: 32px 16px 0;
             background-color: rgb(var(--center-channel-bg-rgb));
         }
 

--- a/webapp/src/components/boardTemplateSelector/boardTemplateSelector.scss
+++ b/webapp/src/components/boardTemplateSelector/boardTemplateSelector.scss
@@ -12,7 +12,7 @@
     align-items: center;
     justify-content: center;
 
-    @media (max-width: 1440px) {
+    @media (max-width: 1600px) {
         padding: 80px;
     }
 }

--- a/webapp/src/components/boardTemplateSelector/boardTemplateSelector.scss
+++ b/webapp/src/components/boardTemplateSelector/boardTemplateSelector.scss
@@ -12,7 +12,7 @@
     align-items: center;
     justify-content: center;
 
-    @media (max-height: 1024px) {
+    @media (max-height: 900) {
         padding: 80px;
     }
 }

--- a/webapp/src/components/boardTemplateSelector/boardTemplateSelector.scss
+++ b/webapp/src/components/boardTemplateSelector/boardTemplateSelector.scss
@@ -17,7 +17,7 @@
         display: flex;
         width: 100%;
         justify-content: flex-end;
-        padding: 24px;
+        padding: 24px 24px 0;
     }
 
     .header {
@@ -42,27 +42,44 @@
         margin-right: 32px;
         display: flex;
         flex-direction: column;
+        overflow: hidden;
     }
 
     .templates-sidebar__footer {
         padding: 16px;
         display: flex;
-
+        border-top: 1px solid rgba(var(--center-channel-color-rgb), 0.16);
 
         button {
             width: 100%;
         }
     }
 
+    .templates__empty-board {
+        color: rgb(var(--button-bg-rgb));
+        padding: 0;
+        border: 0;
+        display: flex;
+        align-items: center;
+        background: transparent;
+        font-weight: 600;
+        gap: 10px;
+
+        i {
+            font-size: 16px;
+        }
+    }
+
     .templates {
         display: flex;
         width: 100%;
-        padding: 0 32px;
+        padding: 2px 32px;
         justify-content: center;
         flex: 1;
+        overflow: hidden;
 
         @media (min-width: 768px) {
-            padding: 0 10%;
+            padding: 2px 10%;
         }
 
         .templates-list {
@@ -98,15 +115,26 @@
         border-radius: var(--modal-rad);
         overflow: hidden;
         width: 100%;
-        max-width: 1000px;
+        max-width: 1600px;
 
         .buttons {
             display: flex;
             position: absolute;
-            right: 0;
-            top: 0;
-            padding: 32px 16px 0;
-            background-color: rgb(var(--center-channel-bg-rgb));
+            left: 0;
+            bottom: 0;
+            width: 100%;
+            padding: 24px;
+            justify-content: center;
+
+            &::before {
+                content: '';
+                background: linear-gradient(rgba(var(--center-channel-bg-rgb), 0), rgb(var(--center-channel-bg-rgb)), rgb(var(--center-channel-bg-rgb)));
+                position: absolute;
+                top: -16px;
+                left: 0;
+                width: 100%;
+                height: calc(100% + 16px);
+            }
         }
 
         .empty-board {

--- a/webapp/src/components/boardTemplateSelector/boardTemplateSelector.scss
+++ b/webapp/src/components/boardTemplateSelector/boardTemplateSelector.scss
@@ -8,7 +8,6 @@
     width: 100%;
     height: 100%;
     padding: 120px;
-    background-color: rgba(0, 0, 0, 0.56);
     display: flex;
     align-items: center;
     justify-content: center;
@@ -16,6 +15,25 @@
     @media (max-width: 1440px) {
         padding: 80px;
     }
+}
+
+.BoardTemplateSelector__container--page {
+    position: absolute;
+    padding: 0;
+
+    .BoardTemplateSelector {
+        max-width: 100%;
+        max-height: 100%;
+    }
+}
+
+.BoardTemplateSelector__backdrop {
+    background-color: rgba(0, 0, 0, 0.56);
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
 }
 
 .BoardTemplateSelector {
@@ -130,7 +148,6 @@
         background-color: rgb(var(--center-channel-bg-rgb));
         overflow: hidden;
         width: 100%;
-        max-width: 1600px;
 
         .buttons {
             display: flex;

--- a/webapp/src/components/boardTemplateSelector/boardTemplateSelector.scss
+++ b/webapp/src/components/boardTemplateSelector/boardTemplateSelector.scss
@@ -9,7 +9,9 @@
     width: 100%;
     height: 100%;
     overflow: auto;
-    padding-bottom: 48px;
+    padding-bottom: 80px;
+    display: flex;
+    flex-direction: column;
 
     .toolbar {
         display: flex;
@@ -35,20 +37,36 @@
         }
     }
 
+    .templates-sidebar {
+        width: 300px;
+        margin-right: 32px;
+        display: flex;
+        flex-direction: column;
+    }
+
+    .templates-sidebar__footer {
+        padding: 16px;
+        display: flex;
+
+
+        button {
+            width: 100%;
+        }
+    }
+
     .templates {
         display: flex;
         width: 100%;
         padding: 0 32px;
         justify-content: center;
+        flex: 1;
 
         @media (min-width: 768px) {
             padding: 0 10%;
         }
 
         .templates-list {
-            margin-right: 32px;
-            width: 300px;
-            max-height: 500px;
+            flex: 1;
             overflow-y: auto;
 
             .new-template {
@@ -72,7 +90,7 @@
     }
 
     .template-preview-box {
-        padding-bottom: 32px;
+        padding: 32px;
         position: relative;
         background-color: rgb(var(--center-channel-bg-rgb));
         box-shadow: rgba(var(--center-channel-color-rgb), 0.1) 0 0 0 1px,
@@ -81,38 +99,18 @@
         overflow: hidden;
         width: 100%;
         max-width: 1000px;
-        height: 512px;
 
         .buttons {
             display: flex;
             position: absolute;
-            bottom: 32px;
-            width: 100%;
-            justify-content: center;
-            flex-direction: column;
-            padding: 0 24px;
-
-            @media (min-width: 1024px) {
-                flex-direction: row;
-            }
+            right: 0;
+            top: 0;
+            padding: 32px;
+            background-color: rgb(var(--center-channel-bg-rgb));
         }
 
         .empty-board {
             background-color: rgb(var(--center-channel-bg-rgb));
-        }
-
-        .Button {
-            &:first-child {
-                margin-bottom: 16px;
-
-                @media (min-width: 1024px) {
-                    margin: 0 16px 0 0;
-                }
-            }
-
-            > .buttons:first-child {
-                padding-top: 32px;
-            }
         }
     }
 }

--- a/webapp/src/components/boardTemplateSelector/boardTemplateSelector.scss
+++ b/webapp/src/components/boardTemplateSelector/boardTemplateSelector.scss
@@ -13,7 +13,7 @@
     align-items: center;
     justify-content: center;
 
-    @media (max-width: 1280px) {
+    @media (max-width: 1440px) {
         padding: 80px;
     }
 }
@@ -142,6 +142,7 @@
             justify-content: flex-end;
             height: 89px;
             border-top: 1px solid rgba(var(--center-channel-color-rgb), 0.16);
+            background-color: rgb(var(--center-channel-bg-rgb));
         }
 
         .empty-board {

--- a/webapp/src/components/boardTemplateSelector/boardTemplateSelector.scss
+++ b/webapp/src/components/boardTemplateSelector/boardTemplateSelector.scss
@@ -1,54 +1,87 @@
 @import '../../styles/z-index';
 
+.BoardTemplateSelector__container {
+    @include z-index(modal-permissions-label);
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    padding: 120px;
+    background-color: rgba(0, 0, 0, 0.56);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    @media (max-width: 1280px) {
+        padding: 80px;
+    }
+}
+
 .BoardTemplateSelector {
     @include z-index(board-template-selector);
-    position: absolute;
+    position: relative;
     background-color: rgb(var(--center-channel-bg-rgb));
+    border: 1px solid rgba(var(--center-channel-color-rgb), 0.16);
     top: 0;
     left: 0;
     width: 100%;
     height: 100%;
     overflow: auto;
-    padding-bottom: 80px;
     display: flex;
     flex-direction: column;
+    border-radius: 12px;
+    max-width: 1600px;
+    max-height: 1200px;
 
     .toolbar {
         display: flex;
-        width: 100%;
         justify-content: flex-end;
-        padding: 24px 24px 0;
+        padding: 20px;
+        position: absolute;
+        right: 0;
+        top: 0;
     }
 
     .header {
         width: 100%;
+        height: 80px;
         display: flex;
         align-items: center;
-        flex-direction: column;
+        justify-content: flex-start;
+        padding: 32px;
+        border-bottom: 1px solid rgba(var(--center-channel-color-rgb), 0.16);
 
         .title {
-            font-size: 25px;
+            font-size: 22px;
+            margin: 0;
         }
 
         .description {
             max-width: 640px;
             text-align: center;
-            margin: 0 0 32px;
+            color: rgba(var(--center-channel-color-rgb), 0.56);
+            border-left: 1px solid rgba(var(--center-channel-color-rgb), 0.08);
+            padding-left: 8px;
+            margin: 0 0 0 8px;
         }
     }
 
     .templates-sidebar {
-        width: 300px;
-        margin-right: 32px;
+        flex: 0 0 294px;
         display: flex;
         flex-direction: column;
         overflow: hidden;
+        background-color: rgba(var(--center-channel-color-rgb), 0.04);
+        border-right: 1px solid rgba(var(--center-channel-color-rgb), 0.08);
     }
 
     .templates-sidebar__footer {
-        padding: 16px;
         display: flex;
+        align-items: center;
         border-top: 1px solid rgba(var(--center-channel-color-rgb), 0.16);
+        padding: 24px;
+        height: 89px;
 
         button {
             width: 100%;
@@ -73,35 +106,20 @@
     .templates {
         display: flex;
         width: 100%;
-        padding: 2px 32px;
         justify-content: center;
         flex: 1;
         overflow: hidden;
 
-        @media (min-width: 768px) {
-            padding: 2px 10%;
-        }
-
         .templates-list {
             flex: 1;
             overflow-y: auto;
+            padding: 16px;
 
             .new-template {
-                position: relative;
-                display: flex;
-                align-items: center;
-                padding: 8px 16px;
-                margin-bottom: 4px;
-                border-radius: var(--default-rad);
-                cursor: pointer;
-
-                .template-icon {
-                    margin-right: 10px;
-                }
-
-                &:hover {
-                    background-color: rgba(var(--center-channel-color-rgb), 0.1);
-                }
+                width: 100%;
+                justify-content: flex-start;
+                padding-left: 14px;
+                margin-bottom: 16px;
             }
         }
     }
@@ -110,9 +128,6 @@
         padding: 32px;
         position: relative;
         background-color: rgb(var(--center-channel-bg-rgb));
-        box-shadow: rgba(var(--center-channel-color-rgb), 0.1) 0 0 0 1px,
-            rgba(var(--center-channel-color-rgb), 0.1) 0 2px 4px;
-        border-radius: var(--modal-rad);
         overflow: hidden;
         width: 100%;
         max-width: 1600px;
@@ -124,17 +139,9 @@
             bottom: 0;
             width: 100%;
             padding: 24px;
-            justify-content: center;
-
-            &::before {
-                content: '';
-                background: linear-gradient(rgba(var(--center-channel-bg-rgb), 0), rgb(var(--center-channel-bg-rgb)), rgb(var(--center-channel-bg-rgb)));
-                position: absolute;
-                top: -16px;
-                left: 0;
-                width: 100%;
-                height: calc(100% + 16px);
-            }
+            justify-content: flex-end;
+            height: 89px;
+            border-top: 1px solid rgba(var(--center-channel-color-rgb), 0.16);
         }
 
         .empty-board {

--- a/webapp/src/components/boardTemplateSelector/boardTemplateSelector.test.tsx
+++ b/webapp/src/components/boardTemplateSelector/boardTemplateSelector.test.tsx
@@ -221,13 +221,13 @@ describe('components/boardTemplateSelector/boardTemplateSelector', () => {
             expect(onClose).toBeCalledTimes(1)
         })
         test('return BoardTemplateSelector and click new template', () => {
-            const {container} = render(wrapDNDIntl(
+            render(wrapDNDIntl(
                 <ReduxProvider store={store}>
                     <BoardTemplateSelector onClose={jest.fn()}/>
                 </ReduxProvider>
                 ,
             ), {wrapper: MemoryRouter})
-            const divNewTemplate = container.querySelector('div.new-template')
+            const divNewTemplate = screen.getByText('Create new template').parentElement
             expect(divNewTemplate).not.toBeNull()
             userEvent.click(divNewTemplate!)
             expect(mockedMutator.addEmptyBoardTemplate).toBeCalledTimes(1)

--- a/webapp/src/components/boardTemplateSelector/boardTemplateSelector.tsx
+++ b/webapp/src/components/boardTemplateSelector/boardTemplateSelector.tsx
@@ -4,6 +4,8 @@ import React, {useEffect, useState, useCallback, useMemo} from 'react'
 import {FormattedMessage, useIntl} from 'react-intl'
 import {useHistory, useRouteMatch} from 'react-router-dom'
 
+import CompassIcon from '../../widgets/icons/compassIcon'
+
 import {Board} from '../../blocks/board'
 import IconButton from '../../widgets/buttons/iconButton'
 import CloseIcon from '../../widgets/icons/close'
@@ -180,21 +182,20 @@ const BoardTemplateSelector = (props: Props) => {
                         </div>
                     </div>
                     <div className='templates-sidebar__footer'>
-                        <Button
-                            className='empty-board'
-                            emphasis={'secondary'}
-                            size={'medium'}
+                        <button
+                            className='templates__empty-board'
                             onClick={async () => {
                                 const boardsAndBlocks = await mutator.addEmptyBoard(currentTeam?.id || '', intl, showBoard, () => showBoard(currentBoardId))
                                 const board = boardsAndBlocks.boards[0]
                                 await mutator.updateBoard({...board, channelId: props.channelId || ''}, board, 'linked channel')
                             }}
                         >
+                            <CompassIcon icon='kanban'/>
                             <FormattedMessage
                                 id='BoardTemplateSelector.create-empty-board'
                                 defaultMessage='Create empty board'
                             />
-                        </Button>
+                        </button>
                     </div>
                 </div>
                 <div className='template-preview-box'>

--- a/webapp/src/components/boardTemplateSelector/boardTemplateSelector.tsx
+++ b/webapp/src/components/boardTemplateSelector/boardTemplateSelector.tsx
@@ -126,91 +126,93 @@ const BoardTemplateSelector = (props: Props) => {
     }
 
     return (
-        <div className='BoardTemplateSelector'>
-            <div className='toolbar'>
-                {onClose &&
-                    <IconButton
-                        size='medium'
-                        onClick={onClose}
-                        icon={<CloseIcon/>}
-                        title={'Close'}
-                    />}
-            </div>
-            <div className='header'>
-                <h1 className='title'>
-                    {title || (
-                        <FormattedMessage
-                            id='BoardTemplateSelector.title'
-                            defaultMessage='Create a board'
-                        />
-                    )}
-                </h1>
-                <p className='description'>
-                    {description || (
-                        <FormattedMessage
-                            id='BoardTemplateSelector.description'
-                            defaultMessage='Add a board to the sidebar using any of the templates defined below or start from scratch.'
-                        />
-                    )}
-                </p>
-            </div>
-
-            <div className='templates'>
-                <div className='templates-sidebar'>
-                    <div className='templates-list'>
-                        {allTemplates.map((boardTemplate) => (
-                            <BoardTemplateSelectorItem
-                                key={boardTemplate.id}
-                                isActive={activeTemplate?.id === boardTemplate.id}
-                                template={boardTemplate}
-                                onSelect={setActiveTemplate}
-                                onDelete={onBoardTemplateDelete}
-                                onEdit={showBoard}
+        <div className='BoardTemplateSelector__container'>
+            <div className='BoardTemplateSelector'>
+                <div className='toolbar'>
+                    {onClose &&
+                        <IconButton
+                            size='medium'
+                            onClick={onClose}
+                            icon={<CloseIcon/>}
+                            title={'Close'}
+                        />}
+                </div>
+                <div className='header'>
+                    <h1 className='title'>
+                        {title || (
+                            <FormattedMessage
+                                id='BoardTemplateSelector.title'
+                                defaultMessage='Create a board'
                             />
-                        ))}
-                        <div
-                            className='new-template'
-                            onClick={() => mutator.addEmptyBoardTemplate(currentTeam?.id || '', intl, showBoard, () => showBoard(currentBoardId))}
-                        >
-                            <span className='template-icon'><AddIcon/></span>
-                            <span className='template-name'>
+                        )}
+                    </h1>
+                    <p className='description'>
+                        {description || (
+                            <FormattedMessage
+                                id='BoardTemplateSelector.description'
+                                defaultMessage='Add a board to the sidebar using any of the templates defined below or start from scratch.'
+                            />
+                        )}
+                    </p>
+                </div>
+                <div className='templates'>
+                    <div className='templates-sidebar'>
+                        <div className='templates-list'>
+                            <Button
+                                emphasis='link'
+                                size='medium'
+                                icon={<CompassIcon icon='plus'/>}
+                                className='new-template'
+                                onClick={() => mutator.addEmptyBoardTemplate(currentTeam?.id || '', intl, showBoard, () => showBoard(currentBoardId))}
+                            >
                                 <FormattedMessage
                                     id='BoardTemplateSelector.add-template'
-                                    defaultMessage='New template'
+                                    defaultMessage='Create new template'
                                 />
-                            </span>
+                            </Button>
+                            {allTemplates.map((boardTemplate) => (
+                                <BoardTemplateSelectorItem
+                                    key={boardTemplate.id}
+                                    isActive={activeTemplate?.id === boardTemplate.id}
+                                    template={boardTemplate}
+                                    onSelect={setActiveTemplate}
+                                    onDelete={onBoardTemplateDelete}
+                                    onEdit={showBoard}
+                                />
+                            ))}
+                        </div>
+                        <div className='templates-sidebar__footer'>
+                            <Button
+                                emphasis='secondary'
+                                size={'medium'}
+                                icon={<CompassIcon icon='kanban'/>}
+                                onClick={async () => {
+                                    const boardsAndBlocks = await mutator.addEmptyBoard(currentTeam?.id || '', intl, showBoard, () => showBoard(currentBoardId))
+                                    const board = boardsAndBlocks.boards[0]
+                                    await mutator.updateBoard({...board, channelId: props.channelId || ''}, board, 'linked channel')
+                                }}
+                            >
+                                <FormattedMessage
+                                    id='BoardTemplateSelector.create-empty-board'
+                                    defaultMessage='Create empty board'
+                                />
+                            </Button>
                         </div>
                     </div>
-                    <div className='templates-sidebar__footer'>
-                        <button
-                            className='templates__empty-board'
-                            onClick={async () => {
-                                const boardsAndBlocks = await mutator.addEmptyBoard(currentTeam?.id || '', intl, showBoard, () => showBoard(currentBoardId))
-                                const board = boardsAndBlocks.boards[0]
-                                await mutator.updateBoard({...board, channelId: props.channelId || ''}, board, 'linked channel')
-                            }}
-                        >
-                            <CompassIcon icon='kanban'/>
-                            <FormattedMessage
-                                id='BoardTemplateSelector.create-empty-board'
-                                defaultMessage='Create empty board'
-                            />
-                        </button>
-                    </div>
-                </div>
-                <div className='template-preview-box'>
-                    <BoardTemplateSelectorPreview activeTemplate={activeTemplate}/>
-                    <div className='buttons'>
-                        <Button
-                            filled={true}
-                            size={'medium'}
-                            onClick={handleUseTemplate}
-                        >
-                            <FormattedMessage
-                                id='BoardTemplateSelector.use-this-template'
-                                defaultMessage='Use this template'
-                            />
-                        </Button>
+                    <div className='template-preview-box'>
+                        <BoardTemplateSelectorPreview activeTemplate={activeTemplate}/>
+                        <div className='buttons'>
+                            <Button
+                                filled={true}
+                                size={'medium'}
+                                onClick={handleUseTemplate}
+                            >
+                                <FormattedMessage
+                                    id='BoardTemplateSelector.use-this-template'
+                                    defaultMessage='Use this template'
+                                />
+                            </Button>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/webapp/src/components/boardTemplateSelector/boardTemplateSelector.tsx
+++ b/webapp/src/components/boardTemplateSelector/boardTemplateSelector.tsx
@@ -3,13 +3,13 @@
 import React, {useEffect, useState, useCallback, useMemo} from 'react'
 import {FormattedMessage, useIntl} from 'react-intl'
 import {useHistory, useRouteMatch} from 'react-router-dom'
+import {useHotkeys} from 'react-hotkeys-hook'
 
 import CompassIcon from '../../widgets/icons/compassIcon'
 
 import {Board} from '../../blocks/board'
 import IconButton from '../../widgets/buttons/iconButton'
 import CloseIcon from '../../widgets/icons/close'
-import AddIcon from '../../widgets/icons/add'
 import Button from '../../widgets/buttons/button'
 import octoClient from '../../octoClient'
 import mutator from '../../mutator'
@@ -49,6 +49,8 @@ const BoardTemplateSelector = (props: Props) => {
     const history = useHistory()
     const match = useRouteMatch<{boardId: string, viewId?: string}>()
     const me = useAppSelector<IUser|null>(getMe)
+
+    useHotkeys('esc', () => props.onClose?.())
 
     const showBoard = useCallback(async (boardId) => {
         Utils.showBoard(boardId, match, history)
@@ -126,7 +128,12 @@ const BoardTemplateSelector = (props: Props) => {
     }
 
     return (
-        <div className='BoardTemplateSelector__container'>
+        <div className={`BoardTemplateSelector__container ${onClose ? '' : 'BoardTemplateSelector__container--page'}`}>
+            {onClose &&
+                <div
+                    onClick={onClose}
+                    className='BoardTemplateSelector__backdrop'
+                />}
             <div className='BoardTemplateSelector'>
                 <div className='toolbar'>
                     {onClose &&

--- a/webapp/src/components/boardTemplateSelector/boardTemplateSelector.tsx
+++ b/webapp/src/components/boardTemplateSelector/boardTemplateSelector.tsx
@@ -182,7 +182,7 @@ const BoardTemplateSelector = (props: Props) => {
                     <div className='templates-sidebar__footer'>
                         <Button
                             className='empty-board'
-                            emphasis={'tertiary'}
+                            emphasis={'secondary'}
                             size={'medium'}
                             onClick={async () => {
                                 const boardsAndBlocks = await mutator.addEmptyBoard(currentTeam?.id || '', intl, showBoard, () => showBoard(currentBoardId))

--- a/webapp/src/components/boardTemplateSelector/boardTemplateSelector.tsx
+++ b/webapp/src/components/boardTemplateSelector/boardTemplateSelector.tsx
@@ -154,28 +154,47 @@ const BoardTemplateSelector = (props: Props) => {
             </div>
 
             <div className='templates'>
-                <div className='templates-list'>
-                    {allTemplates.map((boardTemplate) => (
-                        <BoardTemplateSelectorItem
-                            key={boardTemplate.id}
-                            isActive={activeTemplate?.id === boardTemplate.id}
-                            template={boardTemplate}
-                            onSelect={setActiveTemplate}
-                            onDelete={onBoardTemplateDelete}
-                            onEdit={showBoard}
-                        />
-                    ))}
-                    <div
-                        className='new-template'
-                        onClick={() => mutator.addEmptyBoardTemplate(currentTeam?.id || '', intl, showBoard, () => showBoard(currentBoardId))}
-                    >
-                        <span className='template-icon'><AddIcon/></span>
-                        <span className='template-name'>
-                            <FormattedMessage
-                                id='BoardTemplateSelector.add-template'
-                                defaultMessage='New template'
+                <div className='templates-sidebar'>
+                    <div className='templates-list'>
+                        {allTemplates.map((boardTemplate) => (
+                            <BoardTemplateSelectorItem
+                                key={boardTemplate.id}
+                                isActive={activeTemplate?.id === boardTemplate.id}
+                                template={boardTemplate}
+                                onSelect={setActiveTemplate}
+                                onDelete={onBoardTemplateDelete}
+                                onEdit={showBoard}
                             />
-                        </span>
+                        ))}
+                        <div
+                            className='new-template'
+                            onClick={() => mutator.addEmptyBoardTemplate(currentTeam?.id || '', intl, showBoard, () => showBoard(currentBoardId))}
+                        >
+                            <span className='template-icon'><AddIcon/></span>
+                            <span className='template-name'>
+                                <FormattedMessage
+                                    id='BoardTemplateSelector.add-template'
+                                    defaultMessage='New template'
+                                />
+                            </span>
+                        </div>
+                    </div>
+                    <div className='templates-sidebar__footer'>
+                        <Button
+                            className='empty-board'
+                            emphasis={'tertiary'}
+                            size={'medium'}
+                            onClick={async () => {
+                                const boardsAndBlocks = await mutator.addEmptyBoard(currentTeam?.id || '', intl, showBoard, () => showBoard(currentBoardId))
+                                const board = boardsAndBlocks.boards[0]
+                                await mutator.updateBoard({...board, channelId: props.channelId || ''}, board, 'linked channel')
+                            }}
+                        >
+                            <FormattedMessage
+                                id='BoardTemplateSelector.create-empty-board'
+                                defaultMessage='Create empty board'
+                            />
+                        </Button>
                     </div>
                 </div>
                 <div className='template-preview-box'>
@@ -189,22 +208,6 @@ const BoardTemplateSelector = (props: Props) => {
                             <FormattedMessage
                                 id='BoardTemplateSelector.use-this-template'
                                 defaultMessage='Use this template'
-                            />
-                        </Button>
-                        <Button
-                            className='empty-board'
-                            filled={false}
-                            emphasis={'secondary'}
-                            size={'medium'}
-                            onClick={async () => {
-                                const boardsAndBlocks = await mutator.addEmptyBoard(currentTeam?.id || '', intl, showBoard, () => showBoard(currentBoardId))
-                                const board = boardsAndBlocks.boards[0]
-                                await mutator.updateBoard({...board, channelId: props.channelId || ''}, board, 'linked channel')
-                            }}
-                        >
-                            <FormattedMessage
-                                id='BoardTemplateSelector.create-empty-board'
-                                defaultMessage='Create empty board'
                             />
                         </Button>
                     </div>

--- a/webapp/src/components/boardTemplateSelector/boardTemplateSelector.tsx
+++ b/webapp/src/components/boardTemplateSelector/boardTemplateSelector.tsx
@@ -206,8 +206,10 @@ const BoardTemplateSelector = (props: Props) => {
                             </Button>
                         </div>
                     </div>
-                    <div className='template-preview-box'>
-                        <BoardTemplateSelectorPreview activeTemplate={activeTemplate}/>
+                    <div className='templates-content'>
+                        <div className='template-preview-box'>
+                            <BoardTemplateSelectorPreview activeTemplate={activeTemplate}/>
+                        </div>
                         <div className='buttons'>
                             <Button
                                 filled={true}

--- a/webapp/src/components/boardTemplateSelector/boardTemplateSelectorItem.scss
+++ b/webapp/src/components/boardTemplateSelector/boardTemplateSelectorItem.scss
@@ -23,7 +23,6 @@
 
         i {
             font-size: 16px;
-            margin: 0 -5px 0 -4px;
         }
     }
 

--- a/webapp/src/components/boardTemplateSelector/boardTemplateSelectorPreview.scss
+++ b/webapp/src/components/boardTemplateSelector/boardTemplateSelectorPreview.scss
@@ -1,7 +1,8 @@
 .BoardTemplateSelectorPreview {
     position: relative;
-    transform: scale(0.6) translateX(-30%) translateY(-30%);
-    width: 158%;
+    transform-origin: top left;
+    transform: scale(0.8);
+    width: 126%;
     height: 480px;
     border-radius: var(--modal-rad);
     pointer-events: none;

--- a/webapp/src/components/boardTemplateSelector/boardTemplateSelectorPreview.scss
+++ b/webapp/src/components/boardTemplateSelector/boardTemplateSelectorPreview.scss
@@ -7,6 +7,10 @@
     border-radius: var(--modal-rad);
     pointer-events: none;
 
+    .ButtonWithMenu {
+        display: none;
+    }
+
     .Kanban {
         overflow: hidden;
     }

--- a/webapp/src/components/kanban/kanbanCard.scss
+++ b/webapp/src/components/kanban/kanbanCard.scss
@@ -5,9 +5,8 @@
     flex-direction: column;
     align-items: flex-start;
     overflow-wrap: anywhere;
-
-    border-radius: 3px;
-    margin-bottom: 10px;
+    border-radius: 4px;
+    margin-bottom: 16px;
     padding: 12px 16px;
     box-shadow: rgba(var(--center-channel-color-rgb), 0.1) 0 0 0 1px,
         rgba(var(--center-channel-color-rgb), 0.1) 0 2px 4px;

--- a/webapp/src/widgets/buttons/button.scss
+++ b/webapp/src/widgets/buttons/button.scss
@@ -104,6 +104,10 @@
         }
     }
 
+    &.emphasis--link {
+        color: rgb(var(--button-bg-rgb));
+    }
+
     &.active {
         background: rgba(var(--button-bg-rgb), 0.08);
         color: rgb(var(--button-bg-rgb));


### PR DESCRIPTION
#### Summary
Updating board template picker ui to include the use template button in the header, and empty board button in the sidebar, so the buttons do not overlap the content.

Additionally, made the UI scalable on larger screen sizes so scroll on the sidebar can be avoided.

#### Screenshot
<img width="2008" alt="Screenshot 2022-11-16 at 12 17 28 AM" src="https://user-images.githubusercontent.com/11034289/202008146-9dbbe4bd-82a0-4a5e-abc0-a9fb06756abd.png">
<img width="2011" alt="Screenshot 2022-11-16 at 12 17 44 AM" src="https://user-images.githubusercontent.com/11034289/202008151-c3eeb64b-7776-408d-a7db-93425a3fd65e.png">

