### PR TITLE
MM-50804 - add reference to template id to action function

### DIFF
--- a/mattermost-plugin/webapp/src/components/createBoardFromTemplate.tsx
+++ b/mattermost-plugin/webapp/src/components/createBoardFromTemplate.tsx
@@ -73,7 +73,7 @@ const CreateBoardFromTemplate = (props: Props) => {
 
         let boardsAndBlocks = undefined
 
-        if (selectedBoardTemplateId === EMPTY_BOARD) {
+        if (templateIdRef.current === EMPTY_BOARD) {
             boardsAndBlocks = await mutator.addEmptyBoard(teamId, intl)
         } else {
             boardsAndBlocks = await mutator.duplicateBoard(templateIdRef.current as string, ACTION_DESCRIPTION, asTemplate, undefined, undefined, teamId)


### PR DESCRIPTION
#### Summary
Use the reference id value instead of the component state value when validating the id of the template inside the action function sent from the plugin to the webapp.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-50804

Before:

https://user-images.githubusercontent.com/10082627/221557657-4b71d0e6-242d-42c6-b559-d8bcdf3dcc9c.mov


After:

https://user-images.githubusercontent.com/10082627/221557703-efa57845-de2f-4a83-96bd-36c68fd70699.mov


