### PR TITLE
fix: broken Dockerfile fix

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,7 +10,7 @@ RUN CPPFLAGS="-DPNG_ARM_NEON_OPT=0" npm install --no-optional && \
     npm run pack
 
 ### Go build
-FROM golang:1.18.3@sha256:b203dc573d81da7b3176264bfa447bd7c10c9347689be40540381838d75eebef AS gobuild
+FROM golang:1.21.8@sha256:856073656d1a517517792e6cdd2f7a5ef080d3ca2dff33e518c8412f140fdd2d AS gobuild
 
 WORKDIR /go/src/focalboard
 ADD . /go/src/focalboard


### PR DESCRIPTION
Changed go image version according to updated dependencies in commit c8e729b6fed16f28aa69e01517eed68c92b1a5ca

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute

Assign two reviewers for this pull request from the names suggested. If no names are suggested or you are not sure who to assign, set `Core Focalboard` as the reviewer.
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the ticket).
-->
Right now Dockerfile is broken, because c8e729b6fed16f28aa69e01517eed68c92b1a5ca bumped `golang` version to `1.21`, but in Dockerfile `1.18` is used for build. `go.mod` file is using `toolchain` keyword, that was introduced in `1.21` - it leads into broken build:

![Screenshot_20240617_213212](https://github.com/mattermost/focalboard/assets/39347109/03dbf001-780d-4709-8935-6a22f6fe4c0e)

**Solution**: updated version of the golang in Dockerfile to [1.21.8@sha256:856073656d1a517517792e6cdd2f7a5ef080d3ca2dff33e518c8412f140fdd2d](https://hub.docker.com/layers/library/golang/1.21.8/images/sha256-e28f8918b44f85c5200599ff039da6004eb19081d00004b2985f10fc1be0794c?context=explore)

After that change build is working:
![Screenshot_20240617_215953](https://github.com/mattermost/focalboard/assets/39347109/faef6af0-7e4f-4646-9896-c4a623ef8292)


#### Ticket Link
<!--
If this pull request addresses a Github issue, please link the relevant issue, e.g.

  Fixes https://github.com/mattermost/focalboard/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
No ticket
