### PR TITLE
Fixed bug where boards would move to category of a different team

### DIFF
--- a/server/app/boards_test.go
+++ b/server/app/boards_test.go
@@ -434,6 +434,7 @@ func TestBoardCategory(t *testing.T) {
 				Name: "Boards",
 			}, nil)
 			th.Store.EXPECT().GetMembersForUser("user_id").Return([]*model.BoardMember{}, nil)
+			th.Store.EXPECT().GetBoardsForUserAndTeam("user_id", "team_id", false).Return([]*model.Board{}, nil)
 			th.Store.EXPECT().AddUpdateCategoryBoard("user_id", map[string]string{
 				"board_id_1": "default_category_id",
 				"board_id_2": "default_category_id",

--- a/server/app/category_boards_test.go
+++ b/server/app/category_boards_test.go
@@ -21,6 +21,20 @@ func TestGetUserCategoryBoards(t *testing.T) {
 			Name: "Boards",
 		}, nil)
 
+		board1 := &model.Board{
+			ID: "board_id_1",
+		}
+
+		board2 := &model.Board{
+			ID: "board_id_2",
+		}
+
+		board3 := &model.Board{
+			ID: "board_id_3",
+		}
+
+		th.Store.EXPECT().GetBoardsForUserAndTeam("user_id", "team_id", false).Return([]*model.Board{board1, board2, board3}, nil)
+
 		th.Store.EXPECT().GetMembersForUser("user_id").Return([]*model.BoardMember{
 			{
 				BoardID:   "board_id_1",
@@ -58,6 +72,7 @@ func TestGetUserCategoryBoards(t *testing.T) {
 		}, nil)
 
 		th.Store.EXPECT().GetMembersForUser("user_id").Return([]*model.BoardMember{}, nil)
+		th.Store.EXPECT().GetBoardsForUserAndTeam("user_id", "team_id", false).Return([]*model.Board{}, nil)
 
 		categoryBoards, err := th.App.GetUserCategoryBoards("user_id", "team_id")
 		assert.NoError(t, err)
@@ -93,6 +108,7 @@ func TestCreateBoardsCategory(t *testing.T) {
 			Type: "system",
 			Name: "Boards",
 		}, nil)
+		th.Store.EXPECT().GetBoardsForUserAndTeam("user_id", "team_id", false).Return([]*model.Board{}, nil)
 		th.Store.EXPECT().GetMembersForUser("user_id").Return([]*model.BoardMember{}, nil)
 
 		existingCategoryBoards := []model.CategoryBoards{}
@@ -110,6 +126,7 @@ func TestCreateBoardsCategory(t *testing.T) {
 			Type: "system",
 			Name: "Boards",
 		}, nil)
+		th.Store.EXPECT().GetBoardsForUserAndTeam("user_id", "team_id", false).Return([]*model.Board{}, nil)
 		th.Store.EXPECT().GetMembersForUser("user_id").Return([]*model.BoardMember{
 			{
 				BoardID:   "board_id_1",
@@ -143,6 +160,17 @@ func TestCreateBoardsCategory(t *testing.T) {
 			Type: "system",
 			Name: "Boards",
 		}, nil)
+
+		board1 := &model.Board{
+			ID: "board_id_1",
+		}
+		board2 := &model.Board{
+			ID: "board_id_2",
+		}
+		board3 := &model.Board{
+			ID: "board_id_3",
+		}
+		th.Store.EXPECT().GetBoardsForUserAndTeam("user_id", "team_id", false).Return([]*model.Board{board1, board2, board3}, nil)
 		th.Store.EXPECT().GetMembersForUser("user_id").Return([]*model.BoardMember{
 			{
 				BoardID:   "board_id_1",
@@ -179,6 +207,11 @@ func TestCreateBoardsCategory(t *testing.T) {
 			Type: "system",
 			Name: "Boards",
 		}, nil)
+
+		board1 := &model.Board{
+			ID: "board_id_1",
+		}
+		th.Store.EXPECT().GetBoardsForUserAndTeam("user_id", "team_id", false).Return([]*model.Board{board1}, nil)
 		th.Store.EXPECT().GetMembersForUser("user_id").Return([]*model.BoardMember{
 			{
 				BoardID:   "board_id_1",

--- a/server/app/category_test.go
+++ b/server/app/category_test.go
@@ -375,6 +375,7 @@ func TestMoveBoardsToDefaultCategory(t *testing.T) {
 			Type: "system",
 		}, nil)
 		th.Store.EXPECT().GetMembersForUser("user_id").Return([]*model.BoardMember{}, nil)
+		th.Store.EXPECT().GetBoardsForUserAndTeam("user_id", "team_id", false).Return([]*model.Board{}, nil)
 		th.Store.EXPECT().AddUpdateCategoryBoard("user_id", utils.Anything).Return(nil)
 
 		err := th.App.moveBoardsToDefaultCategory("user_id", "team_id", "category_id_2")

--- a/server/app/import_test.go
+++ b/server/app/import_test.go
@@ -55,6 +55,7 @@ func TestApp_ImportArchive(t *testing.T) {
 			ID:   "boards_category_id",
 			Name: "Boards",
 		}, nil)
+		th.Store.EXPECT().GetBoardsForUserAndTeam("user", "test-team", false).Return([]*model.Board{}, nil)
 		th.Store.EXPECT().GetMembersForUser("user").Return([]*model.BoardMember{}, nil)
 		th.Store.EXPECT().AddUpdateCategoryBoard("user", utils.Anything).Return(nil)
 

--- a/server/app/onboarding_test.go
+++ b/server/app/onboarding_test.go
@@ -77,6 +77,7 @@ func TestPrepareOnboardingTour(t *testing.T) {
 			ID:   "boards_category",
 			Name: "Boards",
 		}, nil)
+		th.Store.EXPECT().GetBoardsForUserAndTeam("user_id_1", teamID, false).Return([]*model.Board{}, nil)
 		th.Store.EXPECT().AddUpdateCategoryBoard("user_id_1", map[string]string{"board_id_2": "boards_category_id"}).Return(nil)
 
 		teamID, boardID, err := th.App.PrepareOnboardingTour(userID, teamID)


### PR DESCRIPTION
Fixes #4283

## Explanation

In PR #4283 I was using the method `GetMembersForUser(<userID>)` to fetch the list of all boards for a user in a team. However, I missed the fact that that method is NOT scoped to a specific team, as you can see from its parameters.
What this caused was for all boards in all teams to be considered as candidate boards to be moved into the current team's default `Boards` category. This ended the system in a state where the board belongs to Team A but is associated with a category of Team B, so it didn't show up anywhere.

I've now fixed this by using the method `GetBoardsForUserAndTeam(<userID,> <teamID>, <includePublicBoards>` to gets user's boards for the current team.