### PR TITLE
MM-49637 Make chunk filenames generated for MPA unique

### DIFF
--- a/mattermost-plugin/webapp/webpack.config.js
+++ b/mattermost-plugin/webapp/webpack.config.js
@@ -172,6 +172,7 @@ if (TARGET_IS_PRODUCT) {
 
     config.output = {
         path: path.join(__dirname, '/dist'),
+        chunkFilename: '[name].[contenthash].js',
     };
 } else {
     config.resolve.alias['react-intl'] = path.resolve(__dirname, '../../webapp/node_modules/react-intl/');


### PR DESCRIPTION
This is fixes the caching issue that Christopher reported earlier and that some others have reported over the last while as well. Basically, the product version of Boards was generating chunks with non-unique file names causing some people to get weeks old versions of Boards on community. This was never a problem with the plugin version since, even though it just generates a consistently-named `bundle.js`, the MM server would give it a unique name instead.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-49637
