### PR TITLE
Adds a retry count to the websocket re-open flow

### DIFF
--- a/webapp/src/wsclient.ts
+++ b/webapp/src/wsclient.ts
@@ -127,6 +127,8 @@ class WSClient {
     onUnfollowBlock: FollowChangeHandler = () => {}
     private notificationDelay = 100
     private reopenDelay = 3000
+    private reopenRetryCount = 0
+    private reopenMaxRetries = 10
     private updatedData: UpdatedData = {Blocks: [], Categories: [], BoardCategories: [], Boards: [], BoardMembers: [], CategoryOrder: []}
     private updateTimeout?: NodeJS.Timeout
     private errorPollId?: NodeJS.Timeout
@@ -400,6 +402,7 @@ class WSClient {
         ws.onopen = () => {
             Utils.log('WSClient webSocket opened.')
             this.state = 'open'
+            this.reopenRetryCount = 0
 
             // if has a token defined when connecting, authenticate
             if (this.token) {
@@ -426,19 +429,25 @@ class WSClient {
             Utils.log(`WSClient websocket onclose, code: ${e.code}, reason: ${e.reason}`)
             if (ws === this.ws) {
                 // Unexpected close, re-open
-                Utils.logError('Unexpected close, re-opening websocket')
+                Utils.logError(`Unexpected WSClient close`)
                 for (const handler of this.onStateChange) {
                     handler(this, 'close')
                 }
                 this.state = 'close'
-                setTimeout(() => {
-                    // ToDo: assert that this actually runs the onopen
-                    // contents (auth + this.subscribe())
-                    this.open()
-                    for (const handler of this.onReconnect) {
-                        handler(this)
-                    }
-                }, this.reopenDelay)
+
+                if (this.reopenRetryCount < this.reopenMaxRetries) {
+                    setTimeout(() => {
+                        this.reopenRetryCount++
+                        Utils.log(`Reopening websocket connection, count: ${this.reopenRetryCount}`)
+
+                        this.open()
+                        for (const handler of this.onReconnect) {
+                            handler(this)
+                        }
+                    }, this.reopenDelay)
+                } else {
+                    Utils.logError('Reached max websocket re-opening attempts')
+                }
             }
         }
 

--- a/webapp/src/wsclient.ts
+++ b/webapp/src/wsclient.ts
@@ -429,7 +429,7 @@ class WSClient {
             Utils.log(`WSClient websocket onclose, code: ${e.code}, reason: ${e.reason}`)
             if (ws === this.ws) {
                 // Unexpected close, re-open
-                Utils.logError(`Unexpected WSClient close`)
+                Utils.logError('Unexpected WSClient close')
                 for (const handler of this.onStateChange) {
                     handler(this, 'close')
                 }


### PR DESCRIPTION
#### Summary
Adds a reconnection retry count to the websocket client for Personal Server and Personal Desktop. Product client builds on top of the main Mattermost websockets client, so it doesn't require of any change.

#### Ticket Link
https://github.com/mattermost/focalboard/issues/4632
