### PR TITLE
Use `name` column to determine if schema_migrations table is correct format

### DIFF
--- a/mattermost-plugin/server/manifest.go
+++ b/mattermost-plugin/server/manifest.go
@@ -45,8 +45,7 @@ const manifestStr = `
         "type": "bool",
         "help_text": "This allows board editors to share boards that can be accessed by anyone with the link.",
         "placeholder": "",
-        "default": false,
-        "hosting": ""
+        "default": false
       }
     ]
   }

--- a/server/services/store/sqlstore/schema_table_migration.go
+++ b/server/services/store/sqlstore/schema_table_migration.go
@@ -177,7 +177,7 @@ func (s *SQLStore) isSchemaMigrationNeededSQLite() (bool, error) {
 		idxName
 		idxType
 		idxNotnull
-		idxDflt_value
+		idxDfltValue
 		idxPk
 	)
 
@@ -191,7 +191,7 @@ func (s *SQLStore) isSchemaMigrationNeededSQLite() (bool, error) {
 			&row[idxName],
 			&row[idxType],
 			&row[idxNotnull],
-			&row[idxDflt_value],
+			&row[idxDfltValue],
 			&row[idxPk],
 		)
 		if err != nil {

--- a/server/services/store/sqlstore/schema_table_migration.go
+++ b/server/services/store/sqlstore/schema_table_migration.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"strings"
 
 	sq "github.com/Masterminds/squirrel"
 	"github.com/mattermost/focalboard/server/model"
@@ -22,7 +23,7 @@ func (s *SQLStore) EnsureSchemaMigrationFormat() error {
 	}
 
 	if !migrationNeeded {
-		s.logger.Debug("Schema migration table is correct format")
+		s.logger.Info("Schema migration table is correct format")
 		return nil
 	}
 
@@ -177,9 +178,14 @@ func (s *SQLStore) isSchemaMigrationNeededSQLite() (bool, error) {
 		data = append(data, row)
 	}
 
+	if len(data) == 0 {
+		// if no data then tables does not exist and therefore a schema migration is not needed.
+		return false, nil
+	}
+
 	for _, row := range data {
 		// look for a column named 'name', if found then no migration is needed
-		if len(row) >= 2 && *row[idx_name] == "name" {
+		if len(row) >= 2 && strings.ToLower(*row[idx_name]) == "name" {
 			return false, nil
 		}
 	}

--- a/server/services/store/sqlstore/schema_table_migration.go
+++ b/server/services/store/sqlstore/schema_table_migration.go
@@ -173,12 +173,12 @@ func (s *SQLStore) isSchemaMigrationNeededSQLite() (bool, error) {
 	defer s.CloseRows(rows)
 
 	const (
-		idx_cid = iota
-		idx_name
-		idx_type
-		idx_notnull
-		idx_dflt_value
-		idx_pk
+		idxCid = iota
+		idxName
+		idxType
+		idxNotnull
+		idxDflt_value
+		idxPk
 	)
 
 	data := [][]*string{}
@@ -187,12 +187,12 @@ func (s *SQLStore) isSchemaMigrationNeededSQLite() (bool, error) {
 		row := make([]*string, 6)
 
 		err := rows.Scan(
-			&row[idx_cid],
-			&row[idx_name],
-			&row[idx_type],
-			&row[idx_notnull],
-			&row[idx_dflt_value],
-			&row[idx_pk],
+			&row[idxCid],
+			&row[idxName],
+			&row[idxType],
+			&row[idxNotnull],
+			&row[idxDflt_value],
+			&row[idxPk],
 		)
 		if err != nil {
 			s.logger.Error("error scanning rows from SQLite schema_migrations table definition", mlog.Err(err))
@@ -209,7 +209,7 @@ func (s *SQLStore) isSchemaMigrationNeededSQLite() (bool, error) {
 
 	for _, row := range data {
 		// look for a column named 'name', if found then no migration is needed
-		if len(row) >= 2 && strings.ToLower(*row[idx_name]) == "name" {
+		if len(row) >= 2 && strings.ToLower(*row[idxName]) == "name" {
 			return false, nil
 		}
 	}

--- a/server/services/store/sqlstore/schema_table_migration.go
+++ b/server/services/store/sqlstore/schema_table_migration.go
@@ -179,7 +179,7 @@ func (s *SQLStore) isSchemaMigrationNeededSQLite() (bool, error) {
 	}
 
 	if len(data) == 0 {
-		// if no data then tables does not exist and therefore a schema migration is not needed.
+		// if no data then table does not exist and therefore a schema migration is not needed.
 		return false, nil
 	}
 


### PR DESCRIPTION
#### Summary
A number of support tickets have been due to full migrations being run on existing Sqlite databases when upgrading.  There are only a few causes for the server to think a complete set of migrations is needed.  

1.  The schema_migrations table is empty
2.  The schema_migrations table has a column named `dirty`, forcing a schema migration for Morph 
3.  The schema_migrations table is missing

Point 3 would result in an error being logged.  

The most likely cause is item 2 since we have observed issues deleting columns in Sqlite.  Instead of checking for a column named `dirty` to ensure it was deleted, this PR modifies the check to look for a column named `name` to determine if a schema migration is needed on the schema_migrations table.  The `name` column was added for Morph, and is more reliable than ensuring a column was deleted.

#### Ticket Link
various