### PR TITLE
use specific class, rather than NOT an unrelated ID

### DIFF
--- a/webapp/src/widgets/menu/menu.scss
+++ b/webapp/src/widgets/menu/menu.scss
@@ -1,6 +1,6 @@
 @import '../../styles/z-index';
 
-.Menu:not(#statusDropdownMenu) {
+.Menu.noselect {
     @include z-index(menu);
     display: flex;
     flex-direction: column;
@@ -173,7 +173,7 @@
     }
 }
 
-.Menu:not(#statusDropdownMenu),
+.Menu.noselect,
 .SubMenuOption .SubMenu {
     @media screen and (max-width: 430px) {
         position: fixed;


### PR DESCRIPTION
#### Summary
A css change for another issue(https://github.com/mattermost/focalboard/pull/4411) started using an ID in a NOT() operation which caused the css specificity to change. Because of that change the "shareboard.css" gets overwritten rather than being the final css.

This PR changes to use the specific classes used by menu.tsx, which allows the specificity to remain the same. 

#### Ticket Link

  Fixes https://github.com/mattermost/focalboard/pull/4411
