### PR TITLE
Undo behavior for auto-added table rows

### DIFF
--- a/webapp/src/components/table/tableRow.tsx
+++ b/webapp/src/components/table/tableRow.tsx
@@ -51,6 +51,7 @@ const TableRow = (props: Props) => {
 
     const titleRef = useRef<{ focus(selectAll?: boolean): void }>(null)
     const [title, setTitle] = useState(props.card.title || '')
+    const [hasEditedTitle, setHasEditedTitle] = useState(false)
     const isGrouped = Boolean(groupById)
     const [isDragging, isOver, cardRef] = useSortable('card', card, !props.readonly && (isManualSort || isGrouped), props.onDrop)
     const [showConfirmationDialogBox, setShowConfirmationDialogBox] = useState<boolean>(false)
@@ -72,18 +73,42 @@ const TableRow = (props: Props) => {
         }
     }, [groupById && card.fields.properties[groupById!], props.isLastCard, props.addCard])
 
+    const handleDeleteCard = useCallback(async () => {
+        if (!card) {
+            Utils.assertFailure()
+            return
+        }
+        TelemetryClient.trackEvent(TelemetryCategory, TelemetryActions.DeleteCard, {board: board.id, card: card.id})
+        await mutator.deleteBlock(card, 'delete card')
+    }, [card, board.id])
+
+    const shouldDeleteEmptyAutoAddedCard = useCallback(() => {
+        return props.focusOnMount &&
+            !hasEditedTitle &&
+            (card.title || '') === '' &&
+            title.trim() === ''
+    }, [props.focusOnMount, hasEditedTitle, card.title, title])
+
     const onSave = useCallback((saveType) => {
+        if (saveType === 'onEnter' && shouldDeleteEmptyAutoAddedCard()) {
+            handleDeleteCard()
+            return
+        }
+
         if (card.title !== title) {
             mutator.changeBlockTitle(props.board.id, card.id, card.title, title)
             if (saveType === 'onEnter') {
                 onSaveWithEnter()
             }
         }
-    }, [card.title, title, onSaveWithEnter, board.id, card.id])
+    }, [card.title, title, onSaveWithEnter, board.id, card.id, shouldDeleteEmptyAutoAddedCard, handleDeleteCard])
 
     const onTitleChange = useCallback((newTitle: string) => {
+        if (!hasEditedTitle && newTitle !== (card.title || '')) {
+            setHasEditedTitle(true)
+        }
         setTitle(newTitle)
-    }, [title, setTitle])
+    }, [hasEditedTitle, card.title, setTitle])
 
     const visiblePropertyTemplates = useMemo(() => (
         visiblePropertyIds.map((id) => board.cardProperties.find((t) => t.id === id)).filter((i) => i) as IPropertyTemplate[]
@@ -113,15 +138,6 @@ const TableRow = (props: Props) => {
     if (props.readonly) {
         className += ' readonly'
     }
-
-    const handleDeleteCard = useCallback(async () => {
-        if (!card) {
-            Utils.assertFailure()
-            return
-        }
-        TelemetryClient.trackEvent(TelemetryCategory, TelemetryActions.DeleteCard, {board: board.id, card: card.id})
-        await mutator.deleteBlock(card, 'delete card')
-    }, [card, board.id])
 
     const confirmDialogProps: ConfirmationDialogBoxProps = useMemo(() => {
         return {
@@ -174,7 +190,13 @@ const TableRow = (props: Props) => {
                         placeholderText='Untitled'
                         onChange={onTitleChange}
                         onSave={onSave}
-                        onCancel={() => setTitle(card.title || '')}
+                        onCancel={() => {
+                            if (shouldDeleteEmptyAutoAddedCard()) {
+                                handleDeleteCard()
+                                return
+                            }
+                            setTitle(card.title || '')
+                        }}
                         readonly={props.readonly}
                         spellCheck={true}
                     />

--- a/webapp/src/components/table/tableRow.tsx
+++ b/webapp/src/components/table/tableRow.tsx
@@ -50,6 +50,7 @@ const TableRow = (props: Props) => {
     const {board, card, isManualSort, groupById, visiblePropertyIds, collapsedOptionIds} = props
 
     const titleRef = useRef<{ focus(selectAll?: boolean): void }>(null)
+    const isAutoAddedCardRef = useRef(props.focusOnMount)
     const [title, setTitle] = useState(props.card.title || '')
     const [hasEditedTitle, setHasEditedTitle] = useState(false)
     const isGrouped = Boolean(groupById)
@@ -83,11 +84,11 @@ const TableRow = (props: Props) => {
     }, [card, board.id])
 
     const shouldDeleteEmptyAutoAddedCard = useCallback(() => {
-        return props.focusOnMount &&
+        return isAutoAddedCardRef.current &&
             !hasEditedTitle &&
             (card.title || '') === '' &&
             title.trim() === ''
-    }, [props.focusOnMount, hasEditedTitle, card.title, title])
+    }, [hasEditedTitle, card.title, title])
 
     const onSave = useCallback((saveType) => {
         if (saveType === 'onEnter' && shouldDeleteEmptyAutoAddedCard()) {

--- a/webapp/src/pages/boardPage/undoRedoHotKeys.tsx
+++ b/webapp/src/pages/boardPage/undoRedoHotKeys.tsx
@@ -10,7 +10,21 @@ import {Utils} from '../../utils'
 const UndoRedoHotKeys = (): null => {
     const intl = useIntl()
 
-    useHotkeys('ctrl+z,cmd+z', () => {
+    useHotkeys('ctrl+z,cmd+z', (e: KeyboardEvent) => {
+        const target = e.target as HTMLElement | null
+        const isInputTag = target ? ['INPUT', 'TEXTAREA', 'SELECT'].includes(target.tagName) : false
+        const isTableTitleInput = Boolean(
+            target &&
+            target.tagName === 'INPUT' &&
+            target.classList.contains('Editable') &&
+            target.closest('.octo-table-row'),
+        )
+
+        // Keep native undo in non-table inputs (comments, markdown editor, etc).
+        if (isInputTag && !isTableTitleInput) {
+            return true
+        }
+
         Utils.log('Undo')
         if (mutator.canUndo) {
             const description = mutator.undoDescription
@@ -32,9 +46,24 @@ const UndoRedoHotKeys = (): null => {
                 severity: 'low',
             })
         }
-    })
+        // Prevent browser/input-level undo when board-level undo is triggered.
+        return false
+    }, {enableOnTags: ['INPUT', 'TEXTAREA', 'SELECT']})
 
-    useHotkeys('shift+ctrl+z,shift+cmd+z', () => {
+    useHotkeys('shift+ctrl+z,shift+cmd+z', (e: KeyboardEvent) => {
+        const target = e.target as HTMLElement | null
+        const isInputTag = target ? ['INPUT', 'TEXTAREA', 'SELECT'].includes(target.tagName) : false
+        const isTableTitleInput = Boolean(
+            target &&
+            target.tagName === 'INPUT' &&
+            target.classList.contains('Editable') &&
+            target.closest('.octo-table-row'),
+        )
+
+        if (isInputTag && !isTableTitleInput) {
+            return true
+        }
+
         Utils.log('Redo')
         if (mutator.canRedo) {
             const description = mutator.redoDescription
@@ -57,7 +86,8 @@ const UndoRedoHotKeys = (): null => {
                 severity: 'low',
             })
         }
-    })
+        return false
+    }, {enableOnTags: ['INPUT', 'TEXTAREA', 'SELECT']})
     return null
 }
 


### PR DESCRIPTION
## Summary
Fixes table-view row undo behavior for auto-added rows created after pressing `Enter` on the last row title.

This PR ensures:

1. For a newly auto-added row with empty, untouched title:
   - `Esc` removes the row
   - `Enter` removes the row
   - `Ctrl/Cmd+Z` removes the row

2. If the user typed in the new row title first:
   - `Esc` only cancels/reverts title editing behavior and does not remove the row
   - `Ctrl/Cmd+Z` removes the added row/card (undo at board level)

Fixes https://github.com/mattermost-community/focalboard/issues/4849

## Manual Test Coverage
- Create auto-added row via `Enter` on last row title.
- `Esc` on untouched empty auto-added row removes it.
- `Enter` on untouched empty auto-added row removes it.
- `Ctrl/Cmd+Z` on untouched empty auto-added row removes it.
- After typing in new row title, `Esc` does not remove the row.
- After typing in new row title, `Ctrl/Cmd+Z` removes the added row.