### PR TITLE
Suppress error message on unfound option id

### DIFF
--- a/webapp/src/boardUtils.ts
+++ b/webapp/src/boardUtils.ts
@@ -1,6 +1,5 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
-import {Utils} from './utils'
 import {Card} from './blocks/card'
 import {IPropertyTemplate, IPropertyOption, BoardGroup} from './blocks/board'
 
@@ -17,7 +16,7 @@ function groupCardsByOptions(cards: Card[], optionIds: string[], groupByProperty
                 }
                 groups.push(group)
             } else {
-                Utils.logError(`groupCardsByOptions: Missing option with id: ${optionId}`)
+                // if optionId not found, its an old (deleted) option that can be ignored
             }
         } else {
             // Empty group


### PR DESCRIPTION
#### Summary
Several of our templates have been created with different options over time. That has resulted in some invalid date in the templates and missing option ids. Currently, we display an error when an option id isn't found. However, there is no action to take and this is a benign error, this PR removes the error.


#### Ticket Link

  Fixes https://github.com/mattermost/focalboard/issues/3846
