### PR TITLE
Fix schema migration check for postgres

### DIFF
--- a/server/services/store/sqlstore/schema_table_migration.go
+++ b/server/services/store/sqlstore/schema_table_migration.go
@@ -123,8 +123,11 @@ func (s *SQLStore) isSchemaMigrationNeeded() (bool, error) {
 			"TABLE_NAME": s.tablePrefix + "schema_migrations",
 		})
 
-	if s.dbType == model.MysqlDBType {
+	switch s.dbType {
+	case model.MysqlDBType:
 		query = query.Where(sq.Eq{"TABLE_SCHEMA": s.schemaName})
+	case model.PostgresDBType:
+		query = query.Where(sq.Eq{"TABLE_SCHEMA": "current_schema()"})
 	}
 
 	rows, err := query.Query()


### PR DESCRIPTION
#### Summary
Fix `isSchemaMigrationNeeded` for postgres when running under Perseus.