### PR TITLE
GH-4520 - Check isBot property before displaying BotBadge

### DIFF
--- a/webapp/src/components/markdownEditorInput/entryComponent/entryComponent.tsx
+++ b/webapp/src/components/markdownEditorInput/entryComponent/entryComponent.tsx
@@ -30,7 +30,7 @@ const Entry = (props: EntryComponentProps): ReactElement => {
                     />
                     <div className={theme?.mentionSuggestionsEntryText}>
                         {mention.name}
-                        {BotBadge && <BotBadge show={mention.is_bot}/>}
+                        {BotBadge && mention.is_bot && <BotBadge/>}
                         <GuestBadge show={mention.is_guest}/>
                     </div>
                     <div className={theme?.mentionSuggestionsEntryText}>


### PR DESCRIPTION
#### Summary
The BotsBadge we use from windows Components was updated [here](https://github.com/mattermost/mattermost-webapp/pull/11100).

As part of the update, 
- removed the `show` prop and instead added conditional rendering to where it got used

This PR adds conditional rendering instead of passing the property to the component.


#### Ticket Link

  Fixes https://github.com/mattermost/focalboard/issues/4520
