### PR TITLE
MM-52722: Fixed error when accessing property on undefined

### DIFF
--- a/webapp/src/components/live-markdown-plugin/liveMarkdownPlugin.ts
+++ b/webapp/src/components/live-markdown-plugin/liveMarkdownPlugin.ts
@@ -180,7 +180,7 @@ const maintainInlineStyles = (
 
     // If enter was pressed (or the block was otherwise split) we must maintain
     // styles in the previous block as well
-    if (lastChangeType === 'split-block') {
+    if (lastChangeType === 'split-block' && contentState.getBlockBefore(blockKey) !== undefined) {
         const newPrevBlock = mapInlineStyles(
             contentState.getBlockBefore(blockKey)!,
             inlineStyleStrategies,


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute

Assign two reviewers for this pull request from the names suggested. If no names are suggested or you are not sure who to assign, set `Core Focalboard` as the reviewer.
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the ticket).
-->
The red JavaScript banner was due an error that was occurring when a property was trying to be accessed on undefined. This undefined value occurs only when empty lines are given in the comments box. Therefore, placed a check to not do this if there are no text values in the comment box. 

Testing:
check the following issue link to follow the steps to reproduce: https://github.com/mattermost/focalboard/issues/4831
Also, do a basic sanity test to see if the comment box functionality is working as expected. 

#### Ticket Link
<!--
If this pull request addresses a Github issue, please link the relevant issue, e.g.

  Fixes https://github.com/mattermost/focalboard/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://github.com/mattermost/focalboard/issues/4831
https://mattermost.atlassian.net/browse/MM-52722
