### PR TITLE
Use GetDirectChannelOrCreate when notifying block chg in MPA mode

### DIFF
--- a/mattermost-plugin/product/api_adapter.go
+++ b/mattermost-plugin/product/api_adapter.go
@@ -49,6 +49,11 @@ func (a *serviceAPIAdapter) GetDirectChannel(userID1, userID2 string) (*mm_model
 	return channel, normalizeAppErr(appErr)
 }
 
+func (a *serviceAPIAdapter) GetDirectChannelOrCreate(userID1, userID2 string) (*mm_model.Channel, error) {
+	channel, appErr := a.api.channelService.GetDirectChannelOrCreate(userID1, userID2)
+	return channel, normalizeAppErr(appErr)
+}
+
 func (a *serviceAPIAdapter) GetChannelByID(channelID string) (*mm_model.Channel, error) {
 	channel, appErr := a.api.channelService.GetChannelByID(channelID)
 	return channel, normalizeAppErr(appErr)

--- a/mattermost-plugin/server/api_adapter.go
+++ b/mattermost-plugin/server/api_adapter.go
@@ -54,6 +54,12 @@ func (a *pluginAPIAdapter) GetDirectChannel(userID1, userID2 string) (*mm_model.
 	return channel, normalizeAppErr(appErr)
 }
 
+func (a *pluginAPIAdapter) GetDirectChannelOrCreate(userID1, userID2 string) (*mm_model.Channel, error) {
+	// plugin API's GetDirectChannel will create channel if it does not exist.
+	channel, appErr := a.api.GetDirectChannel(userID1, userID2)
+	return channel, normalizeAppErr(appErr)
+}
+
 func (a *pluginAPIAdapter) GetChannelByID(channelID string) (*mm_model.Channel, error) {
 	channel, appErr := a.api.GetChannel(channelID)
 	return channel, normalizeAppErr(appErr)

--- a/mattermost-plugin/server/manifest.go
+++ b/mattermost-plugin/server/manifest.go
@@ -45,8 +45,7 @@ const manifestStr = `
         "type": "bool",
         "help_text": "This allows board editors to share boards that can be accessed by anyone with the link.",
         "placeholder": "",
-        "default": false,
-        "hosting": ""
+        "default": false
       }
     ]
   }

--- a/server/model/mocks/mockservicesapi.go
+++ b/server/model/mocks/mockservicesapi.go
@@ -199,6 +199,21 @@ func (mr *MockServicesAPIMockRecorder) GetDirectChannel(arg0, arg1 interface{}) 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDirectChannel", reflect.TypeOf((*MockServicesAPI)(nil).GetDirectChannel), arg0, arg1)
 }
 
+// GetDirectChannelOrCreate mocks base method.
+func (m *MockServicesAPI) GetDirectChannelOrCreate(arg0, arg1 string) (*model.Channel, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetDirectChannelOrCreate", arg0, arg1)
+	ret0, _ := ret[0].(*model.Channel)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetDirectChannelOrCreate indicates an expected call of GetDirectChannelOrCreate.
+func (mr *MockServicesAPIMockRecorder) GetDirectChannelOrCreate(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDirectChannelOrCreate", reflect.TypeOf((*MockServicesAPI)(nil).GetDirectChannelOrCreate), arg0, arg1)
+}
+
 // GetFileInfo mocks base method.
 func (m *MockServicesAPI) GetFileInfo(arg0 string) (*model.FileInfo, error) {
 	m.ctrl.T.Helper()

--- a/server/model/services_api.go
+++ b/server/model/services_api.go
@@ -30,6 +30,7 @@ var FocalboardBot = &mm_model.Bot{
 type ServicesAPI interface {
 	// Channels service
 	GetDirectChannel(userID1, userID2 string) (*mm_model.Channel, error)
+	GetDirectChannelOrCreate(userID1, userID2 string) (*mm_model.Channel, error)
 	GetChannelByID(channelID string) (*mm_model.Channel, error)
 	GetChannelMember(channelID string, userID string) (*mm_model.ChannelMember, error)
 	GetChannelsForTeamForUser(teamID string, userID string, includeDeleted bool) (mm_model.ChannelList, error)

--- a/server/services/notify/plugindelivery/plugin_delivery.go
+++ b/server/services/notify/plugindelivery/plugin_delivery.go
@@ -8,9 +8,9 @@ import (
 )
 
 type servicesAPI interface {
-	// GetDirectChannel gets a direct message channel.
-	// If the channel does not exist it will create it.
-	GetDirectChannel(userID1, userID2 string) (*mm_model.Channel, error)
+	// GetDirectChannelOrCreate gets a direct message channel,
+	// or creates one if it does not already exist
+	GetDirectChannelOrCreate(userID1, userID2 string) (*mm_model.Channel, error)
 
 	// CreatePost creates a post.
 	CreatePost(post *mm_model.Post) (*mm_model.Post, error)

--- a/server/services/notify/plugindelivery/subscription_deliver.go
+++ b/server/services/notify/plugindelivery/subscription_deliver.go
@@ -70,5 +70,5 @@ func (pd *PluginDelivery) getDirectChannel(teamID string, userID string, botID s
 	if err != nil {
 		return nil, fmt.Errorf("cannot add bot to team %s: %w", teamID, err)
 	}
-	return pd.api.GetDirectChannel(userID, botID)
+	return pd.api.GetDirectChannelOrCreate(userID, botID)
 }

--- a/server/services/notify/plugindelivery/subscription_deliver.go
+++ b/server/services/notify/plugindelivery/subscription_deliver.go
@@ -53,7 +53,7 @@ func (pd *PluginDelivery) getDirectChannelID(teamID string, subscriberID string,
 			return "", fmt.Errorf("cannot find user: %w", err)
 		}
 		channel, err := pd.getDirectChannel(teamID, user.Id, botID)
-		if err != nil {
+		if err != nil || channel == nil {
 			return "", fmt.Errorf("cannot get direct channel: %w", err)
 		}
 		return channel.Id, nil

--- a/server/services/notify/plugindelivery/user_test.go
+++ b/server/services/notify/plugindelivery/user_test.go
@@ -101,6 +101,10 @@ func (m servicesAPIMock) GetDirectChannel(userID1, userID2 string) (*mm_model.Ch
 	return nil, nil
 }
 
+func (m servicesAPIMock) GetDirectChannelOrCreate(userID1, userID2 string) (*mm_model.Channel, error) {
+	return nil, nil
+}
+
 func (m servicesAPIMock) CreatePost(post *mm_model.Post) (*mm_model.Post, error) {
 	return post, nil
 }


### PR DESCRIPTION
#### Summary
There is a bug in Boards notification system in MPA mode. When a notification is sent, it first gets or creates a channel between the Boards bot and the user to be notified. Previously this used the GetDirectChannel method in the plugin API. That method gets or creates the channel. The product API version of that call only gets the channel and will not create it if not found. 

This PR fixes the issue by calling the newly added GetDirectChannelOrCreate product API.  Requires the [matching mm-server PR](https://github.com/mattermost/mattermost-server/pull/22112) to be merged first.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-49752