### PR TITLE
Added support for multiperson property in notifications

### DIFF
--- a/server/model/properties.go
+++ b/server/model/properties.go
@@ -98,6 +98,32 @@ func (pd PropDef) GetValue(v interface{}, resolver PropValueResolver) (string, e
 		}
 		return userID, nil
 
+	case "multiPerson":
+		// v is a slice of user IDs
+		userIDs, ok := v.([]interface{})
+		if !ok {
+			return "", fmt.Errorf("multiPerson property type: %w", ErrInvalidPropertyValueType)
+		}
+		if resolver != nil {
+			usernames := make([]string, len(userIDs))
+
+			for i, userIDInterface := range userIDs {
+				userID := userIDInterface.(string)
+
+				user, err := resolver.GetUserByID(userID)
+				if err != nil {
+					return "", err
+				}
+				if user == nil {
+					usernames[i] = userID
+				} else {
+					usernames[i] = user.Username
+				}
+			}
+
+			return strings.Join(usernames, ", "), nil
+		}
+
 	case "multiSelect":
 		// v is a slice of strings containing option ids
 		ms, ok := v.([]interface{})


### PR DESCRIPTION
#### Summary
Basically, the server didn't have any support for multiperson property so it wasn't processing the user IDs. I've added support for the multiperson property type.

#### Ticket Link
Fixes #4424