### PR TITLE
Enable cross-compilation of Linux webapp via Docker

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,10 +1,10 @@
-# This dockerfile is used to build Focalboard for Linux
-# it builds all the parts inside the container and the last stage just holds the
-# package that can be extracted using docker cp command
-# ie
-# docker build -f Dockerfile.build --no-cache -t focalboard-build:dirty .
-# docker run --rm -v /tmp/dist:/tmp -d --name test focalboard-build:dirty /bin/sh -c 'sleep 1000'
-# docker cp test:/dist/focalboard-server-linux-amd64.tar.gz .
+# This Dockerfile is used to build Focalboard for Linux. It builds all the parts inside the image
+# and the last stage just holds the package which is then copied back to the host.
+#
+# docker buildx build -f Dockerfile.build --no-cache --platform linux/amd64 -t focalboard-build:dirty --output out .
+# docker buildx build -f Dockerfile.build --no-cache --platform linux/arm64 -t focalboard-build:dirty --output out .
+#
+# Afterwards the packages can be found in the ./out folder.
 
 # build frontend
 FROM node:16.3.0@sha256:ca6daf1543242acb0ca59ff425509eab7defb9452f6ae07c156893db06c7a9a4 AS frontend
@@ -12,8 +12,10 @@ FROM node:16.3.0@sha256:ca6daf1543242acb0ca59ff425509eab7defb9452f6ae07c156893db
 WORKDIR /webapp
 COPY webapp .
 
-RUN npm install --no-optional
-RUN npm run pack
+### 'CPPFLAGS="-DPNG_ARM_NEON_OPT=0"' Needed To Avoid Bug Described in: https://github.com/imagemin/optipng-bin/issues/118#issuecomment-1019838562
+### Can be Removed when Ticket will be Closed
+RUN CPPFLAGS="-DPNG_ARM_NEON_OPT=0" npm install --no-optional && \
+    npm run pack
 
 # build backend and package
 FROM golang:1.18.3@sha256:b203dc573d81da7b3176264bfa447bd7c10c9347689be40540381838d75eebef AS backend
@@ -21,13 +23,13 @@ FROM golang:1.18.3@sha256:b203dc573d81da7b3176264bfa447bd7c10c9347689be405403818
 COPY . .
 COPY --from=frontend /webapp/pack webapp/pack
 
+ARG TARGETARCH
+
 # RUN apt-get update && apt-get install libgtk-3-dev libwebkit2gtk-4.0-dev -y
-RUN make server-linux
-RUN make server-linux-package-docker
+RUN EXCLUDE_PLUGIN=true EXCLUDE_SERVER=true EXCLUDE_ENTERPRISE=true make server-linux arch=${TARGETARCH}
+RUN make server-linux-package-docker arch=${TARGETARCH}
 
-# just hold the packages to output later
-FROM alpine:3.12@sha256:c75ac27b49326926b803b9ed43bf088bc220d22556de1bc5f72d742c91398f69 AS dist
-
-WORKDIR /dist
-
-COPY --from=backend /go/dist/focalboard-server-linux-amd64.tar.gz .
+# Copy package back to host
+FROM scratch AS dist
+ARG TARGETARCH
+COPY --from=backend /go/dist/focalboard-server-linux-${TARGETARCH}.tar.gz .

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ endif
 server-linux: setup-go-work ## Build server for Linux.
 	mkdir -p bin/linux
 	$(eval LDFLAGS += -X "github.com/mattermost/focalboard/server/model.Edition=linux")
-	cd server; env GOOS=linux GOARCH=amd64 go build -ldflags '$(LDFLAGS)' -tags '$(BUILD_TAGS)' -o ../bin/linux/focalboard-server ./main
+	cd server; env GOOS=linux GOARCH=$(arch) go build -ldflags '$(LDFLAGS)' -tags '$(BUILD_TAGS)' -o ../bin/linux/focalboard-server ./main
 
 server-docker: setup-go-work ## Build server for Docker Architectures.
 	mkdir -p bin/docker
@@ -101,7 +101,7 @@ server-linux-package-docker:
 	cp NOTICE.txt package/${PACKAGE_FOLDER}
 	cp webapp/NOTICE.txt package/${PACKAGE_FOLDER}/webapp-NOTICE.txt
 	mkdir -p dist
-	cd package && tar -czvf ../dist/focalboard-server-linux-amd64.tar.gz ${PACKAGE_FOLDER}
+	cd package && tar -czvf ../dist/focalboard-server-linux-$(arch).tar.gz ${PACKAGE_FOLDER}
 	rm -rf package
 
 generate: ## Install and run code generators.


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute

Assign two reviewers for this pull request from the names suggested. If no names are suggested or you are not sure who to assign, set `Core Focalboard` as the reviewer.
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the ticket).
-->

This is a step towards https://github.com/mattermost/focalboard/issues/4470 and extends the existing `Dockerfile.build` to enable cross-compilation of the Linux web app. In particular, this allows building arm64 binaries from a non-arm host via

```
docker buildx build -f Dockerfile.build --no-cache --platform linux/arm64 -t focalboard-build:dirty --output out .
```

#### Ticket Link

Relates to https://github.com/mattermost/focalboard/issues/4470
