### PR TITLE
Fix CI after mono-repo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
         repository: "mattermost/mattermost-server"
         fetch-depth: "20"
         path: "mattermost-server"
-        ref : "master"
+        ref : "b61c096497ac1f22f64b77afe58d0dd5a72b38f1"
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
@@ -74,7 +74,7 @@ jobs:
         repository: "mattermost/mattermost-server"
         fetch-depth: "20"
         path: "mattermost-server"
-        ref : "master"
+        ref : "b61c096497ac1f22f64b77afe58d0dd5a72b38f1"
     - name: npm ci
       run: |
         cd focalboard/webapp && npm ci && cd -
@@ -132,7 +132,7 @@ jobs:
         repository: "mattermost/mattermost-server"
         fetch-depth: "20"
         path: "mattermost-server"
-        ref : "master"
+        ref : "b61c096497ac1f22f64b77afe58d0dd5a72b38f1"
 
     - name: Set up Go
       uses: actions/setup-go@v3
@@ -169,7 +169,7 @@ jobs:
         repository: "mattermost/mattermost-server"
         fetch-depth: "20"
         path: "mattermost-server"
-        ref : "master"
+        ref : "b61c096497ac1f22f64b77afe58d0dd5a72b38f1"
 
     - name: Set up Go
       uses: actions/setup-go@v3

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -8,14 +8,14 @@ on:
   workflow_dispatch:
 
 env:
- BRANCH_NAME: ${{ github.head_ref || github.ref_name }} 
+ BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
  EXCLUDE_ENTERPRISE: true
 
 jobs:
 
   ubuntu:
     runs-on: ubuntu-18.04
- 
+
     steps:
     - uses: actions/checkout@v3
       with:
@@ -25,16 +25,16 @@ jobs:
       continue-on-error: true
       with:
         repository: "mattermost/mattermost-server"
-        fetch-depth: "20" 
+        fetch-depth: "20"
         path: "mattermost-server"
         ref: ${{ env.BRANCH_NAME }}
     - uses: actions/checkout@v3
       if: steps.mattermostServer.outcome == 'failure'
       with:
         repository: "mattermost/mattermost-server"
-        fetch-depth: "20" 
+        fetch-depth: "20"
         path: "mattermost-server"
-        ref : "master"
+        ref : "b61c096497ac1f22f64b77afe58d0dd5a72b38f1"
 
     - name: Replace token 1 server
       run: sed -i -e "s,placeholder_rudder_dataplane_url,${{ secrets.RUDDER_DATAPLANE_URL }},g" ${{ github.workspace }}/focalboard/server/services/telemetry/telemetry.go
@@ -101,16 +101,16 @@ jobs:
       continue-on-error: true
       with:
         repository: "mattermost/mattermost-server"
-        fetch-depth: "20" 
+        fetch-depth: "20"
         path: "mattermost-server"
         ref: ${{ env.BRANCH_NAME }}
     - uses: actions/checkout@v3
       if: steps.mattermostServer.outcome == 'failure'
       with:
         repository: "mattermost/mattermost-server"
-        fetch-depth: "20" 
+        fetch-depth: "20"
         path: "mattermost-server"
-        ref : "master"
+        ref : "b61c096497ac1f22f64b77afe58d0dd5a72b38f1"
     - name: Replace token 1 server
       run: sed -i -e "s,placeholder_rudder_dataplane_url,${{ secrets.RUDDER_DATAPLANE_URL }},g" ${{ github.workspace }}/focalboard/server/services/telemetry/telemetry.go
 
@@ -159,16 +159,16 @@ jobs:
       continue-on-error: true
       with:
         repository: "mattermost/mattermost-server"
-        fetch-depth: "20" 
+        fetch-depth: "20"
         path: "mattermost-server"
         ref: ${{ env.BRANCH_NAME }}
     - uses: actions/checkout@v3
       if: steps.mattermostServer.outcome == 'failure'
       with:
         repository: "mattermost/mattermost-server"
-        fetch-depth: "20" 
+        fetch-depth: "20"
         path: "mattermost-server"
-        ref : "master"
+        ref : "b61c096497ac1f22f64b77afe58d0dd5a72b38f1"
     - name: Replace token 1 server
       run: sed -i -e "s,placeholder_rudder_dataplane_url,${{ secrets.RUDDER_DATAPLANE_URL }},g" ${{ github.workspace }}/focalboard/server/services/telemetry/telemetry.go
 
@@ -229,16 +229,16 @@ jobs:
       continue-on-error: true
       with:
         repository: "mattermost/mattermost-server"
-        fetch-depth: "20" 
+        fetch-depth: "20"
         path: "mattermost-server"
         ref: ${{ env.BRANCH_NAME }}
     - uses: actions/checkout@v3
       if: steps.mattermostServer.outcome == 'failure'
       with:
         repository: "mattermost/mattermost-server"
-        fetch-depth: "20" 
+        fetch-depth: "20"
         path: "mattermost-server"
-        ref : "master"
+        ref : "b61c096497ac1f22f64b77afe58d0dd5a72b38f1"
 
     - name: Replace token 1 server
       run: sed -i -e "s,placeholder_rudder_dataplane_url,${{ secrets.RUDDER_DATAPLANE_URL }},g" ${{ github.workspace }}/focalboard/server/services/telemetry/telemetry.go

--- a/.github/workflows/lint-server.yml
+++ b/.github/workflows/lint-server.yml
@@ -48,7 +48,7 @@ jobs:
           repository: "mattermost/mattermost-server"
           fetch-depth: "20"
           path: "mattermost-server"
-          ref : "master"
+          ref : "b61c096497ac1f22f64b77afe58d0dd5a72b38f1"
       - name: set up golangci-lint
         run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.50.1
       - name: lint

--- a/.github/workflows/prod-release.yml
+++ b/.github/workflows/prod-release.yml
@@ -21,16 +21,16 @@ jobs:
       continue-on-error: true
       with:
         repository: "mattermost/mattermost-server"
-        fetch-depth: "20" 
+        fetch-depth: "20"
         path: "mattermost-server"
         ref: ${{ env.BRANCH_NAME }}
     - uses: actions/checkout@v3
       if: steps.mattermostServer.outcome == 'failure'
       with:
         repository: "mattermost/mattermost-server"
-        fetch-depth: "20" 
+        fetch-depth: "20"
         path: "mattermost-server"
-        ref : "master"
+        ref : "b61c096497ac1f22f64b77afe58d0dd5a72b38f1"
 
     - name: Replace token 1 server
       run: sed -i -e "s,placeholder_rudder_dataplane_url,${{ secrets.RUDDER_DATAPLANE_URL }},g" ${{ github.workspace }}/focalboard/server/services/telemetry/telemetry.go
@@ -97,16 +97,16 @@ jobs:
       continue-on-error: true
       with:
         repository: "mattermost/mattermost-server"
-        fetch-depth: "20" 
+        fetch-depth: "20"
         path: "mattermost-server"
         ref: ${{ env.BRANCH_NAME }}
     - uses: actions/checkout@v3
       if: steps.mattermostServer.outcome == 'failure'
       with:
         repository: "mattermost/mattermost-server"
-        fetch-depth: "20" 
+        fetch-depth: "20"
         path: "mattermost-server"
-        ref : "master"
+        ref : "b61c096497ac1f22f64b77afe58d0dd5a72b38f1"
 
     - name: Replace token 1 server
       run: sed -i -e "s,placeholder_rudder_dataplane_url,${{ secrets.RUDDER_DATAPLANE_URL }},g" ${{ github.workspace }}/focalboard/server/services/telemetry/telemetry.go
@@ -156,16 +156,16 @@ jobs:
       continue-on-error: true
       with:
         repository: "mattermost/mattermost-server"
-        fetch-depth: "20" 
+        fetch-depth: "20"
         path: "mattermost-server"
         ref: ${{ env.BRANCH_NAME }}
     - uses: actions/checkout@v3
       if: steps.mattermostServer.outcome == 'failure'
       with:
         repository: "mattermost/mattermost-server"
-        fetch-depth: "20" 
+        fetch-depth: "20"
         path: "mattermost-server"
-        ref : "master"
+        ref : "b61c096497ac1f22f64b77afe58d0dd5a72b38f1"
 
     - name: Replace token 1 server
       run: sed -i -e "s,placeholder_rudder_dataplane_url,${{ secrets.RUDDER_DATAPLANE_URL }},g" ${{ github.workspace }}/focalboard/server/services/telemetry/telemetry.go
@@ -228,16 +228,16 @@ jobs:
       continue-on-error: true
       with:
         repository: "mattermost/mattermost-server"
-        fetch-depth: "20" 
+        fetch-depth: "20"
         path: "mattermost-server"
         ref: ${{ env.BRANCH_NAME }}
     - uses: actions/checkout@v3
       if: steps.mattermostServer.outcome == 'failure'
       with:
         repository: "mattermost/mattermost-server"
-        fetch-depth: "20" 
+        fetch-depth: "20"
         path: "mattermost-server"
-        ref : "master"
+        ref : "b61c096497ac1f22f64b77afe58d0dd5a72b38f1"
 
     - name: Replace token 1 server
       run: sed -i -e "s,placeholder_rudder_dataplane_url,${{ secrets.RUDDER_DATAPLANE_URL }},g" ${{ github.workspace }}/focalboard/server/services/telemetry/telemetry.go


### PR DESCRIPTION
#### Summary

This PR updates the default `mattermost-server` reference to be pulled if a test run doesn't have a branch on the server repo. The reference now points to the commit pre-mono-repo, so the code can build and test can run normally.

This fixes CI for `main` and for the PRs of both new fixes and cherry-picks to the release branches we're still maintaining