### PR TITLE
Fix/update go version for toolchain support

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -18,7 +18,7 @@ RUN CPPFLAGS="-DPNG_ARM_NEON_OPT=0" npm install --no-optional && \
     npm run pack
 
 # build backend and package
-FROM golang:1.18.3@sha256:b203dc573d81da7b3176264bfa447bd7c10c9347689be40540381838d75eebef AS backend
+FROM golang:1.21 AS backend
 
 COPY . .
 COPY --from=frontend /webapp/pack webapp/pack

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,7 +22,7 @@ ARG TARGETARCH
 RUN EXCLUDE_PLUGIN=true EXCLUDE_SERVER=true EXCLUDE_ENTERPRISE=true make server-docker os=${TARGETOS} arch=${TARGETARCH}
 
 ## Final image
-FROM debian:buster-slim@sha256:5b0b1a9a54651bbe9d4d3ee96bbda2b2a1da3d2fa198ddebbced46dfdca7f216
+FROM debian:bookworm-slim
 
 RUN mkdir -p /opt/focalboard/data/files
 RUN chown -R nobody:nogroup /opt/focalboard

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,7 +10,7 @@ RUN CPPFLAGS="-DPNG_ARM_NEON_OPT=0" npm install --no-optional && \
     npm run pack
 
 ### Go build
-FROM golang:1.18.3@sha256:b203dc573d81da7b3176264bfa447bd7c10c9347689be40540381838d75eebef AS gobuild
+FROM golang:1.21 AS gobuild
 
 WORKDIR /go/src/focalboard
 ADD . /go/src/focalboard


### PR DESCRIPTION
Commit 1: Fix Docker build failure by updating Go version to 1.21

  Bug Description:
  Docker builds fail during the Go compilation stage with the following error:
  go: errors parsing go.mod:
  /go/src/focalboard/server/go.mod:5: unknown directive: toolchain
  make: *** [Makefile:66: server-docker] Error 1

  The build process exits with code 2, preventing the Docker image from being created.

  What it does:
  Updates the Go compiler version in both Dockerfiles from golang:1.18.3 to golang:1.21.

  Why it's needed:
  - The project's server/go.mod file specifies go 1.21 with toolchain go1.21.8 directive (line 5)
  - The toolchain directive was introduced in Go 1.21
  - Using Go 1.18.3 caused build failures because it doesn't recognize this directive
  - This fix aligns the Docker build environment with the project's Go requirements

  Files changed:
  - docker/Dockerfile (line 13)
  - Dockerfile.build (line 21)

  ---
  Commit 2: Update base image to debian:bookworm-slim for GLIBC compatibility

  Bug Description:
  After fixing the build error, the container builds successfully but crashes immediately at startup with:
  /opt/focalboard/bin/focalboard-server: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by /opt/focalboard/bin/focalboard-server)
  /opt/focalboard/bin/focalboard-server: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.33' not found (required by /opt/focalboard/bin/focalboard-server)
  /opt/focalboard/bin/focalboard-server: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by /opt/focalboard/bin/focalboard-server)

  The container exits with status code 1, and docker ps -a shows the container as Exited (1).

  What it does:
  Updates the final stage base image from debian:buster-slim to debian:bookworm-slim.

  Why it's needed:
  - Go 1.21 compiled binaries require GLIBC 2.32, 2.33, and 2.34
  - Debian Buster (oldoldstable) only provides GLIBC 2.28
  - Debian Bookworm (stable) provides GLIBC 2.36, which satisfies all requirements
  - Without this change, the container builds successfully but crashes immediately at startup

  Files changed:
  - docker/Dockerfile (line 25)

  ---
  Impact:
  These two commits work together to fix both the build-time and runtime errors:
  - ✅ Before: Build fails with "unknown directive: toolchain"
  - ✅ After Commit 1: Build succeeds but container crashes with GLIBC errors
  - ✅ After Commit 2: Build succeeds AND container runs successfully
  - ✅ Application starts and serves correctly at http://localhost
  - ✅ docker-compose deployment works as expected