### PR TITLE
Cherry-pick 4395:  services/store: use mattermost sql settings for migration connections…

### DIFF
--- a/mattermost-plugin/server/boards/boardsapp.go
+++ b/mattermost-plugin/server/boards/boardsapp.go
@@ -85,6 +85,7 @@ func NewBoardsApp(api model.ServicesAPI) (*BoardsApp, error) {
 			return cluster.NewMutex(&mutexAPIAdapter{api: api}, name)
 		},
 		ServicesAPI: api,
+		ConfigFn:    api.GetConfig,
 	}
 
 	var db store.Store

--- a/server/services/store/sqlstore/migrate.go
+++ b/server/services/store/sqlstore/migrate.go
@@ -13,6 +13,7 @@ import (
 
 	sq "github.com/Masterminds/squirrel"
 
+	mmModel "github.com/mattermost/mattermost-server/v6/model"
 	"github.com/mattermost/mattermost-server/v6/shared/mlog"
 	"github.com/mattermost/mattermost-server/v6/store/sqlstore"
 
@@ -59,14 +60,14 @@ func (s *SQLStore) getMigrationConnection() (*sql.DB, error) {
 		}
 	}
 
-	db, err := sql.Open(s.dbType, connectionString)
-	if err != nil {
-		return nil, err
+	var settings mmModel.SqlSettings
+	settings.SetDefaults(false)
+	if s.configFn != nil {
+		settings = s.configFn().SqlSettings
 	}
+	*settings.DriverName = s.dbType
 
-	if err = db.Ping(); err != nil {
-		return nil, err
-	}
+	db := sqlstore.SetupConnection("master", connectionString, &settings)
 
 	return db, nil
 }

--- a/server/services/store/sqlstore/params.go
+++ b/server/services/store/sqlstore/params.go
@@ -26,6 +26,7 @@ type Params struct {
 	NewMutexFn       MutexFactory
 	ServicesAPI      servicesAPI
 	SkipMigrations   bool
+	ConfigFn         func() *mmModel.Config
 }
 
 func (p Params) CheckValid() error {

--- a/server/services/store/sqlstore/sqlstore.go
+++ b/server/services/store/sqlstore/sqlstore.go
@@ -29,6 +29,7 @@ type SQLStore struct {
 	servicesAPI      servicesAPI
 	isBinaryParam    bool
 	schemaName       string
+	configFn         func() *mmModel.Config
 }
 
 // MutexFactory is used by the store in plugin mode to generate
@@ -53,6 +54,7 @@ func New(params Params) (*SQLStore, error) {
 		isSingleUser:     params.IsSingleUser,
 		NewMutexFn:       params.NewMutexFn,
 		servicesAPI:      params.ServicesAPI,
+		configFn:         params.ConfigFn,
 	}
 
 	var err error


### PR DESCRIPTION
#### Summary
Cherry-pick https://github.com/mattermost/focalboard/pull/4395 into rolling-stable as it is a breaking change.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-49352