### PR TITLE
stop logging errors for api error responses

### DIFF
--- a/server/api/api.go
+++ b/server/api/api.go
@@ -178,7 +178,6 @@ func (a *API) userIsGuest(userID string) (bool, error) {
 // Response helpers
 
 func (a *API) errorResponse(w http.ResponseWriter, r *http.Request, err error) {
-	a.logger.Error(err.Error())
 	errorResponse := model.ErrorResponse{Error: err.Error()}
 
 	switch {
@@ -195,14 +194,15 @@ func (a *API) errorResponse(w http.ResponseWriter, r *http.Request, err error) {
 	case model.IsErrNotImplemented(err):
 		errorResponse.ErrorCode = http.StatusNotImplemented
 	default:
-		a.logger.Error("API ERROR",
-			mlog.Int("code", http.StatusInternalServerError),
-			mlog.Err(err),
-			mlog.String("api", r.URL.Path),
-		)
 		errorResponse.Error = "internal server error"
 		errorResponse.ErrorCode = http.StatusInternalServerError
 	}
+
+	a.logger.Warn("api error response",
+		mlog.Int("code", http.StatusInternalServerError),
+		mlog.Err(err),
+		mlog.String("api", r.URL.Path),
+	)
 
 	setResponseHeader(w, "Content-Type", "application/json")
 	data, err := json.Marshal(errorResponse)


### PR DESCRIPTION
#### Summary
From a cursory glance, when a real error occurs, we already log something at the application layer, so there's no reason to echo every api error response as an error log too. Errors should be actionable, but these logs were not, e.g.:

> access denied to templates

or:

> category ID specified in input does not exist for user

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-59325