### PR TITLE
Filter the fileinfo deletion query on block child deletion

### DIFF
--- a/server/services/store/sqlstore/blocks.go
+++ b/server/services/store/sqlstore/blocks.go
@@ -968,6 +968,10 @@ func (s *SQLStore) deleteBlockChildren(db sq.BaseRunner, boardID string, parentI
 		From(s.tablePrefix + "blocks").
 		Where(sq.Eq{"board_id": boardID})
 
+	if parentID != "" {
+		fileDeleteQuery = fileDeleteQuery.Where(sq.Eq{"parent_id": parentID})
+	}
+
 	rows, err := fileDeleteQuery.Query()
 	if err != nil {
 		return err


### PR DESCRIPTION
#### Summary
Adds the `parent_id` filter to the query that fetches the blocks to get `fileId`s and `attachmentId`s and prevents soft deleting more `FileInfo`s than intended.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-53713
