### PR TITLE
Max width for tooltip is disabled ...

### DIFF
--- a/webapp/src/widgets/tooltip.scss
+++ b/webapp/src/widgets/tooltip.scss
@@ -22,10 +22,7 @@ $tooltop-vertical-offset: 2px;
     text-shadow: rgba(0, 0, 0, 0.098) 1px 1px 1px;
     box-shadow: rgba(0, 0, 0, 0.1) 1px 1px 2px 0;
     min-width: 2em;
-    max-width: 21em;
     white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
     display: block;
 }
 
@@ -102,8 +99,6 @@ $tooltop-vertical-offset: 2px;
     }
     // Bottom tooltip body style
     &.tooltip-bottom:hover::after {
-        left: 50%;
         top: calc(100% + 4px);
-        transform: translate(-50%, -#{$tooltop-horizontal-offset});
     }
 }


### PR DESCRIPTION
So users could read long file names when hovering on it.
- Tooltip position is changed. New position starts in accordance with file's name
![Peek 2023-04-10 00-08](https://user-images.githubusercontent.com/39624400/230796671-e2a57bb4-2d01-4398-84ec-15c014a247b7.gif)



#### Summary
Fixes shortened long filename scenario on attachments.
Fixes position according to replies on issue thread.

#### Ticket Link


  Fixes https://github.com/mattermost/focalboard/issues/4433


