### PR TITLE
Avoid panic in file request handler on error

### DIFF
--- a/server/api/files.go
+++ b/server/api/files.go
@@ -19,6 +19,7 @@ import (
 	"github.com/mattermost/focalboard/server/model"
 
 	"github.com/mattermost/focalboard/server/services/audit"
+
 	mmModel "github.com/mattermost/mattermost-server/v6/model"
 
 	"github.com/mattermost/mattermost-server/v6/shared/mlog"
@@ -167,7 +168,14 @@ func (a *API) handleServeFile(w http.ResponseWriter, r *http.Request) {
 		_ = a.app.MoveFile(board.ChannelID, board.TeamID, boardID, filename)
 	}
 
+	if err != nil {
+		// if err is still not nil then it is an error other than `not found` so we must
+		// return the error to the requestor.  fileReader and Fileinfo are nil in this case.
+		a.errorResponse(w, r, err)
+	}
+
 	defer fileReader.Close()
+
 	mimeType := ""
 	var fileSize int64
 	if fileInfo != nil {


### PR DESCRIPTION
#### Summary
This PR fixes a panic in the Boards Rest API for fetching files.  It panics if the `app.getFile` call returns an error other than `not found`.

The panic is caught and handled, but it is logged and thus is [reported by customers](https://community.mattermost.com/private-core/pl/pqnrooyqj3b9fcz7ktq46rkshr) as a crash.  It also returns the wrong error to the client.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-51885

Fixes https://github.com/mattermost/focalboard/issues/4691

#### Release Note
```release-note
Fixes an innocuous panic in Boards Rest API when requesting files and a error other than `not found` is encountered.
```
