### PR TITLE
Backport: MM-51842: fix value-change detection in number properties

### DIFF
--- a/webapp/src/properties/number/__snapshots__/number.test.tsx.snap
+++ b/webapp/src/properties/number/__snapshots__/number.test.tsx.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`properties/link should match snapshot for number with empty value 1`] = `
+<div>
+  <input
+    class="Editable octo-propertyvalue"
+    placeholder=""
+    style="width: 100%;"
+    title=""
+    value=""
+  />
+</div>
+`;

--- a/webapp/src/properties/number/number.test.tsx
+++ b/webapp/src/properties/number/number.test.tsx
@@ -1,0 +1,72 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React, {ComponentProps} from 'react'
+import {render, screen} from '@testing-library/react'
+import {mocked} from 'jest-mock'
+
+import userEvent from '@testing-library/user-event'
+
+import {wrapIntl} from '../../testUtils'
+import {TestBlockFactory} from '../../test/testBlockFactory'
+import mutator from '../../mutator'
+
+import {Board, IPropertyTemplate} from '../..//blocks/board'
+import {Card} from '../../blocks/card'
+
+import NumberProperty from './property'
+import NumberEditor from './number'
+
+jest.mock('../../components/flashMessages')
+jest.mock('../../mutator')
+
+const mockedMutator = mocked(mutator)
+
+describe('properties/link', () => {
+    let board: Board
+    let card: Card
+    let propertyTemplate: IPropertyTemplate
+    let baseProps: ComponentProps<typeof NumberEditor>
+
+    beforeEach(() => {
+        board = TestBlockFactory.createBoard()
+        card = TestBlockFactory.createCard()
+        propertyTemplate = board.cardProperties[0]
+
+        baseProps = {
+            property: new NumberProperty(),
+            card,
+            board,
+            propertyTemplate,
+            propertyValue: '',
+            readOnly: false,
+            showEmptyPlaceholder: false,
+        }
+    })
+
+    it('should match snapshot for number with empty value', () => {
+        const {container} = render(
+            wrapIntl((
+                <NumberEditor
+                    {...baseProps}
+                />
+            )),
+        )
+        expect(container).toMatchSnapshot()
+    })
+
+    it('should fire change event when valid number value is entered', async () => {
+        render(
+            wrapIntl(
+                <NumberEditor
+                    {...baseProps}
+                />,
+            ),
+        )
+        const value = '42'
+        const input = screen.getByRole('textbox')
+        userEvent.type(input, `${value}{Enter}`)
+
+        expect(mockedMutator.changePropertyValue).toHaveBeenCalledWith(board.id, card, propertyTemplate.id, `${value}`)
+    })
+})

--- a/webapp/src/properties/number/number.tsx
+++ b/webapp/src/properties/number/number.tsx
@@ -10,7 +10,7 @@ const Number = (props: PropertyProps): JSX.Element => {
     return (
         <BaseTextEditor
             {...props}
-            validator={() => !isNaN(parseInt(props.propertyValue as string, 10))}
+            validator={() => props.propertyValue === '' || !isNaN(parseInt(props.propertyValue as string, 10))}
         />
     )
 }


### PR DESCRIPTION
#### Summary
Fixes Number property value validator to accept empty values. This allows save/change mechanisms to work property when creating/editing cards.

<details>
<summary>Screenshots</summary>

##### Fixed
https://user-images.githubusercontent.com/11724372/229595205-d72b1bb5-a756-4911-9eb6-3bb585ae0da6.mp4

##### Bug
https://user-images.githubusercontent.com/11724372/229595210-e745a685-c84b-422b-bcd4-71a904620b79.mp4

</details>

#### Related Pull Requests
- https://github.com/mattermost/mattermost-server/pull/22795

#### Ticket Link
- Fixes https://mattermost.atlassian.net/browse/MM-51842
- Fixes https://github.com/mattermost/focalboard/issues/4659
