### PR TITLE
Update snapshots for date format

### DIFF
--- a/mattermost-plugin/webapp/src/components/__snapshots__/rhsChannelBoardItem.test.tsx.snap
+++ b/mattermost-plugin/webapp/src/components/__snapshots__/rhsChannelBoardItem.test.tsx.snap
@@ -35,7 +35,7 @@ exports[`components/rhsChannelBoardItem render board 1`] = `
     <div
       class="date"
     >
-      Last update at: July 08, 8:10 PM
+      Last update at: July 08, 2022, 8:10 PM
     </div>
   </div>
 </div>
@@ -168,7 +168,7 @@ exports[`components/rhsChannelBoardItem render board with menu open 1`] = `
     <div
       class="date"
     >
-      Last update at: July 08, 8:10 PM
+      Last update at: July 08, 2022, 8:10 PM
     </div>
   </div>
 </div>

--- a/mattermost-plugin/webapp/src/components/__snapshots__/rhsChannelBoards.test.tsx.snap
+++ b/mattermost-plugin/webapp/src/components/__snapshots__/rhsChannelBoards.test.tsx.snap
@@ -64,7 +64,7 @@ exports[`components/rhsChannelBoards renders the RHS for channel boards 1`] = `
           <div
             class="date"
           >
-            Last update at: July 08, 8:10 PM
+            Last update at: July 08, 2022, 8:10 PM
           </div>
         </div>
         <div
@@ -100,7 +100,7 @@ exports[`components/rhsChannelBoards renders the RHS for channel boards 1`] = `
           <div
             class="date"
           >
-            Last update at: July 08, 8:10 PM
+            Last update at: July 08, 2022, 8:10 PM
           </div>
         </div>
       </div>


### PR DESCRIPTION
#### Summary
Date format changed because these dates are now "last year", the years is now displayed.

Update snapshots to fix.
