### PR TITLE
Fix category dialog

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,6 @@
 PACKAGE_FOLDER = focalboard
 
 # Build Flags
-# Change to kick off and test CI
 BUILD_NUMBER ?= $(BUILD_NUMBER:)
 BUILD_DATE = $(shell date -u)
 BUILD_HASH = $(shell git rev-parse HEAD)

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 PACKAGE_FOLDER = focalboard
 
 # Build Flags
+# Change to kick off and test CI
 BUILD_NUMBER ?= $(BUILD_NUMBER:)
 BUILD_DATE = $(shell date -u)
 BUILD_HASH = $(shell git rev-parse HEAD)

--- a/webapp/src/components/sidebar/sidebarCategory.scss
+++ b/webapp/src/components/sidebar/sidebarCategory.scss
@@ -7,7 +7,7 @@
     }
 
     .Dialog {
-        color: rgba(var(--center-channel-color-rgb))
+        color: rgba(var(--center-channel-color-rgb));
     }
 
     .octo-sidebar-item {

--- a/webapp/src/components/sidebar/sidebarCategory.scss
+++ b/webapp/src/components/sidebar/sidebarCategory.scss
@@ -6,7 +6,7 @@
         margin-top: 0;
     }
 
-    .Dialog {
+    .dialog {
         color: rgba(var(--center-channel-color-rgb));
     }
 

--- a/webapp/src/components/sidebar/sidebarCategory.scss
+++ b/webapp/src/components/sidebar/sidebarCategory.scss
@@ -6,6 +6,10 @@
         margin-top: 0;
     }
 
+    .Dialog {
+        color: rgba(var(--center-channel-color-rgb))
+    }
+
     .octo-sidebar-item {
         display: flex;
         flex-direction: row;


### PR DESCRIPTION
#### Summary
Set the color for sidebar dialog box. Currently defaults to Sidebar Color `rgb(var(--sidebar-text-rgb))`, which cannot be seen in normal color scheme.

#### Ticket Link
  Fixes https://github.com/mattermost/focalboard/issues/4649

#### Release Note
```release-note
Fixes issue with Delete Category Dialog message not visible
```
