### PR TITLE
Update ubuntu version to use latest LTS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ env:
 jobs:
 
   ci-ubuntu-server:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     strategy:
       matrix:
@@ -39,7 +39,7 @@ jobs:
       run: cd focalboard; make server-test-${{matrix['db']}}
 
   ci-ubuntu-webapp:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - name: Checkout
       uses: actions/checkout@v3

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -17,7 +17,7 @@ jobs:
     permissions:
       security-events: write  # for github/codeql-action/autobuild to send a status report
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     strategy:
       fail-fast: false

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -14,7 +14,7 @@ env:
 jobs:
 
   ubuntu:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
       with:
@@ -172,7 +172,7 @@ jobs:
         path: ${{ github.workspace }}/focalboard/win-wpf/dist/focalboard-win.zip
 
   plugin:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/lint-server.yml
+++ b/.github/workflows/lint-server.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   down-migrations:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
         with:
@@ -26,7 +26,7 @@ jobs:
 
   golangci:
     name: plugin
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/setup-go@v3
         with:

--- a/.github/workflows/prod-release.yml
+++ b/.github/workflows/prod-release.yml
@@ -9,7 +9,7 @@ env:
 jobs:
 
   ubuntu:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
     - name: Checkout
@@ -171,7 +171,7 @@ jobs:
         path: ${{ github.workspace }}/focalboard/win-wpf/dist/focalboard-win.zip
 
   plugin-release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
     - name: Checkout

--- a/.github/workflows/scorecards-analysis.yml
+++ b/.github/workflows/scorecards-analysis.yml
@@ -13,7 +13,7 @@ permissions: read-all
 jobs:
   analysis:
     name: Scorecards analysis
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     permissions:
       # Needed to upload the results to code-scanning dashboard.
       security-events: write


### PR DESCRIPTION
#### Summary
This PR updates the CI image from `ubuntu-latest` to `ubuntu-20.04` to compile pinning the latest LTS.

We should probably cherry-pick to `v7.11` and `v7.10`