### PR TITLE
check permissions to channel before patching via api

### DIFF
--- a/server/app/boards.go
+++ b/server/app/boards.go
@@ -355,12 +355,15 @@ func (a *App) PatchBoard(patch *model.BoardPatch, boardID, userID string) (*mode
 	var oldMembers []*model.BoardMember
 
 	if patch.Type != nil || patch.ChannelID != nil {
+		testChannel := ""
 		if patch.ChannelID != nil && *patch.ChannelID == "" {
 			var err error
 			oldMembers, err = a.GetMembersForBoard(boardID)
 			if err != nil {
 				a.logger.Error("Unable to get the board members", mlog.Err(err))
 			}
+		} else if patch.ChannelID != nil && *patch.ChannelID != "" {
+			testChannel = *patch.ChannelID
 		}
 
 		board, err := a.store.GetBoard(boardID)
@@ -372,7 +375,17 @@ func (a *App) PatchBoard(patch *model.BoardPatch, boardID, userID string) (*mode
 		}
 		oldChannelID = board.ChannelID
 		isTemplate = board.IsTemplate
+		if testChannel == "" {
+			testChannel = oldChannelID
+		}
+
+		if testChannel != "" {
+			if !a.permissions.HasPermissionToChannel(userID, testChannel, model.PermissionCreatePost) {
+				return nil, model.NewErrPermission("access denied to channel")
+			}
+		}
 	}
+
 	updatedBoard, err := a.store.PatchBoard(boardID, patch, userID)
 	if err != nil {
 		return nil, err

--- a/server/app/boards_test.go
+++ b/server/app/boards_test.go
@@ -469,7 +469,7 @@ func TestPatchBoard(t *testing.T) {
 		const userID = "user_id_2"
 		const teamID = "team_id_1"
 
-		channelID := "myChannel"
+		const channelID = "myChannel"
 		clearChannel := ""
 		patchType := model.BoardTypeOpen
 		patch := &model.BoardPatch{
@@ -498,7 +498,6 @@ func TestPatchBoard(t *testing.T) {
 		_, err := th.App.PatchBoard(patch, boardID, userID)
 		require.Error(t, err)
 	})
-
 }
 
 func TestGetBoardCount(t *testing.T) {

--- a/server/app/boards_test.go
+++ b/server/app/boards_test.go
@@ -185,6 +185,7 @@ func TestPatchBoard(t *testing.T) {
 
 		// Type not null will retrieve team members
 		th.Store.EXPECT().GetUsersByTeam(teamID, "", false, false).Return([]*model.User{}, nil)
+		th.Store.EXPECT().GetUserByID(userID).Return(&model.User{ID: userID, Username: "UserName"}, nil)
 
 		th.Store.EXPECT().PatchBoard(boardID, patch, userID).Return(
 			&model.Board{
@@ -423,6 +424,44 @@ func TestPatchBoard(t *testing.T) {
 		th.API.EXPECT().HasPermissionToChannel(userID, channelID, model.PermissionCreatePost).Return(false).Times(1)
 		_, err := th.App.PatchBoard(patch, boardID, userID)
 		require.Error(t, err)
+	})
+
+	t.Run("patch type channel, user with post permissions", func(t *testing.T) {
+		const boardID = "board_id_1"
+		const userID = "user_id_2"
+		const teamID = "team_id_1"
+
+		channelID := "myChannel"
+		patch := &model.BoardPatch{
+			ChannelID: &channelID,
+		}
+
+		// Type not nil, will cause board to be reteived
+		// to check isTemplate
+		th.Store.EXPECT().GetBoard(boardID).Return(&model.Board{
+			ID:     boardID,
+			TeamID: teamID,
+		}, nil).Times(2)
+
+		th.API.EXPECT().HasPermissionToChannel(userID, channelID, model.PermissionCreatePost).Return(true).Times(1)
+
+		th.Store.EXPECT().PatchBoard(boardID, patch, userID).Return(
+			&model.Board{
+				ID:     boardID,
+				TeamID: teamID,
+			},
+			nil)
+
+		// Should call GetMembersForBoard 2 times
+		// - for WS BroadcastBoardChange
+		// - for AddTeamMembers check
+		th.Store.EXPECT().GetMembersForBoard(boardID).Return([]*model.BoardMember{}, nil).Times(2)
+
+		th.Store.EXPECT().PostMessage(utils.Anything, "", "").Times(1)
+
+		patchedBoard, err := th.App.PatchBoard(patch, boardID, userID)
+		require.NoError(t, err)
+		require.Equal(t, boardID, patchedBoard.ID)
 	})
 
 	t.Run("patch type remove channel, user without post permissions", func(t *testing.T) {

--- a/webapp/src/properties/url/url.tsx
+++ b/webapp/src/properties/url/url.tsx
@@ -35,11 +35,14 @@ const URLProperty = (props: PropertyProps): JSX.Element => {
         if (value !== (props.card.fields.properties[props.propertyTemplate?.id || ''] || '')) {
             mutator.changePropertyValue(props.board.id, props.card, props.propertyTemplate?.id || '', value)
         }
-    }, [props.card, props.propertyTemplate, value])
+    }, [props.board.id, props.card, props.propertyTemplate?.id, value])
 
     const saveTextPropertyRef = useRef<() => void>(saveTextProperty)
-    saveTextPropertyRef.current = saveTextProperty
-
+    if (props.readOnly) {
+        saveTextPropertyRef.current = () => null
+    } else {
+        saveTextPropertyRef.current = saveTextProperty
+    }
     useEffect(() => {
         return () => {
             saveTextPropertyRef.current && saveTextPropertyRef.current()


### PR DESCRIPTION

#### Summary
When patching a board, ensure a user can Post to a channel before allowing the linking to occur. This will ensure the user is a member of the channel and not a read-only user.

#### Ticket Link
  Fixes https://mattermost.atlassian.net/browse/MM-51062
