### PR TITLE
Minor improvements to logging

### DIFF
--- a/server/services/notify/notifysubscriptions/diff2slackattachments.go
+++ b/server/services/notify/notifysubscriptions/diff2slackattachments.go
@@ -316,7 +316,7 @@ func appendContentChanges(fields []*mm_model.SlackAttachmentField, cardDiff *Dif
 			}
 		}
 
-		logger.Debug("appendContentChanges",
+		logger.Trace("appendContentChanges",
 			mlog.String("type", string(child.BlockType)),
 			mlog.String("opString", opString),
 			mlog.String("oldTitle", oldTitle),

--- a/server/utils/callbackqueue.go
+++ b/server/utils/callbackqueue.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"context"
+	"runtime/debug"
 	"sync/atomic"
 	"time"
 
@@ -119,9 +120,11 @@ func (cn *CallbackQueue) exec(f CallbackFunc) {
 	// don't let a panic in the callback exit the thread.
 	defer func() {
 		if r := recover(); r != nil {
+			stack := debug.Stack()
 			cn.logger.Error("CallbackQueue callback panic",
 				mlog.String("name", cn.name),
 				mlog.Any("panic", r),
+				mlog.String("stack", string(stack)),
 			)
 		}
 	}()

--- a/server/ws/plugin_adapter.go
+++ b/server/ws/plugin_adapter.go
@@ -454,7 +454,7 @@ func (pa *PluginAdapter) sendBoardMessage(teamID, boardID string, payload map[st
 }
 
 func (pa *PluginAdapter) BroadcastBlockChange(teamID string, block *model.Block) {
-	pa.logger.Debug("BroadcastingBlockChange",
+	pa.logger.Trace("BroadcastingBlockChange",
 		mlog.String("teamID", teamID),
 		mlog.String("boardID", block.BoardID),
 		mlog.String("blockID", block.ID),


### PR DESCRIPTION
#### Summary
This PR makes a few minor improvements to logging:

1. change log level for `appendContentChanges` to trace to reduce debug  noise
2. force a stack trace for the notify callback panic handler
3. change log level for `BroadcastingBlockChange` to trace to reduce debug  noise

Will be cherry-picked to mono-repo branch

#### Ticket Link
NONE