### PR TITLE
Replace a non-semantic JSX child in one of the test files with an empty fragment

### DIFF
--- a/webapp/src/components/kanban/kanbanColumn.test.tsx
+++ b/webapp/src/components/kanban/kanbanColumn.test.tsx
@@ -12,7 +12,7 @@ describe('src/components/kanban/kanbanColumn', () => {
             <KanbanColumn
                 onDrop={jest.fn()}
             >
-                {}
+                <></>
             </KanbanColumn>,
         ))
         expect(container).toMatchSnapshot()


### PR DESCRIPTION
#### Summary

this was done in preparation for TS 5.3 since a bug was fixed by https://github.com/microsoft/TypeScript/pull/55981 and this repo is "affected" by this fix (this was found by the bot [here](https://github.com/microsoft/TypeScript/issues/56032#issuecomment-1752146385))
