### PR TITLE
Show assignee properly in dark mode

### DIFF
--- a/webapp/src/components/personSelector.tsx
+++ b/webapp/src/components/personSelector.tsx
@@ -60,6 +60,7 @@ const selectStyles = {
         position: 'static',
         top: 'unset',
         transform: 'unset',
+        color: 'rgb(var(--center-channel-color-rgb))',
     }),
     menu: (provided: CSSObject): CSSObject => ({
         ...provided,


### PR DESCRIPTION


#### Summary
This will fix the color of the text of assignee field of tasks in dark theme.
#### Ticket Link

  Fixes https://github.com/mattermost/focalboard/issues/4621

