### PR TITLE
GH-4478 - Forcing global header icons on the right

### DIFF
--- a/mattermost-plugin/webapp/src/plugin.scss
+++ b/mattermost-plugin/webapp/src/plugin.scss
@@ -2,6 +2,10 @@
     font-size: 20px;
 }
 
+.focalboard-body .RightControlsContainer-eacbOh {
+    flex-basis: auto;
+}
+
 .focalboard-body .feature-global-header>header {
     z-index: 1000;
 


### PR DESCRIPTION
#### Summary
GH-4478 - Forcing global header icons on the right

#### Ticket Link
Fixes #4478 