### PR TITLE
Improves startup logs

### DIFF
--- a/mattermost-plugin/product/boards_product.go
+++ b/mattermost-plugin/product/boards_product.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/mattermost/focalboard/mattermost-plugin/server/boards"
 	"github.com/mattermost/focalboard/server/model"
+	"github.com/mattermost/focalboard/server/utils"
 
 	mm_model "github.com/mattermost/mattermost-server/v6/model"
 	"github.com/mattermost/mattermost-server/v6/plugin"
@@ -227,6 +228,12 @@ func (bp *boardsProduct) Start() error {
 		return nil
 	}
 
+	if utils.IsEnvTrue("MM_FEATUREFLAGS_BoardsProduct") {
+		bp.logger.Info("Boards product enabled via environment variable")
+	} else {
+		bp.logger.Info("Boards product enabled via feature flag")
+	}
+
 	bp.logger.Info("Starting boards service")
 
 	adapter := newServiceAPIAdapter(bp)
@@ -242,7 +249,7 @@ func (bp *boardsProduct) Start() error {
 	}
 
 	bp.boardsApp = boardsApp
-	if err := bp.boardsApp.Start(); err != nil {
+	if err := bp.boardsApp.Start("product"); err != nil {
 		return fmt.Errorf("failed to start Boards service: %w", err)
 	}
 

--- a/mattermost-plugin/server/boards/boardsapp.go
+++ b/mattermost-plugin/server/boards/boardsapp.go
@@ -170,14 +170,14 @@ func NewBoardsApp(api model.ServicesAPI) (*BoardsApp, error) {
 	}, nil
 }
 
-func (b *BoardsApp) Start() error {
+func (b *BoardsApp) Start(mode string) error {
 	if err := b.server.Start(); err != nil {
 		return fmt.Errorf("error starting Boards server: %w", err)
 	}
 
 	b.servicesAPI.RegisterRouter(b.server.GetRootRouter())
 
-	b.logger.Info("Boards backend successfully started.")
+	b.logger.Info(fmt.Sprintf("Boards %s successfully started.", mode))
 
 	return nil
 }

--- a/mattermost-plugin/server/boards/boardsapp.go
+++ b/mattermost-plugin/server/boards/boardsapp.go
@@ -177,7 +177,7 @@ func (b *BoardsApp) Start() error {
 
 	b.servicesAPI.RegisterRouter(b.server.GetRootRouter())
 
-	b.logger.Info("Boards product successfully started.")
+	b.logger.Info("Boards backend successfully started.")
 
 	return nil
 }

--- a/mattermost-plugin/server/plugin.go
+++ b/mattermost-plugin/server/plugin.go
@@ -29,7 +29,7 @@ type Plugin struct {
 
 func (p *Plugin) OnActivate() error {
 	if p.API.GetConfig().FeatureFlags.BoardsProduct {
-		p.API.LogError(ErrPluginNotAllowed.Error())
+		p.API.LogWarn(ErrPluginNotAllowed.Error())
 		return ErrPluginNotAllowed
 	}
 
@@ -56,7 +56,7 @@ func (p *Plugin) OnActivate() error {
 	model.LogServerInfo(logger)
 
 	p.boardsApp = boardsApp
-	return p.boardsApp.Start()
+	return p.boardsApp.Start("plugin")
 }
 
 // OnConfigurationChange is invoked when configuration changes may have been made.

--- a/server/utils/debug.go
+++ b/server/utils/debug.go
@@ -1,20 +1,6 @@
 package utils
 
-import (
-	"os"
-	"strings"
-)
-
 // IsRunningUnitTests returns true if this instance of FocalBoard is running unit or integration tests.
 func IsRunningUnitTests() bool {
-	testing := os.Getenv("FOCALBOARD_UNIT_TESTING")
-	if testing == "" {
-		return false
-	}
-
-	switch strings.ToLower(testing) {
-	case "1", "t", "y", "true", "yes":
-		return true
-	}
-	return false
+	return IsEnvTrue("FOCALBOARD_UNIT_TESTING")
 }

--- a/server/utils/utils.go
+++ b/server/utils/utils.go
@@ -2,7 +2,9 @@ package utils
 
 import (
 	"encoding/json"
+	"os"
 	"reflect"
+	"strings"
 	"time"
 
 	mmModel "github.com/mattermost/mattermost-server/v6/model"
@@ -118,4 +120,20 @@ func DedupeStringArr(arr []string) []string {
 	}
 
 	return dedupedArr
+}
+
+func IsStringTrue(v string) bool {
+	switch strings.ToLower(v) {
+	case "1", "t", "y", "true", "yes":
+		return true
+	}
+	return false
+}
+
+func IsEnvTrue(varName string) bool {
+	v := os.Getenv(varName)
+	if v == "" {
+		return false
+	}
+	return IsStringTrue(v)
 }


### PR DESCRIPTION
#### Summary
This PR updates the `boardsapp.Start` method to receive the mode of the starting backend, and logs it on start. In the case of the product, logic has been added to detect why the product is starting, if the environment variable is enabled or the startup process was triggered by the feature flag only.