### PR TITLE
Add DuplicateBoard to service API

### DIFF
--- a/mattermost-plugin/server/boards/boards_service_api.go
+++ b/mattermost-plugin/server/boards/boards_service_api.go
@@ -75,5 +75,9 @@ func (bs *boardsServiceAPI) HasPermissionToBoard(userID, boardID string, permiss
 	return bs.app.HasPermissionToBoard(userID, boardID, permission)
 }
 
+func (bs *boardsServiceAPI) DuplicateBoard(boardID string, userID string, toTeam string, asTemplate bool) (*model.BoardsAndBlocks, []*model.BoardMember, error) {
+	return bs.app.DuplicateBoard(boardID, userID, toTeam, asTemplate)
+}
+
 // Ensure boardsServiceAPI implements product.BoardsService interface.
 var _ product.BoardsService = (*boardsServiceAPI)(nil)

--- a/mattermost-plugin/server/boards/boards_service_api.go
+++ b/mattermost-plugin/server/boards/boards_service_api.go
@@ -75,7 +75,8 @@ func (bs *boardsServiceAPI) HasPermissionToBoard(userID, boardID string, permiss
 	return bs.app.HasPermissionToBoard(userID, boardID, permission)
 }
 
-func (bs *boardsServiceAPI) DuplicateBoard(boardID string, userID string, toTeam string, asTemplate bool) (*model.BoardsAndBlocks, []*model.BoardMember, error) {
+func (bs *boardsServiceAPI) DuplicateBoard(boardID string, userID string,
+	toTeam string, asTemplate bool) (*model.BoardsAndBlocks, []*model.BoardMember, error) {
 	return bs.app.DuplicateBoard(boardID, userID, toTeam, asTemplate)
 }
 


### PR DESCRIPTION
#### Summary
This PR adds `DuplicateBoard` to the Boards service API.

mm-server PR: 

#### Ticket Link
NONE