### PR TITLE
Fix public boards setting not applying properly

### DIFF
--- a/server/auth/auth.go
+++ b/server/auth/auth.go
@@ -54,6 +54,10 @@ func (a *Auth) IsValidReadToken(boardID string, readToken string) (bool, error) 
 		return false, err
 	}
 
+	if !a.config.EnablePublicSharedBoards {
+		return false, errors.New("public shared boards disabled")
+	}
+
 	if sharing != nil && (sharing.ID == boardID && sharing.Enabled && sharing.Token == readToken) {
 		return true, nil
 	}

--- a/server/integrationtests/permissions_test.go
+++ b/server/integrationtests/permissions_test.go
@@ -581,6 +581,35 @@ func TestPermissionsGetBoard(t *testing.T) {
 	})
 }
 
+func TestPermissionsGetBoardPublic(t *testing.T) {
+	ttCases := []TestCase{
+		{"/boards/{PRIVATE_BOARD_ID}?read_token=invalid", methodGet, "", userAnon, http.StatusUnauthorized, 0},
+		{"/boards/{PRIVATE_BOARD_ID}?read_token=valid", methodGet, "", userAnon, http.StatusUnauthorized, 1},
+		{"/boards/{PRIVATE_BOARD_ID}?read_token=invalid", methodGet, "", userNoTeamMember, http.StatusForbidden, 0},
+		{"/boards/{PRIVATE_BOARD_ID}?read_token=valid", methodGet, "", userTeamMember, http.StatusForbidden, 1},
+	}
+	t.Run("plugin", func(t *testing.T) {
+		th := SetupTestHelperPluginMode(t)
+		defer th.TearDown()
+		cfg := th.Server.Config()
+		cfg.EnablePublicSharedBoards = false
+		th.Server.UpdateAppConfig()
+		clients := setupClients(th)
+		testData := setupData(t, th)
+		runTestCases(t, ttCases, testData, clients)
+	})
+	t.Run("local", func(t *testing.T) {
+		th := SetupTestHelperLocalMode(t)
+		defer th.TearDown()
+		cfg := th.Server.Config()
+		cfg.EnablePublicSharedBoards = false
+		th.Server.UpdateAppConfig()
+		clients := setupLocalClients(th)
+		testData := setupData(t, th)
+		runTestCases(t, ttCases, testData, clients)
+	})
+}
+
 func TestPermissionsPatchBoard(t *testing.T) {
 	ttCases := []TestCase{
 		{"/boards/{PRIVATE_BOARD_ID}", methodPatch, "{\"title\": \"test\"}", userAnon, http.StatusUnauthorized, 0},


### PR DESCRIPTION
Backport of https://github.com/mattermost/mattermost-server/pull/22921

#### Summary

The public boards setting was not applied properly. This fixes it so the setting will now apply to existing board links.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-51820

```release-note
NONE
```
