### PR TITLE
prevent ModifiedBy overwrite

### DIFF
--- a/server/app/import.go
+++ b/server/app/import.go
@@ -200,7 +200,9 @@ func (a *App) ImportBoardJSONL(r io.Reader, opt model.ImportArchiveOptions) (*mo
 					if err2 := json.Unmarshal(archiveLine.Data, &board); err2 != nil {
 						return nil, fmt.Errorf("invalid board in archive line %d: %w", lineNum, err2)
 					}
-					board.ModifiedBy = userID
+					if board.ModifiedBy == "" {
+						board.ModifiedBy = userID
+					}
 					board.UpdateAt = now
 					board.TeamID = opt.TeamID
 					boardsAndBlocks.Boards = append(boardsAndBlocks.Boards, &board)
@@ -224,7 +226,9 @@ func (a *App) ImportBoardJSONL(r io.Reader, opt model.ImportArchiveOptions) (*mo
 					if err2 := json.Unmarshal(archiveLine.Data, &block); err2 != nil {
 						return nil, fmt.Errorf("invalid block in archive line %d: %w", lineNum, err2)
 					}
-					block.ModifiedBy = userID
+					if block.ModifiedBy == "" {
+						block.ModifiedBy = userID
+					}
 					block.UpdateAt = now
 					block.BoardID = boardID
 					boardsAndBlocks.Blocks = append(boardsAndBlocks.Blocks, block)


### PR DESCRIPTION
#### Summary
This pull request introduces a fix to ensure that the ModifiedBy field is not overwritten if it already contains a userID. We added a conditional check to verify if the ModifiedBy field is empty before assigning a new userID, enhancing the data integrity of the block modification tracking.

By default the system uses default userID from person, who is importing data. If board.jsonl is already filled with existing IDs from current board or mattermost instance, we should accept it, not overwrite.

#### Ticket Link
https://community.mattermost.com/core/pl/7x9n4kfy4pbdxphsnuhtoodqxy
