### PR TITLE
Added deploy template for RepoCloud.io to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,10 @@ You can build standalone apps that package the server to run locally against SQL
 
 Cross-compilation currently isn't fully supported, so please build on the appropriate platform. Refer to the GitHub Actions workflows (`build-mac.yml`, `build-win.yml`, `build-ubuntu.yml`) for the detailed list of steps on each platform.
 
+### One Click Deployment Options (Third-Party)
+
+[![Deploy on RepoCloud](https://d16t0pc4846x52.cloudfront.net/deploy.png)](https://repocloud.io/details/?app_id=33)
+
 ### Unit testing
 
 Before checking in commits, run `make ci`, which is similar to the `.gitlab-ci.yml` workflow and includes:


### PR DESCRIPTION
Integration with RepoCloud Deploy Template to the Focalboard GitHub page, enabling one-click deployment. This addition simplifies the process for users to quickly deploy and scale Focalboard using RepoCloud's efficient cloud hosting services. 

TOA form completed.

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute

Assign two reviewers for this pull request from the names suggested. If no names are suggested or you are not sure who to assign, set `Core Focalboard` as the reviewer.
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the ticket).
-->

#### Ticket Link
<!--
If this pull request addresses a Github issue, please link the relevant issue, e.g.

  Fixes https://github.com/mattermost/focalboard/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
