### PR TITLE
MM-50810 Fix module loading issues caused by shared modules

### DIFF
--- a/mattermost-plugin/webapp/webpack.config.js
+++ b/mattermost-plugin/webapp/webpack.config.js
@@ -132,11 +132,18 @@ if (TARGET_IS_PRODUCT) {
         const sharedObject = {};
 
         for (const packageName of packageNames) {
-            // Set both versions to false so that the version of this module provided by the web app will be used
             sharedObject[packageName] = {
-                requiredVersion: false,
+
+                // Ensure only one copy of this package is ever loaded
                 singleton: true,
-                version: false,
+
+                // Set this to false to prevent Webpack from packaging any "fallback" version of this package so that
+                // only the version provided by the web app will be used
+                import: false,
+
+                // Set these to false so that any version provided by the web app will be accepted
+                requiredVersion: false,
+                version: false
             };
         }
 


### PR DESCRIPTION
With Playbooks moving to MPA, we're running into some errors that cause either one of Boards or Playbooks to fail to load. It seems like it was happening due to an issue with the resolution of shared modules by module federation. Specifically, it seems to be due to how it was trying to choose which version of those shared modules to use between the ones bundled with the web app, Boards, and Playbooks.

Since I've been trying to make the web app the authority for these dependencies, I just changed it so that the builds for both Boards and Playbooks will never include "fallback" versions of React and such since we know they'll always exist in the web app.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-50818

#### Related Pull Requests
https://github.com/mattermost/mattermost-plugin-playbooks/pull/1826
https://github.com/mattermost/mattermost-webapp/pull/12282