### PR TITLE
MM-41813 Fix path to fonts loaded by plugin

### DIFF
--- a/mattermost-plugin/webapp/webpack.config.js
+++ b/mattermost-plugin/webapp/webpack.config.js
@@ -112,11 +112,19 @@ const config = {
                 exclude: [/node_modules/],
             },
             {
-                test: /\.(png|eot|tiff|svg|woff2|woff|ttf|jpg|gif)$/,
+                test: /\.(png|eot|tiff|svg|ttf|jpg|gif)$/,
                 type: 'asset/resource',
                 generator: {
                     filename: '[name][ext]',
                     publicPath: TARGET_IS_PRODUCT ? undefined : '/static/',
+                }
+            },
+            {
+                test: /\.(woff2|woff)$/,
+                type: 'asset/resource',
+                generator: {
+                    filename: '[name][ext]',
+                    publicPath: TARGET_IS_PRODUCT ? undefined : '/plugins/focalboard/static/',
                 }
             },
         ],


### PR DESCRIPTION
#### Summary
The Boards plugin has been trying to load the fonts that it packages from the wrong place for a while now. These fonts aren't actually necessary because the MM web app also loads the same fonts from a different location (`/static/<some-hash>.woff2`), but I figured it would be less likely to break something if I fixed that instead of removing the CSS that includes that font file.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-41813
