### PR TITLE
CSS fix for readonly user

### DIFF
--- a/webapp/src/components/table/tableRow.scss
+++ b/webapp/src/components/table/tableRow.scss
@@ -62,4 +62,9 @@
     .URLProperty:hover .Button_Copy {
         display: none;
     }
+
+    .octo-propertyvalue--readonly {
+        flex-wrap: nowrap;
+        overflow: hidden !important;
+    }
 }


### PR DESCRIPTION
#### Summary
This PR will fix the overflow and alignment of read-only users in the table view

#### Ticket Link
Fixes https://github.com/mattermost/focalboard/issues/4184