### PR TITLE
Hide horizontal scrollbar during some  board templates

### DIFF
--- a/webapp/src/components/table/table.scss
+++ b/webapp/src/components/table/table.scss
@@ -3,7 +3,7 @@
 .Table {
     margin-top: 16px;
     margin-left: 0 !important;
-    overflow: auto;
+    overflow: hidden;
     position: relative;
     flex: 1;
 


### PR DESCRIPTION


#### Summary
Overflow of table selector is changed from...
auto to hidden so that users wont see horizontal scroll bar during new template.

#### Ticket Link

  Fixes https://github.com/mattermost/focalboard/issues/4255

