### PR TITLE
only send category updates to user

### DIFF
--- a/server/api/files.go
+++ b/server/api/files.go
@@ -8,6 +8,8 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -20,8 +22,29 @@ import (
 	mmModel "github.com/mattermost/mattermost-server/v6/model"
 
 	"github.com/mattermost/mattermost-server/v6/shared/mlog"
-	"github.com/mattermost/mattermost-server/v6/shared/web"
 )
+
+var UnsafeContentTypes = [...]string{
+	"application/javascript",
+	"application/ecmascript",
+	"text/javascript",
+	"text/ecmascript",
+	"application/x-javascript",
+	"text/html",
+}
+
+var MediaContentTypes = [...]string{
+	"image/jpeg",
+	"image/png",
+	"image/bmp",
+	"image/gif",
+	"image/tiff",
+	"video/avi",
+	"video/mpeg",
+	"video/mp4",
+	"audio/mpeg",
+	"audio/wav",
+}
 
 // FileUploadResponse is the response to a file upload
 // swagger:model
@@ -145,8 +168,72 @@ func (a *API) handleServeFile(w http.ResponseWriter, r *http.Request) {
 	}
 
 	defer fileReader.Close()
-	web.WriteFileResponse(filename, fileInfo.MimeType, fileInfo.Size, time.Now(), "", fileReader, false, w, r)
+	mimeType := ""
+	var fileSize int64
+	if fileInfo != nil {
+		mimeType = fileInfo.MimeType
+		fileSize = fileInfo.Size
+	}
+	writeFileResponse(filename, mimeType, fileSize, time.Now(), "", fileReader, false, w, r)
 	auditRec.Success()
+}
+
+func writeFileResponse(filename string, contentType string, contentSize int64,
+	lastModification time.Time, webserverMode string, fileReader io.ReadSeeker, forceDownload bool, w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Cache-Control", "private, no-cache")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+
+	if contentSize > 0 {
+		contentSizeStr := strconv.Itoa(int(contentSize))
+		if webserverMode == "gzip" {
+			w.Header().Set("X-Uncompressed-Content-Length", contentSizeStr)
+		} else {
+			w.Header().Set("Content-Length", contentSizeStr)
+		}
+	}
+
+	if contentType == "" {
+		contentType = "application/octet-stream"
+	} else {
+		for _, unsafeContentType := range UnsafeContentTypes {
+			if strings.HasPrefix(contentType, unsafeContentType) {
+				contentType = "text/plain"
+				break
+			}
+		}
+	}
+
+	w.Header().Set("Content-Type", contentType)
+
+	var toDownload bool
+	if forceDownload {
+		toDownload = true
+	} else {
+		isMediaType := false
+
+		for _, mediaContentType := range MediaContentTypes {
+			if strings.HasPrefix(contentType, mediaContentType) {
+				isMediaType = true
+				break
+			}
+		}
+
+		toDownload = !isMediaType
+	}
+
+	filename = url.PathEscape(filename)
+
+	if toDownload {
+		w.Header().Set("Content-Disposition", "attachment;filename=\""+filename+"\"; filename*=UTF-8''"+filename)
+	} else {
+		w.Header().Set("Content-Disposition", "inline;filename=\""+filename+"\"; filename*=UTF-8''"+filename)
+	}
+
+	// prevent file links from being embedded in iframes
+	w.Header().Set("X-Frame-Options", "DENY")
+	w.Header().Set("Content-Security-Policy", "Frame-ancestors 'none'")
+
+	http.ServeContent(w, r, filename, lastModification, fileReader)
 }
 
 func (a *API) getFileInfo(w http.ResponseWriter, r *http.Request) {

--- a/server/ws/server.go
+++ b/server/ws/server.go
@@ -471,6 +471,17 @@ func (ws *Server) getListenersForTeam(teamID string) []*websocketSession {
 	return ws.listenersByTeam[teamID]
 }
 
+// getListenersForUser returns the listener for a user subscribed to a
+// team changes.
+func (ws *Server) getListenerForUser(teamID, userID string) *websocketSession {
+	for _, listener := range ws.listenersByTeam[teamID] {
+		if listener.userID == userID {
+			return listener
+		}
+	}
+	return nil
+}
+
 // getListenersForTeamAndBoard returns the listeners subscribed to a
 // team changes and members of a given board.
 func (ws *Server) getListenersForTeamAndBoard(teamID, boardID string, ensureUsers ...string) []*websocketSession {
@@ -567,16 +578,10 @@ func (ws *Server) BroadcastCategoryChange(category model.Category) {
 		Category: &category,
 	}
 
-	listeners := ws.getListenersForTeam(category.TeamID)
-	ws.logger.Debug("listener(s) for teamID",
-		mlog.Int("listener_count", len(listeners)),
-		mlog.String("teamID", category.TeamID),
-		mlog.String("categoryID", category.ID),
-	)
-
-	for _, listener := range listeners {
-		ws.logger.Debug("Broadcast block change",
-			mlog.Int("listener_count", len(listeners)),
+	listener := ws.getListenerForUser(category.TeamID, category.UserID)
+	if listener != nil {
+		ws.logger.Debug("Broadcast category change",
+			mlog.String("userID", category.UserID),
 			mlog.String("teamID", category.TeamID),
 			mlog.String("categoryID", category.ID),
 			mlog.Stringer("remoteAddr", listener.conn.RemoteAddr()),
@@ -596,15 +601,10 @@ func (ws *Server) BroadcastCategoryReorder(teamID, userID string, categoryOrder 
 		TeamID:        teamID,
 	}
 
-	listeners := ws.getListenersForTeam(teamID)
-	ws.logger.Debug("listener(s) for teamID",
-		mlog.Int("listener_count", len(listeners)),
-		mlog.String("teamID", teamID),
-	)
-
-	for _, listener := range listeners {
+	listener := ws.getListenerForUser(teamID, userID)
+	if listener != nil {
 		ws.logger.Debug("Broadcast category order change",
-			mlog.Int("listener_count", len(listeners)),
+			mlog.String("userID", userID),
 			mlog.String("teamID", teamID),
 			mlog.Stringer("remoteAddr", listener.conn.RemoteAddr()),
 		)
@@ -624,21 +624,17 @@ func (ws *Server) BroadcastCategoryBoardsReorder(teamID, userID, categoryID stri
 		TeamID:     teamID,
 	}
 
-	listeners := ws.getListenersForTeam(teamID)
-	ws.logger.Debug("listener(s) for teamID",
-		mlog.Int("listener_count", len(listeners)),
-		mlog.String("teamID", teamID),
-	)
-
-	for _, listener := range listeners {
+	listener := ws.getListenerForUser(teamID, userID)
+	if listener != nil {
 		ws.logger.Debug("Broadcast board category order change",
-			mlog.Int("listener_count", len(listeners)),
+			mlog.String("userID", userID),
 			mlog.String("teamID", teamID),
+			mlog.String("categoryID", categoryID),
 			mlog.Stringer("remoteAddr", listener.conn.RemoteAddr()),
 		)
 
 		if err := listener.WriteJSON(message); err != nil {
-			ws.logger.Error("broadcast category order change error", mlog.Err(err))
+			ws.logger.Error("broadcast category boards order change error", mlog.Err(err))
 			listener.conn.Close()
 		}
 	}
@@ -651,16 +647,10 @@ func (ws *Server) BroadcastCategoryBoardChange(teamID, userID string, boardCateg
 		BoardCategories: boardCategories,
 	}
 
-	listeners := ws.getListenersForTeam(teamID)
-	ws.logger.Debug("listener(s) for teamID",
-		mlog.Int("listener_count", len(listeners)),
-		mlog.String("teamID", teamID),
-		mlog.Int("numEntries", len(boardCategories)),
-	)
-
-	for _, listener := range listeners {
-		ws.logger.Debug("Broadcast block change",
-			mlog.Int("listener_count", len(listeners)),
+	listener := ws.getListenerForUser(teamID, userID)
+	if listener != nil {
+		ws.logger.Debug("Broadcast category board change",
+			mlog.String("userID", userID),
 			mlog.String("teamID", teamID),
 			mlog.Int("numEntries", len(boardCategories)),
 			mlog.Stringer("remoteAddr", listener.conn.RemoteAddr()),

--- a/server/ws/server.go
+++ b/server/ws/server.go
@@ -465,12 +465,6 @@ func (ws *Server) getListenersForBlock(blockID string) []*websocketSession {
 	return ws.listenersByBlock[blockID]
 }
 
-// getListenersForTeam returns the listeners subscribed to a
-// team changes.
-func (ws *Server) getListenersForTeam(teamID string) []*websocketSession {
-	return ws.listenersByTeam[teamID]
-}
-
 // getListenersForUser returns the listener for a user subscribed to a
 // team changes.
 func (ws *Server) getListenerForUser(teamID, userID string) *websocketSession {

--- a/server/ws/server.go
+++ b/server/ws/server.go
@@ -465,6 +465,12 @@ func (ws *Server) getListenersForBlock(blockID string) []*websocketSession {
 	return ws.listenersByBlock[blockID]
 }
 
+// getListenersForTeam returns the listeners subscribed to a
+// team changes.
+func (ws *Server) getListenersForTeam(teamID string) []*websocketSession {
+	return ws.listenersByTeam[teamID]
+}
+
 // getListenersForUser returns the listener for a user subscribed to a
 // team changes.
 func (ws *Server) getListenerForUser(teamID, userID string) *websocketSession {

--- a/server/ws/server_test.go
+++ b/server/ws/server_test.go
@@ -101,6 +101,46 @@ func TestTeamSubscription(t *testing.T) {
 		require.Empty(t, server.listenersByTeam[teamID])
 		require.Empty(t, server.listenersByTeam[teamID2])
 	})
+
+	t.Run("Subscribe users to team retrieve by user", func(t *testing.T) {
+		userID1 := "fake-user-id"
+		userSession1 := &websocketSession{
+			conn:   &websocket.Conn{},
+			mu:     sync.Mutex{},
+			userID: userID1,
+			teams:  []string{},
+			blocks: []string{},
+		}
+		userID2 := "fake-user-id2"
+		userSession2 := &websocketSession{
+			conn:   &websocket.Conn{},
+			mu:     sync.Mutex{},
+			userID: userID2,
+			teams:  []string{},
+			blocks: []string{},
+		}
+		teamID := "fake-team-id"
+
+		server.addListener(session)
+		server.subscribeListenerToTeam(session, teamID)
+		server.addListener(userSession1)
+		server.subscribeListenerToTeam(userSession1, teamID)
+		server.addListener(userSession2)
+		server.subscribeListenerToTeam(userSession2, teamID)
+
+		require.Len(t, server.listeners, 3)
+		require.Len(t, server.listenersByTeam[teamID], 3)
+
+		require.Len(t, server.getListenerForUser(teamID, userID1), 1)
+
+		server.removeListener(session)
+		server.removeListener(userSession1)
+		server.removeListener(userSession2)
+
+		require.Empty(t, server.listeners)
+		require.Empty(t, server.listenersByTeam[teamID])
+		require.Empty(t, server.getListenerForUser(teamID, userID1))
+	})
 }
 
 func TestBlocksSubscription(t *testing.T) {

--- a/server/ws/server_test.go
+++ b/server/ws/server_test.go
@@ -131,7 +131,9 @@ func TestTeamSubscription(t *testing.T) {
 		require.Len(t, server.listeners, 3)
 		require.Len(t, server.listenersByTeam[teamID], 3)
 
-		require.Len(t, server.getListenerForUser(teamID, userID1), 1)
+		listener := server.getListenerForUser(teamID, userID1)
+		require.NotNil(t, listener)
+		require.Equal(t, listener.userID, userID1)
 
 		server.removeListener(session)
 		server.removeListener(userSession1)


### PR DESCRIPTION

#### Summary
Fixes issue where an update from one user causes cascading updates back and forth. Fix is to only send Category/CategoryBoards update to user. Categories are now individual, not teams.

#### Ticket Link
  Fixes https://github.com/mattermost/focalboard/issues/4644
