### PR TITLE
Fix: Delete empty cards when dialog is closed without changes

### DIFF
--- a/webapp/src/components/cardDialog.tsx
+++ b/webapp/src/components/cardDialog.tsx
@@ -57,6 +57,23 @@ const CardDialog = (props: Props): JSX.Element => {
     const isTemplate = card && card.fields.isTemplate
 
     const [showConfirmationDialogBox, setShowConfirmationDialogBox] = useState<boolean>(false)
+
+    const handleClose = useCallback(async () => {
+        // If the card is empty (no title, no content, no comments, no attachments),
+        // delete it automatically to prevent empty cards from being created
+        // when users close the dialog without making any changes.
+        if (card &&
+            !card.fields.isTemplate &&
+            card.title === '' &&
+            card.fields.contentOrder.length === 0 &&
+            comments.length === 0 &&
+            attachments.length === 0
+        ) {
+            await mutator.deleteBlock(card, 'delete empty card')
+        }
+        props.onClose()
+    }, [card, comments, attachments, props.onClose])
+
     const makeTemplateClicked = async () => {
         if (!card) {
             Utils.assertFailure('card')
@@ -229,7 +246,7 @@ const CardDialog = (props: Props): JSX.Element => {
             <Dialog
                 title={<div/>}
                 className='cardDialog'
-                onClose={props.onClose}
+                onClose={handleClose}
                 toolsMenu={!props.readonly && !card?.limited && menu}
                 toolbar={attachBtn()}
             >


### PR DESCRIPTION
## Summary
Fixes #4843 — Empty cards are created when no changes are made.

## Problem
When a user clicks the **+ New** button to create a card and immediately closes the modal without making any changes, an empty card is left behind.

## Solution
Added cleanup logic in `CardDialog` that automatically deletes the card when the dialog is closed if the card is still empty (no title, no content blocks, no comments, and no attachments). Template cards are excluded.

## Changes
- **`webapp/src/components/cardDialog.tsx`**: Added `handleClose` callback that checks if the card is empty before closing, and deletes it if so.

## Testing
1. Click **+ New** to create a card → immediately close → ✅ empty card removed
2. Click **+ New** → add title/content → close → ✅ card preserved