### PR TITLE
Don't set cattegory for board template

### DIFF
--- a/server/app/boards.go
+++ b/server/app/boards.go
@@ -189,9 +189,11 @@ func (a *App) DuplicateBoard(boardID, userID, toTeam string, asTemplate bool) (*
 		a.logger.Error("Could not copy files while duplicating board", mlog.String("BoardID", boardID), mlog.Err(err))
 	}
 
-	for _, board := range bab.Boards {
-		if categoryErr := a.setBoardCategoryFromSource(boardID, board.ID, userID, toTeam, asTemplate); categoryErr != nil {
-			return nil, nil, categoryErr
+	if !asTemplate {
+		for _, board := range bab.Boards {
+			if categoryErr := a.setBoardCategoryFromSource(boardID, board.ID, userID, toTeam, asTemplate); categoryErr != nil {
+				return nil, nil, categoryErr
+			}
 		}
 	}
 

--- a/server/app/boards_test.go
+++ b/server/app/boards_test.go
@@ -503,4 +503,39 @@ func TestDuplicateBoard(t *testing.T) {
 		assert.NotNil(t, bab)
 		assert.NotNil(t, members)
 	})
+
+	t.Run("duplicating board as template should not set it's category", func(t *testing.T) {
+		board := &model.Board{
+			ID:    "board_id_2",
+			Title: "Duplicated Board",
+		}
+
+		block := &model.Block{
+			ID:   "block_id_1",
+			Type: "image",
+		}
+
+		th.Store.EXPECT().DuplicateBoard("board_id_1", "user_id_1", "team_id_1", true).Return(
+			&model.BoardsAndBlocks{
+				Boards: []*model.Board{
+					board,
+				},
+				Blocks: []*model.Block{
+					block,
+				},
+			},
+			[]*model.BoardMember{},
+			nil,
+		)
+
+		th.Store.EXPECT().GetBoard("board_id_1").Return(&model.Board{}, nil)
+
+		// for WS change broadcast
+		th.Store.EXPECT().GetMembersForBoard(utils.Anything).Return([]*model.BoardMember{}, nil).Times(2)
+
+		bab, members, err := th.App.DuplicateBoard("board_id_1", "user_id_1", "team_id_1", true)
+		assert.NoError(t, err)
+		assert.NotNil(t, bab)
+		assert.NotNil(t, members)
+	})
 }


### PR DESCRIPTION
#### Summary
When duplicating a board, whether from a template or not, we move the new board to the old board's category. When creating a template from a board, we were assigned a category to the template, which later was assigned to the board created from this template. Not assigning a category to the template stops the chain and causes the new board to be moved to the default category.

#### Ticket Link
Fixes #3938