### PR TITLE
Update to version 8.0

### DIFF
--- a/mattermost-plugin/plugin.json
+++ b/mattermost-plugin/plugin.json
@@ -6,7 +6,7 @@
     "support_url": "https://github.com/mattermost/focalboard/issues",
     "release_notes_url": "https://github.com/mattermost/focalboard/releases",
     "icon_path": "assets/starter-template-icon.svg",
-    "version": "7.12.0",
+    "version": "8.0.0",
     "min_server_version": "7.2.0",
     "server": {
         "executables": {

--- a/mattermost-plugin/server/manifest.go
+++ b/mattermost-plugin/server/manifest.go
@@ -20,7 +20,7 @@ const manifestStr = `
   "support_url": "https://github.com/mattermost/focalboard/issues",
   "release_notes_url": "https://github.com/mattermost/focalboard/releases",
   "icon_path": "assets/starter-template-icon.svg",
-  "version": "7.12.0",
+  "version": "8.0.0",
   "min_server_version": "7.2.0",
   "server": {
     "executables": {

--- a/server/model/version.go
+++ b/server/model/version.go
@@ -8,6 +8,7 @@ import (
 // It should be maintained in chronological order with most current
 // release at the front of the list.
 var versions = []string{
+	"8.0.0",
 	"7.12.0",
 	"7.11.1",
 	"7.11.0",

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "focalboard",
-			"version": "7.12.0",
+			"version": "8.0.0",
 			"dependencies": {
 				"@draft-js-plugins/editor": "^4.1.2",
 				"@draft-js-plugins/emoji": "^4.6.0",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "focalboard",
-	"version": "7.12.0",
+	"version": "8.0.0",
 	"private": true,
 	"description": "",
 	"scripts": {

--- a/webapp/src/components/globalHeader/__snapshots__/globalHeader.test.tsx.snap
+++ b/webapp/src/components/globalHeader/__snapshots__/globalHeader.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`components/sidebar/GlobalHeader header menu should match snapshot 1`] =
     />
     <a
       class="GlobalHeaderComponent__button help-button"
-      href="https://www.focalboard.com/fwlink/doc-boards.html?v=7.12.0"
+      href="https://www.focalboard.com/fwlink/doc-boards.html?v=8.0.0"
       rel="noreferrer"
       target="_blank"
     >

--- a/webapp/src/components/sidebar/__snapshots__/sidebar.test.tsx.snap
+++ b/webapp/src/components/sidebar/__snapshots__/sidebar.test.tsx.snap
@@ -51,9 +51,9 @@ exports[`components/sidebarSidebar dont show hidden boards 1`] = `
                   >
                     <div
                       class="version"
-                      title="v7.12.0"
+                      title="v8.0.0"
                     >
-                      v7.12.0
+                      v8.0.0
                     </div>
                   </div>
                 </div>
@@ -252,9 +252,9 @@ exports[`components/sidebarSidebar should assign default category if current boa
                   >
                     <div
                       class="version"
-                      title="v7.12.0"
+                      title="v8.0.0"
                     >
-                      v7.12.0
+                      v8.0.0
                     </div>
                   </div>
                 </div>
@@ -508,9 +508,9 @@ exports[`components/sidebarSidebar shouldnt do any category assignment is board 
                   >
                     <div
                       class="version"
-                      title="v7.12.0"
+                      title="v8.0.0"
                     >
-                      v7.12.0
+                      v8.0.0
                     </div>
                   </div>
                 </div>
@@ -919,9 +919,9 @@ exports[`components/sidebarSidebar sidebar hidden 1`] = `
                   >
                     <div
                       class="version"
-                      title="v7.12.0"
+                      title="v8.0.0"
                     >
-                      v7.12.0
+                      v8.0.0
                     </div>
                   </div>
                 </div>
@@ -1213,9 +1213,9 @@ exports[`components/sidebarSidebar some categories hidden 1`] = `
                   >
                     <div
                       class="version"
-                      title="v7.12.0"
+                      title="v8.0.0"
                     >
-                      v7.12.0
+                      v8.0.0
                     </div>
                   </div>
                 </div>

--- a/webapp/src/constants.ts
+++ b/webapp/src/constants.ts
@@ -37,8 +37,8 @@ class Constants {
     static readonly titleColumnId = '__title'
     static readonly badgesColumnId = '__badges'
 
-    static readonly versionString = '7.12.0'
-    static readonly versionDisplayString = 'May 2023'
+    static readonly versionString = '8.0.0'
+    static readonly versionDisplayString = 'June 2024'
 
     static readonly archiveHelpPage = 'https://docs.mattermost.com/boards/migrate-to-boards.html'
     static readonly imports = [


### PR DESCRIPTION
#### Summary

Update to version 8.0 that includes all plugin dependency updates including to latest Mattermost server models. 

https://github.com/mattermost/focalboard/pull/5009
https://github.com/mattermost/focalboard/pull/5008

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-58682
