### PR TITLE
Update configuration to use 'ProductSettings.EnablePublicSharedBoards'

### DIFF
--- a/mattermost-plugin/server/boards/configuration.go
+++ b/mattermost-plugin/server/boards/configuration.go
@@ -80,6 +80,9 @@ func (b *BoardsApp) OnConfigurationChange() error {
 	if mmconfig.PluginSettings.Plugins[PluginName][SharedBoardsName] == true {
 		enableShareBoards = true
 	}
+	if mmconfig.ProductSettings.EnablePublicSharedBoards != nil {
+		enableShareBoards = *mmconfig.ProductSettings.EnablePublicSharedBoards
+	}
 	configuration := &configuration{
 		EnablePublicSharedBoards: enableShareBoards,
 	}


### PR DESCRIPTION
#### Summary
Check the ProductSettings.EnablePublicSharedBoards config setting.

Did not remove original check, so not feature flag check is needed.

#### Ticket Link

  Fixes #4481 
