### PR TITLE
Fix schema migration check for postgres

### DIFF
--- a/server/services/store/sqlstore/schema_table_migration.go
+++ b/server/services/store/sqlstore/schema_table_migration.go
@@ -121,8 +121,11 @@ func (s *SQLStore) isSchemaMigrationNeeded() (bool, error) {
 			"COLUMN_NAME": "dirty",
 		})
 
-	if s.dbType == model.MysqlDBType {
+	switch s.dbType {
+	case model.MysqlDBType:
 		query = query.Where(sq.Eq{"TABLE_SCHEMA": s.schemaName})
+	case model.PostgresDBType:
+		query = query.Where(sq.Eq{"TABLE_SCHEMA": "current_schema()"})
 	}
 
 	row := query.QueryRow()


### PR DESCRIPTION
#### Summary
Fix `isSchemaMigrationNeeded` for postgres when running under Perseus.