### PR TITLE
Fix panic when notifying of block change (getDirectChannel returning nil,nil)

### DIFF
--- a/server/services/notify/plugindelivery/subscription_deliver.go
+++ b/server/services/notify/plugindelivery/subscription_deliver.go
@@ -53,7 +53,7 @@ func (pd *PluginDelivery) getDirectChannelID(teamID string, subscriberID string,
 			return "", fmt.Errorf("cannot find user: %w", err)
 		}
 		channel, err := pd.getDirectChannel(teamID, user.Id, botID)
-		if err != nil {
+		if err != nil || channel == nil {
 			return "", fmt.Errorf("cannot get direct channel: %w", err)
 		}
 		return channel.Id, nil


### PR DESCRIPTION
#### Summary
This PR fixes a crashing bug in Boards notification system in MPA mode. When a notification is sent, it first gets or creates a channel between the Boards bot and the user to be notified. Previously this used the `GetDirectChannel` method in the plugin API. That method gets or creates the channel. The product API version of that call only gets the channel and will not create it if not found. To make matters worse, the `getDirectChannel` method in the mm-server app layer swallows the `NotFoundError` and returns `nil, nil`. The Boards code was not expecting a nil channel when there is no error since that that could not happen as a plugin.  

This is a quick fix to ensure mm-server does not crash.  A proper fix will be submitted that requires PRs for Boards and mm-server.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-49752