### PR TITLE
Change board serverRoot from '/plugins/focalboard' to '/boards'

### DIFF
--- a/mattermost-plugin/server/boards/boardsapp_util.go
+++ b/mattermost-plugin/server/boards/boardsapp_util.go
@@ -80,8 +80,12 @@ func createBoardsConfig(mmconfig mm_model.Config, baseURL string, serverID strin
 		showFullName = *mmconfig.PrivacySettings.ShowFullName
 	}
 
+	serverRoot := baseURL + "plugins/focalboard"
+	if mmconfig.FeatureFlags.BoardsProduct {
+		serverRoot = baseURL + "/boards"
+	}
 	return &config.Configuration{
-		ServerRoot:               baseURL + "/boards",
+		ServerRoot:               serverRoot,
 		Port:                     -1,
 		DBType:                   *mmconfig.SqlSettings.DriverName,
 		DBConfigString:           *mmconfig.SqlSettings.DataSource,

--- a/mattermost-plugin/server/boards/boardsapp_util.go
+++ b/mattermost-plugin/server/boards/boardsapp_util.go
@@ -81,7 +81,7 @@ func createBoardsConfig(mmconfig mm_model.Config, baseURL string, serverID strin
 	}
 
 	return &config.Configuration{
-		ServerRoot:               baseURL + "/plugins/focalboard",
+		ServerRoot:               baseURL + "/boards",
 		Port:                     -1,
 		DBType:                   *mmconfig.SqlSettings.DriverName,
 		DBConfigString:           *mmconfig.SqlSettings.DataSource,

--- a/mattermost-plugin/server/boards/boardsapp_util.go
+++ b/mattermost-plugin/server/boards/boardsapp_util.go
@@ -80,7 +80,7 @@ func createBoardsConfig(mmconfig mm_model.Config, baseURL string, serverID strin
 		showFullName = *mmconfig.PrivacySettings.ShowFullName
 	}
 
-	serverRoot := baseURL + "plugins/focalboard"
+	serverRoot := baseURL + "/plugins/focalboard"
 	if mmconfig.FeatureFlags.BoardsProduct {
 		serverRoot = baseURL + "/boards"
 	}


### PR DESCRIPTION
#### Summary
Changes the base URL for the server from '/plugins/focalboard' to '/boards'
This fixes the "Page not found" error in links when linking/unlinking a board. But does NOT fix the issue with Shared Boards.

#### Ticket Link
  Fixes https://github.com/mattermost/focalboard/issues/4441
