### PR TITLE
Updates boards registration as product to use name instead of ID

### DIFF
--- a/mattermost-plugin/product/api_adapter.go
+++ b/mattermost-plugin/product/api_adapter.go
@@ -165,11 +165,11 @@ func (a *serviceAPIAdapter) GetFileInfo(fileID string) (*mm_model.FileInfo, erro
 //
 
 func (a *serviceAPIAdapter) PublishWebSocketEvent(event string, payload map[string]interface{}, broadcast *mm_model.WebsocketBroadcast) {
-	a.api.clusterService.PublishWebSocketEvent(boardsProductID, event, payload, broadcast)
+	a.api.clusterService.PublishWebSocketEvent(boardsProductName, event, payload, broadcast)
 }
 
 func (a *serviceAPIAdapter) PublishPluginClusterEvent(ev mm_model.PluginClusterEvent, opts mm_model.PluginClusterEventSendOptions) error {
-	return a.api.clusterService.PublishPluginClusterEvent(boardsProductID, ev, opts)
+	return a.api.clusterService.PublishPluginClusterEvent(boardsProductName, ev, opts)
 }
 
 //
@@ -201,7 +201,7 @@ func (a *serviceAPIAdapter) GetLogger() mlog.LoggerIFace {
 //
 
 func (a *serviceAPIAdapter) KVSetWithOptions(key string, value []byte, options mm_model.PluginKVSetOptions) (bool, error) {
-	b, appErr := a.api.kvStoreService.SetPluginKeyWithOptions(boardsProductID, key, value, options)
+	b, appErr := a.api.kvStoreService.SetPluginKeyWithOptions(boardsProductName, key, value, options)
 	return b, normalizeAppErr(appErr)
 }
 

--- a/mattermost-plugin/webapp/src/index.tsx
+++ b/mattermost-plugin/webapp/src/index.tsx
@@ -201,7 +201,7 @@ export default class Plugin {
         let theme = mmStore.getState().entities.preferences.myPreferences.theme
         setMattermostTheme(theme)
 
-        const productID = process.env.TARGET_IS_PRODUCT ? 'com.mattermost.boards' : manifest.id
+        const productID = process.env.TARGET_IS_PRODUCT ? 'boards' : manifest.id
 
         // register websocket handlers
         this.registry?.registerWebSocketEventHandler(`custom_${productID}_${ACTION_UPDATE_BOARD}`, (e: any) => wsClient.updateHandler(e.data))


### PR DESCRIPTION
#### Summary
This PR uses the `boards` product name to register with the MPA and label WS messages instead of the ID to be consistent.

Related to https://github.com/mattermost/mattermost-server/pull/21737