### PR TITLE
fixed Bug：After deleting a board, using the undo feature would redire…

### DIFF
--- a/webapp/src/mutator.ts
+++ b/webapp/src/mutator.ts
@@ -224,8 +224,8 @@ class Mutator {
                 await afterRedo?.(board)
             },
             async () => {
-                await beforeUndo?.(board)
                 await octoClient.undeleteBoard(board.id)
+                await beforeUndo?.(board)
             },
             description,
             this.undoGroupId,


### PR DESCRIPTION
#### Summary
<!--
After deleting a board, using the undo feature would redirect to an error page displaying "board-not-found." After reviewing the code, I swapped the order of the undo operation in the deleteBoard function, ensuring that the server data is updated first before redirecting to the page. This change allows for undoing board deletion without encountering an error.
-->

