### PR TITLE
Require build tag to include sqlite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ ifeq ($(BUILD_NUMBER),)
 	BUILD_DATE := n/a
 endif
 
-BUILD_TAGS += json1
+BUILD_TAGS += json1 sqlite3
 
 LDFLAGS += -X "github.com/mattermost/focalboard/server/model.BuildNumber=$(BUILD_NUMBER)"
 LDFLAGS += -X "github.com/mattermost/focalboard/server/model.BuildDate=$(BUILD_DATE)"

--- a/server/services/store/sqlstore/blocks.go
+++ b/server/services/store/sqlstore/blocks.go
@@ -10,7 +10,6 @@ import (
 	sq "github.com/Masterminds/squirrel"
 	_ "github.com/lib/pq" // postgres driver
 	"github.com/mattermost/focalboard/server/model"
-	_ "github.com/mattn/go-sqlite3" // sqlite driver
 
 	"github.com/mattermost/mattermost-server/v6/shared/mlog"
 )

--- a/server/services/store/sqlstore/data_retention.go
+++ b/server/services/store/sqlstore/data_retention.go
@@ -12,7 +12,6 @@ import (
 	sq "github.com/Masterminds/squirrel"
 	_ "github.com/lib/pq" // postgres driver
 	"github.com/mattermost/focalboard/server/model"
-	_ "github.com/mattn/go-sqlite3" // sqlite driver
 
 	"github.com/mattermost/mattermost-server/v6/shared/mlog"
 )

--- a/server/services/store/sqlstore/sqlite.go
+++ b/server/services/store/sqlstore/sqlite.go
@@ -1,0 +1,5 @@
+//go:build sqlite3
+
+package sqlstore
+
+import _ "github.com/mattn/go-sqlite3" // sqlite driver


### PR DESCRIPTION
#### Summary
This PR ensures that the `go-sqlite3` package is only included when the `sqlite3` build tag is specified.  This tag is automatically included for all Focalboard makefile targets, but not included when building in product mode from mm-server.

This fixes an issue with running mm-server on Ubuntu 18.04 which includes an older version of glibc (2.27) while `go-sqlite3` requires 2.28 or higher.  mm-server does not support sqlite thus there is no point including it as a dependency.

go.mod files are not impacted as they always include all packages as if all build tags are active.

See https://community.mattermost.com/private-core/pl/5z4etm5883n6ie88sas9jh1owr for discussion.

Tested with personal server (Linux & Windows). 

#### Ticket Link
fixes https://github.com/mattermost/focalboard/issues/4210