### PR TITLE
Fixed category menu position

### DIFF
--- a/webapp/src/components/sidebar/sidebarCategory.tsx
+++ b/webapp/src/components/sidebar/sidebarCategory.tsx
@@ -313,6 +313,7 @@ const SidebarCategory = (props: Props) => {
                                                     <IconButton icon={<OptionsIcon/>}/>
                                                     <Menu
                                                         position='auto'
+                                                        fixed={true}
                                                         parentRef={menuWrapperRef}
                                                     >
                                                         {


### PR DESCRIPTION
#### Summary
All menues in the LHS are `fixed={true}` as that's the best way to display a menu in an overflow limited container. The menu for categories was missing the `fixed` prop, adding which resolves the issue.

#### Ticket Link
Fixes #4553
