### PR TITLE
GH-4475 - Save date change to database when closing form

### DIFF
--- a/webapp/src/properties/date/date.tsx
+++ b/webapp/src/properties/date/date.tsx
@@ -61,7 +61,6 @@ function DateRange(props: PropertyProps): JSX.Element {
     const onChange = useCallback((newValue) => {
         if (value !== newValue) {
             setValue(newValue)
-            mutator.changePropertyValue(board.id, card, propertyTemplate.id, newValue)
         }
     }, [value, board.id, card, propertyTemplate.id])
 
@@ -150,7 +149,9 @@ function DateRange(props: PropertyProps): JSX.Element {
     }
 
     const onClose = () => {
-        onChange(datePropertyToString(dateProperty))
+        const newDate = datePropertyToString(dateProperty)
+        onChange(newDate)
+        mutator.changePropertyValue(board.id, card, propertyTemplate.id, newDate)
         setShowDialog(false)
     }
 


### PR DESCRIPTION
#### Summary
When updating the date, the caller's <Table> object gets recreated causing the modal to close.

Rather than update the property value with every change, only update once the modal window closes. This keeps the modal open until date changes are complete. 

This works similar to a text field which doesn't update until the changes are complete, it doesn't update with each keystroke. 

#### Ticket Link
  Fixes https://github.com/mattermost/focalboard/issues/4475
