### PR TITLE
add admin user on import

### DIFF
--- a/server/app/import.go
+++ b/server/app/import.go
@@ -241,6 +241,15 @@ func (a *App) ImportBoardJSONL(r io.Reader, opt model.ImportArchiveOptions) (str
 
 	// add users to all the new boards (if not the fake system user).
 	for _, board := range boardsAndBlocks.Boards {
+		// make sure an admin user gets added
+		adminMember := &model.BoardMember{
+			BoardID:     board.ID,
+			UserID:      opt.ModifiedBy,
+			SchemeAdmin: true,
+		}
+		if _, err2 := a.AddMemberToBoard(adminMember); err2 != nil {
+			return "", fmt.Errorf("cannot add adminMember to board: %w", err2)
+		}
 		for _, boardMember := range boardMembers {
 			bm := &model.BoardMember{
 				BoardID:         board.ID,

--- a/server/app/import_test.go
+++ b/server/app/import_test.go
@@ -47,9 +47,8 @@ func TestApp_ImportArchive(t *testing.T) {
 
 		th.Store.EXPECT().CreateBoardsAndBlocks(gomock.AssignableToTypeOf(&model.BoardsAndBlocks{}), "user").Return(babs, nil)
 		th.Store.EXPECT().GetMembersForBoard(board.ID).AnyTimes().Return([]*model.BoardMember{boardMember}, nil)
-		// th.Store.EXPECT().GetBoard(board.ID).Return(board, nil)
-		// th.Store.EXPECT().GetMemberForBoard(board.ID, "user").Return(boardMember, nil)
-		// th.Store.EXPECT().GetUserCategoryBoards("user", "test-team").Return([]model.CategoryBoards{}, nil)
+		th.Store.EXPECT().GetBoard(board.ID).Return(board, nil)
+		th.Store.EXPECT().GetMemberForBoard(board.ID, "user").Return(boardMember, nil)
 		th.Store.EXPECT().GetUserCategoryBoards("user", "test-team").Return([]model.CategoryBoards{
 			{
 				Category: model.Category{


### PR DESCRIPTION
#### Summary
Only users in the import file are being created. The importing user should always be added as an admin to the imported boards.

#### Ticket Link
Found while investigating...
#4532 and #4524 