### PR TITLE
MM-54366 Check guest access to other members

### DIFF
--- a/server/api/users.go
+++ b/server/api/users.go
@@ -93,15 +93,25 @@ func (a *API) handleGetUsersList(w http.ResponseWriter, r *http.Request) {
 	session := ctx.Value(sessionContextKey).(*model.Session)
 	isSystemAdmin := a.permissions.HasPermissionTo(session.UserID, model.PermissionManageSystem)
 
+	sanitizedUsers := make([]*model.User, 0)
 	for _, user := range users {
+		canSeeUser, err := a.app.CanSeeUser(session.UserID, user.ID)
+		if err != nil {
+			a.errorResponse(w, r, err)
+			return
+		}
+		if !canSeeUser {
+			continue
+		}
 		if user.ID == session.UserID {
 			user.Sanitize(map[string]bool{})
 		} else {
 			a.app.SanitizeProfile(user, isSystemAdmin)
 		}
+		sanitizedUsers = append(sanitizedUsers, user)
 	}
 
-	usersList, err := json.Marshal(users)
+	usersList, err := json.Marshal(sanitizedUsers)
 	if err != nil {
 		a.errorResponse(w, r, err)
 		return

--- a/server/api/users.go
+++ b/server/api/users.go
@@ -95,9 +95,9 @@ func (a *API) handleGetUsersList(w http.ResponseWriter, r *http.Request) {
 
 	sanitizedUsers := make([]*model.User, 0)
 	for _, user := range users {
-		canSeeUser, err := a.app.CanSeeUser(session.UserID, user.ID)
-		if err != nil {
-			a.errorResponse(w, r, err)
+		canSeeUser, err2 := a.app.CanSeeUser(session.UserID, user.ID)
+		if err2 != nil {
+			a.errorResponse(w, r, err2)
 			return
 		}
 		if !canSeeUser {

--- a/server/client/client.go
+++ b/server/client/client.go
@@ -634,6 +634,26 @@ func (c *Client) GetUser(id string) (*model.User, *Response) {
 	return user, BuildResponse(r)
 }
 
+func (c *Client) GetUserList(ids []string) ([]model.User, *Response) {
+	r, err := c.DoAPIPost("/users", toJSON(ids))
+	if err != nil {
+		return nil, BuildErrorResponse(r, err)
+	}
+	defer closeBody(r)
+
+	requestBody, err := io.ReadAll(r.Body)
+	if err != nil {
+		return nil, BuildErrorResponse(r, err)
+	}
+
+	var users []model.User
+	err = json.Unmarshal(requestBody, &users)
+	if err != nil {
+		return nil, BuildErrorResponse(r, err)
+	}
+	return users, BuildResponse(r)
+}
+
 func (c *Client) GetUserChangePasswordRoute(id string) string {
 	return fmt.Sprintf("/users/%s/changepassword", id)
 }

--- a/server/integrationtests/pluginteststore.go
+++ b/server/integrationtests/pluginteststore.go
@@ -127,6 +127,17 @@ func (s *PluginTestStore) GetUserByID(userID string) (*model.User, error) {
 	return user, nil
 }
 
+func (s *PluginTestStore) GetUsersList(userIDs []string, showEmail, showName bool) ([]*model.User, error) {
+	var users []*model.User
+	for _, id := range userIDs {
+		user := s.users[id]
+		if user != nil {
+			users = append(users, user)
+		}
+	}
+	return users, nil
+}
+
 func (s *PluginTestStore) GetUserByEmail(email string) (*model.User, error) {
 	for _, user := range s.users {
 		if user.Email == email {

--- a/server/services/store/mattermostauthlayer/mattermostauthlayer.go
+++ b/server/services/store/mattermostauthlayer/mattermostauthlayer.go
@@ -1297,17 +1297,16 @@ func (s *MattermostAuthLayer) CanSeeUser(seerID string, seenID string) (bool, er
 
 	query := s.getQueryBuilder().
 		Select("1").
-		From(s.tablePrefix + "board_members AS BM1").
-		Join(s.tablePrefix + "board_members AS BM2 ON BM1.BoardID=BM2.BoardID").
-		LeftJoin("Bots b ON ( b.UserId = u.id )").
+		From(s.tablePrefix + "board_members AS bm1").
+		Join(s.tablePrefix + "board_members AS bm2 ON bm1.board_id=bm2.board_id").
 		Where(sq.Or{
 			sq.And{
-				sq.Eq{"BM1.UserID": seerID},
-				sq.Eq{"BM2.UserID": seenID},
+				sq.Eq{"bm1.user_id": seerID},
+				sq.Eq{"bm2.user_id": seenID},
 			},
 			sq.And{
-				sq.Eq{"BM1.UserID": seenID},
-				sq.Eq{"BM2.UserID": seerID},
+				sq.Eq{"bm1.user_id": seenID},
+				sq.Eq{"bm2.user_id": seerID},
 			},
 		}).Limit(1)
 
@@ -1323,17 +1322,16 @@ func (s *MattermostAuthLayer) CanSeeUser(seerID string, seenID string) (bool, er
 
 	query = s.getQueryBuilder().
 		Select("1").
-		From("ChannelMembers AS CM1").
-		Join("ChannelMembers AS CM2 ON CM1.BoardID=CM2.BoardID").
-		LeftJoin("Bots b ON ( b.UserId = u.id )").
+		From("channelmembers AS cm1").
+		Join("channelmembers AS cm2 ON cm1.channelid=cm2.channelid").
 		Where(sq.Or{
 			sq.And{
-				sq.Eq{"CM1.UserID": seerID},
-				sq.Eq{"CM2.UserID": seenID},
+				sq.Eq{"cm1.userid": seerID},
+				sq.Eq{"cm2.userid": seenID},
 			},
 			sq.And{
-				sq.Eq{"CM1.UserID": seenID},
-				sq.Eq{"CM2.UserID": seerID},
+				sq.Eq{"cm1.userid": seenID},
+				sq.Eq{"cm2.userid": seerID},
 			},
 		}).Limit(1)
 


### PR DESCRIPTION
#### Summary
Guests should only have access to other members if they are both members of the same channel or board. This PR enforces that on the '/user' post endpoint. Also required fixing queries.

#### Ticket Link

  Fixes https://mattermost.atlassian.net/browse/MM-54366
