### PR TITLE
update ubuntu to latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ env:
 jobs:
 
   ci-ubuntu-server:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     strategy:
       matrix:
@@ -54,7 +54,7 @@ jobs:
       run: cd focalboard; make server-test-${{matrix['db']}}
 
   ci-ubuntu-webapp:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
     - name: Checkout
       uses: actions/checkout@v3

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -14,7 +14,7 @@ env:
 jobs:
 
   ubuntu:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
  
     steps:
     - uses: actions/checkout@v3
@@ -218,7 +218,7 @@ jobs:
         path: ${{ github.workspace }}/focalboard/win-wpf/dist/focalboard-win.zip
 
   plugin:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/lint-server.yml
+++ b/.github/workflows/lint-server.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   down-migrations:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
         with:
@@ -26,7 +26,7 @@ jobs:
 
   golangci:
     name: plugin
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-go@v3
         with:

--- a/.github/workflows/prod-release.yml
+++ b/.github/workflows/prod-release.yml
@@ -9,7 +9,7 @@ env:
 jobs:
 
   ubuntu:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     steps:
     - name: Checkout
@@ -216,7 +216,7 @@ jobs:
         path: ${{ github.workspace }}/focalboard/win-wpf/dist/focalboard-win.zip
 
   plugin-release:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     steps:
     - name: Checkout


### PR DESCRIPTION
#### Summary
Github deprecating ubuntu 18.04, use latest.

https://github.com/actions/runner-images/issues/6002
 > Workflows using the ubuntu-18.04 image label should be updated to ubuntu-latest, ubuntu-20.04, or ubuntu-22.04
