### PR TITLE
Moved `mattermost-plugin-api` dependency from `model` to `utils`

### DIFF
--- a/server/model/error.go
+++ b/server/model/error.go
@@ -7,9 +7,8 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/mattermost/focalboard/server/utils"
 	mmModel "github.com/mattermost/mattermost-server/v6/model"
-
-	pluginapi "github.com/mattermost/mattermost-plugin-api"
 )
 
 var (
@@ -276,7 +275,7 @@ func IsErrNotFound(err error) bool {
 	}
 
 	// check if this is a plugin API error
-	if errors.Is(err, pluginapi.ErrNotFound) {
+	if utils.IsPluginAPINotFound(err) {
 		return true
 	}
 

--- a/server/utils/utils.go
+++ b/server/utils/utils.go
@@ -2,9 +2,11 @@ package utils
 
 import (
 	"encoding/json"
+	"errors"
 	"reflect"
 	"time"
 
+	pluginapi "github.com/mattermost/mattermost-plugin-api"
 	mmModel "github.com/mattermost/mattermost-server/v6/model"
 )
 
@@ -118,4 +120,8 @@ func DedupeStringArr(arr []string) []string {
 	}
 
 	return dedupedArr
+}
+
+func IsPluginAPINotFound(err error) bool {
+	return errors.Is(err, pluginapi.ErrNotFound)
 }


### PR DESCRIPTION
#### Summary
Moved `mattermost-plugin-api` dependency from `model` to `utils` to resolve a cyclical dependency in `mattermost-server/plugin`

#### Ticket Link
None